### PR TITLE
Fix broken deploy.md link in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -157,7 +157,7 @@ rustup target add wasm32-unknown-unknown
 > wasm2wat target/wasm32-unknown-unknown/release/hello_world.wasm
 > ```
 
-The next step is to [deploy your contract](./deploy.md).
+The next step is to [deploy your contract](#deploy).
 
 ## Deploy
 


### PR DESCRIPTION
Replaced the outdated link to deploy.md with an internal anchor link to the Deploy section within examples/README.md. This ensures users are directed to the correct deployment instructions, as the separate deploy.md file does not exist.