### PR TITLE
docs: fix outdated link

### DIFF
--- a/crates/sdk-derive/docs/storage.md
+++ b/crates/sdk-derive/docs/storage.md
@@ -43,4 +43,4 @@ For each variable `Name`, the macro generates:
 - A struct `Name` with `SLOT` constant
 - Methods `get(sdk, ...)` and `set(sdk, ..., value)`
 
-For examples, see the [fluentbase examples repository](https://github.com/fluentlabs-xyz/fluentbase/tree/devel/examples/storage).
+For examples, see the [fluentbase examples repository](https://github.com/fluentlabs-xyz/fluentbase/tree/devel/contracts/examples/storage).


### PR DESCRIPTION
## Description

This PR fixes a outdated link to maintain consistency with the restructuring performed in https://github.com/fluentlabs-xyz/fluentbase/pull/133.

## Additional Info

### before:
<img width="1410" height="564" alt="image" src="https://github.com/user-attachments/assets/50fe5535-3f34-43c3-ae19-5e0fb33351bb" />
### after:
<img width="1481" height="740" alt="image" src="https://github.com/user-attachments/assets/c36a6b9c-fe1e-4e11-a8be-b7bd43600285" />
