### PR TITLE
Add per-crate README files

### DIFF
--- a/crates/build/README.md
+++ b/crates/build/README.md
@@ -1,0 +1,30 @@
+# Fluentbase Build
+
+This crate contains helper functions and a small CLI used to compile Fluentbase
+smart contracts. It powers the build scripts for precompiled contracts and can
+be invoked directly from a custom `build.rs`.
+
+`build` supports deterministic Docker builds, custom Rust toolchains and
+multiple output formats (WAT, rWASM, ABI, Solidity interface files and metadata).
+Configuration is provided via the `BuildArgs` structure.
+
+```rust
+use fluentbase_build::{build_with_args, BuildArgs, Artifact};
+
+fn main() {
+    build_with_args("./contracts/my_contract", BuildArgs {
+        docker: true,
+        generate: vec![Artifact::Rwasm, Artifact::Abi],
+        ..Default::default()
+    });
+}
+```
+
+Artifacts are written to the `out/` directory by default. Set the
+`FLUENTBASE_SKIP_BUILD` environment variable if you wish to skip compilation
+(e.g., when cross compiling from another workspace).
+
+See [`src/lib.rs`](src/lib.rs) for a full list of options and advanced usage
+notes.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/codec-derive/README.md
+++ b/crates/codec-derive/README.md
@@ -1,0 +1,25 @@
+# Fluentbase Codec Derive
+
+Procedural macros for deriving the `Codec` trait from the
+[`fluentbase-codec`](../codec) crate. These macros generate efficient encoding
+and decoding implementations that integrate with both `CompactABI` and
+`SolidityABI` modes.
+
+```rust
+use fluentbase_codec::CompactABI;
+use fluentbase_codec_derive::Codec;
+
+#[derive(Codec)]
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+let mut buf = bytes::BytesMut::new();
+CompactABI::encode(&Point { x: 1, y: 2 }, &mut buf, 0).unwrap();
+```
+
+See [`src/lib.rs`](src/lib.rs) for the supported attributes and
+customisation options.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/contracts/README.md
+++ b/crates/contracts/README.md
@@ -1,0 +1,21 @@
+# Fluentbase Contracts
+
+This crate contains the system precompiled contracts that are bundled with the
+Fluentbase runtimes. They expose compatibility layers for the EVM and SVM, along
+with utilities such as hashing functions and token standards.
+
+The build script compiles each contract to rWASM and embeds the resulting binaries
+under `assets/`. These artifacts are later included in genesis files so that
+clients can deploy them automatically.
+
+Contracts include:
+
+- EVM compatibility layer
+- SVM (Solana VM) compatibility layer
+- Standard cryptographic primitives (SHA256, Blake2, etc.)
+- The reference ERC20 implementation
+
+If the `generate-genesis` feature is enabled a fully populated genesis file with
+embedded contracts will be produced during the build.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/erc20/README.md
+++ b/crates/erc20/README.md
@@ -1,0 +1,14 @@
+# Fluentbase ERC20
+
+A reference implementation of the ERC20 token standard built using the
+Fluentbase SDK. It demonstrates the recommended project layout and how to use the
+SDK entrypoint macros.
+
+The contract exposes the usual `transfer`, `approve` and `transfer_from` methods
+and stores balances in the Fluentbase key-value storage. The implementation is
+`no_std` compatible and can be compiled to rWASM via the [`fluentbase-build`](../build)
+crate.
+
+This contract is included in the system precompile set for testing purposes.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/evm/README.md
+++ b/crates/evm/README.md
@@ -1,0 +1,16 @@
+# Fluentbase EVM
+
+An execution engine implementing the Ethereum Virtual Machine semantics on top of
+Fluentbase types. The crate provides a minimal EVM used for compatibility tests
+and for running Solidity contracts compiled to rWASM.
+
+Major components include:
+
+- Opcode interpreter and gas accounting
+- Memory model and stack implementation matching the Ethereum spec
+- Helpers for translating rWASM runtime calls to EVM behavior
+
+The engine is not intended to be feature complete but aims to be deterministic
+and suitable for zero-knowledge proof generation.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/genesis/README.md
+++ b/crates/genesis/README.md
@@ -1,0 +1,16 @@
+# Fluentbase Genesis
+
+Utilities for creating and manipulating genesis files that bundle Fluentbase
+precompiled contracts. The resulting JSON genesis can be used by Reth or other
+clients to start a local development network with the correct rWASM binaries
+embedded.
+
+The crate exposes helpers for loading the default devnet genesis as well as for
+building custom configurations programmatically.
+
+```rust
+use fluentbase_genesis::devnet_genesis_from_file;
+let genesis = devnet_genesis_from_file();
+```
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/runtime/README.md
+++ b/crates/runtime/README.md
@@ -1,0 +1,17 @@
+# Fluentbase Runtime
+
+The execution environment for rWASM contracts. It provides the host functions
+exposed to smart contracts and manages context such as storage, account data and
+precompiled contract calls.
+
+Features:
+
+- Executes rWASM bytecode with deterministic gas accounting
+- Interfaces with the EVM and SVM compatibility layers
+- Supports running in `no_std` mode for proofs
+- Optional integration with Wasmtime for debugging (`wasmtime` feature)
+
+The runtime is used by the testing framework and can also be embedded in other
+Rust projects that wish to execute Fluentbase contracts.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/sdk-derive/README.md
+++ b/crates/sdk-derive/README.md
@@ -1,0 +1,13 @@
+# Fluentbase SDK Derive
+
+A set of procedural macros that generate boilerplate required by contracts using
+the Fluentbase SDK. The most important macro is `#[derive(Contract)]` which
+expands a struct into the expected entrypoint and dispatch logic.
+
+Additional helper macros are available for generating error types and for
+including a contract's own compiled rWASM for testing purposes.
+
+See [`src/lib.rs`](src/lib.rs) for usage examples and a description of the
+available attributes.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/sdk-derive/derive-core/README.md
+++ b/crates/sdk-derive/derive-core/README.md
@@ -1,0 +1,10 @@
+# Fluentbase SDK Derive Core
+
+Internal helper macros used by `fluentbase-sdk-derive`. These macros are not
+intended to be consumed directly. They provide lower level expansion utilities
+that keep the public derive crate lightweight.
+
+Changes to this crate may require regeneration of the snapshot tests in
+`../snapshots`.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -1,0 +1,17 @@
+# Fluentbase SDK
+
+The main library for developing contracts that run on the Fluentbase runtime. It
+provides the core `SharedAPI` trait, entrypoint macros and a collection of types
+used by contracts.
+
+Key components:
+
+- `basic_entrypoint!` macro which expands into the WASM entrypoint
+- `SharedAPI` trait offering read/write access to storage and context
+- `fluentbase-sdk-derive` macros for reducing boilerplate
+- Re-export of common primitive types from `fluentbase-types`
+
+Add this crate to your contract's `Cargo.toml` together with
+`fluentbase-sdk-derive` and call `basic_entrypoint!` with your contract type.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/svm-shared/README.md
+++ b/crates/svm-shared/README.md
@@ -1,0 +1,11 @@
+# Fluentbase SVM Shared
+
+Common types and utilities used across the Fluentbase SVM crates. These helpers
+allow sharing logic between the SVM runtime and the Solana compatibility
+precompiles.
+
+Currently this crate exposes bincode helpers and a few structures used in tests.
+It is mostly an internal crate but is published separately to avoid code
+duplication.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/svm/README.md
+++ b/crates/svm/README.md
@@ -1,0 +1,11 @@
+# Fluentbase SVM
+
+An implementation of the Solana Virtual Machine adapted for Fluentbase. The
+runtime is used to run Solana-style programs and provides an alternative execution
+environment alongside the EVM.
+
+The crate includes instruction processors, loader logic and account handling
+compatible with the Solana model. It is primarily used internally for testing
+Solana interoperability with rWASM.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/testing/README.md
+++ b/crates/testing/README.md
@@ -1,0 +1,11 @@
+# Fluentbase SDK Testing
+
+Testing utilities for Fluentbase contracts. This crate embeds the runtime and
+provides helpers for executing rWASM modules in unit tests. It also re-exports
+the `include_this_wasm!` macro which allows a contract to include its own WASM
+binary during tests.
+
+The EVM test harness is powered by a forked `revm` and can run Solidity contracts
+or EVM compatibility precompiles directly.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/types/README.md
+++ b/crates/types/README.md
@@ -1,0 +1,10 @@
+# Fluentbase Types
+
+Primitive types and data structures shared across all Fluentbase crates. The
+crate exposes the `Address` and `Bytes` types along with the runtime context
+objects and helper enums used for error handling and contract execution.
+
+Most types are `no_std` friendly and re-export the `rwasm` core primitives when
+the `std` feature is disabled.
+
+This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.


### PR DESCRIPTION
## Summary
- add a README to every crate
- fill in more technical detail about each module

## Testing
- `cargo check` *(fails: failed to read `/workspace/fluentbase/revm/crates/precompile/Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_6883775894608328a14ee87d806f95c0