### PR TITLE
docs: update broken doc link in storage.md

### DIFF
--- a/crates/sdk-derive/docs/storage.md
+++ b/crates/sdk-derive/docs/storage.md
@@ -43,4 +43,4 @@ For each variable `Name`, the macro generates:
 - A struct `Name` with `SLOT` constant
 - Methods `get(sdk, ...)` and `set(sdk, ..., value)`
 
-For examples, see the [fluentbase examples repository](https://github.com/fluentlabs-xyz/fluentbase/tree/next/examples/storage).
+For examples, see the [fluentbase examples repository](https://github.com/fluentlabs-xyz/fluentbase/tree/devel/examples/storage).


### PR DESCRIPTION
This pull request fixes a broken documentation link in `crates/sdk-derive/docs/storage.md`.

The link previously pointed to the `next` branch, which is no longer valid.  
It has now been updated to point to the correct `devel` branch.

### Before

![before](https://github.com/user-attachments/assets/93b5cd38-8099-41f5-992f-86c8154a148c)

### After

![after](https://github.com/user-attachments/assets/6ab2bf1e-fabc-4f55-a355-3a34d3811db4)