### PR TITLE
improve code readability and typo fix

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -22,7 +22,7 @@ fn cargo_rerun_if_changed(metadata: &Metadata, program_dir: &Path) {
     for file in dirs {
         if file.exists() {
             println!(
-                "cargo::rerun-if-changed={}",
+                "cargo:rerun-if-changed={}",
                 file.canonicalize().unwrap().display()
             );
         }

--- a/crates/codec/src/bytes_codec.rs
+++ b/crates/codec/src/bytes_codec.rs
@@ -153,7 +153,7 @@ pub fn read_bytes_header_wasm<B: ByteOrder, const ALIGN: usize>(
     Ok((data_offset, data_len))
 }
 
-/// Reads the header of a Solidiof the data
+/// Reads the header of a Solidity data
 ///
 /// Given the original data:
 /// ```

--- a/crates/codec/src/error.rs
+++ b/crates/codec/src/error.rs
@@ -38,7 +38,7 @@ impl Display for EncodingError {
                 available,
                 details,
             } => {
-                write!(f, "Not enough space in the buf: required {} bytes, but only {} bytes available. {}", required, available, details)
+                write!(f, "Not enough space in the buffer: required {} bytes, but only {} bytes available. {}", required, available, details)
             }
             EncodingError::InvalidInputData(msg) => {
                 write!(f, "Invalid data provided for encoding: {}", msg)
@@ -87,12 +87,12 @@ impl Display for DecodingError {
             } => {
                 write!(
                     f,
-                    "Not enough data in the buf: expected at least {} bytes, found {}. {}",
+                    "Not enough data in the buffer: expected at least {} bytes, found {}. {}",
                     expected, found, msg
                 )
             }
             DecodingError::BufferOverflow { msg } => write!(f, "Buffer overflow: {}", msg),
-            DecodingError::UnexpectedEof => write!(f, "Unexpected end of buf"),
+            DecodingError::UnexpectedEof => write!(f, "Unexpected end of buffer"),
             DecodingError::Overflow => write!(f, "Overflow error"),
             DecodingError::ParseError(msg) => write!(f, "Parsing error: {}", msg),
         }

--- a/crates/codec/src/evm.rs
+++ b/crates/codec/src/evm.rs
@@ -80,7 +80,7 @@ impl<B: ByteOrder, const ALIGN: usize> Encoder<B, ALIGN, false, false> for Bytes
     }
 
     /// Decode the bytes from the buffer.
-    /// Reads the header to get the data offset and size, then read the actual data.
+    /// Reads the header to get the data offset and size, then reads the actual data.
     fn decode(buf: &impl Buf, offset: usize) -> Result<Self, CodecError> {
         Ok(Self::from(read_bytes::<B, ALIGN, false>(buf, offset)?))
     }
@@ -343,7 +343,7 @@ impl<
             return Err(CodecError::Decoding(DecodingError::BufferTooSmall {
                 expected: offset + word_size,
                 found: buf.remaining(),
-                msg: "buf too small to read Uint".to_string(),
+                msg: "Buffer too small to read Uint".to_string(),
             }));
         }
 
@@ -397,7 +397,7 @@ impl<
             return Err(CodecError::Decoding(DecodingError::BufferTooSmall {
                 expected: offset + 32,
                 found: buf.remaining(),
-                msg: "buf too small to read Uint".to_string(),
+                msg: "Buffer too small to read Uint".to_string(),
             }));
         }
 


### PR DESCRIPTION
This PR improves code readability and consistency by refining error messages and fixing typos.

#### **Changes:**  
- **`build/src/lib.rs`**  
  - Fixed a typo in `cargo:rerun-if-changed={}` print statement.
  
- **`codec/src/bytes_codec.rs`**  
  - Corrected a typo in the Solidity header documentation comment.

- **`codec/src/error.rs`**  
  - Standardized error messages to use "buffer" instead of "buf" for clarity.

- **`codec/src/evm.rs`**  
  - Fixed grammatical error "read" to "reads".
  - Standardized error messages to use "buffer" instead of "buf" for clarity.