### PR TITLE
alloy.rs type I256 Solidity int256 signed integers

### DIFF
--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -18,7 +18,7 @@ mod syscall;
 mod utils;
 
 pub use allocator::*;
-pub use alloy_primitives::{address, b256, bloom, bytes, fixed_bytes, Address, Bytes, B256, U256};
+pub use alloy_primitives::{address, b256, bloom, bytes, fixed_bytes, Address, Bytes, B256, U256, I256};
 pub use bytecode_type::*;
 pub use byteorder;
 pub use context::*;


### PR DESCRIPTION
I256 alloy rust documentation:
https://docs.rs/alloy-primitives/latest/alloy_primitives/aliases/type.I256.html

alloy rust example using I256:
https://github.com/alloy-rs/examples/blob/main/examples/sol-macro/examples/decode_returns.rs