### PR TITLE
Fix spelling errors in `context.rs`, `descriptor.rs`, and `run.rs`

### DIFF
--- a/crates/rwasm/e2e/src/context.rs
+++ b/crates/rwasm/e2e/src/context.rs
@@ -350,7 +350,7 @@ impl TestContext<'_> {
     ///
     /// - If no module instances can be found.
     /// - If no function identified with `func_name` can be found.
-    /// - If function invokation returned an error.
+    /// - If function invocation returned an error.
     pub fn invoke(
         &mut self,
         module_name: Option<&str>,

--- a/crates/rwasm/e2e/src/descriptor.rs
+++ b/crates/rwasm/e2e/src/descriptor.rs
@@ -4,7 +4,7 @@ use std::{
 };
 use wast::token::Span;
 
-/// The desciptor of a Wasm spec test suite run.
+/// The descriptor of a Wasm spec test suite run.
 #[derive(Debug)]
 pub struct TestDescriptor {
     /// The path of the Wasm spec test `.wast` file.

--- a/crates/rwasm/e2e/src/run.rs
+++ b/crates/rwasm/e2e/src/run.rs
@@ -320,7 +320,7 @@ fn module_compilation_succeeds(context: &mut TestContext, span: Span, module: wa
     match context.compile_and_instantiate(module) {
         Ok(_) => {}
         Err(error) => panic!(
-            "{}: failed to instantiate module but should have suceeded: {:?}",
+            "{}: failed to instantiate module but should have succeeded: {:?}",
             context.spanned(span),
             error
         ),


### PR DESCRIPTION
- `invokation` → `invocation`
- `desciptor` → `descriptor`
- `suceeded` → `succeeded`
