### PR TITLE
Reduce the size of some error enums

### DIFF
--- a/crates/sdk-derive/derive-core/src/abi/error.rs
+++ b/crates/sdk-derive/derive-core/src/abi/error.rs
@@ -1,34 +1,34 @@
 #[derive(Debug, thiserror::Error)]
 pub enum ABIError {
     #[error("Invalid type: {0}")]
-    InvalidType(String),
+    InvalidType(Box<str>),
 
     #[error("Invalid type conversion: {0}")]
-    TypeConversion(String),
+    TypeConversion(Box<str>),
 
     #[error("Serialization error: {0}")]
-    Serialization(String),
+    Serialization(Box<str>),
 
     #[error("Deserialization error: {0}")]
-    Deserialization(String),
+    Deserialization(Box<str>),
 
     #[error("Unsupported type: {0}")]
-    UnsupportedType(String),
+    UnsupportedType(Box<str>),
 
     #[error("Unsupported pattern: {0}")]
-    UnsupportedPattern(String),
+    UnsupportedPattern(Box<str>),
 
     #[error("Syntax error: {0}")]
-    Syntax(String),
+    Syntax(Box<str>),
 
     #[error("Internal error: {0}")]
-    Internal(String),
+    Internal(Box<str>),
 
     #[error("Artifacts error: {0}")]
-    Artifacts(String),
+    Artifacts(Box<str>),
 
     #[error("Config error: {0}")]
-    Config(String),
+    Config(Box<str>),
 }
 
 impl From<ABIError> for syn::Error {

--- a/crates/sdk-derive/derive-core/src/abi/function.rs
+++ b/crates/sdk-derive/derive-core/src/abi/function.rs
@@ -43,7 +43,7 @@ pub enum StateMutability {
 
 impl From<ConversionError> for ABIError {
     fn from(err: ConversionError) -> Self {
-        ABIError::TypeConversion(err.to_string())
+        ABIError::TypeConversion(err.to_string().into())
     }
 }
 
@@ -126,7 +126,7 @@ impl FunctionABI {
     }
 
     pub fn to_json(&self) -> Result<String, ABIError> {
-        serde_json::to_string(self).map_err(|e| ABIError::Serialization(e.to_string()))
+        serde_json::to_string(self).map_err(|e| ABIError::Serialization(e.to_string().into()))
     }
 
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {

--- a/crates/sdk-derive/derive-core/src/abi/parameter.rs
+++ b/crates/sdk-derive/derive-core/src/abi/parameter.rs
@@ -26,7 +26,7 @@ impl Parameter {
             syn::Data::Struct(data) => &data.fields,
             _ => {
                 return Err(ConversionError::UnsupportedType(
-                    "Only structs are supported".to_string(),
+                    "Only structs are supported".into(),
                 ))
             }
         };
@@ -190,7 +190,7 @@ impl Parameter {
     pub fn get_canonical_type(&self) -> Result<String, ConversionError> {
         if self.ty == "tuple" {
             let components = self.components.as_ref().ok_or_else(|| {
-                ConversionError::UnsupportedType("Tuple without components".to_string())
+                ConversionError::UnsupportedType("Tuple without components".into())
             })?;
 
             let inner_types = components

--- a/crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs
+++ b/crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs
@@ -4,13 +4,13 @@ use syn::{self, GenericArgument, PathArguments, Type};
 #[derive(Debug, thiserror::Error, Clone, PartialEq)]
 pub enum ConversionError {
     #[error("Unsupported type: {0}")]
-    UnsupportedType(String),
+    UnsupportedType(Box<str>),
     #[error("Invalid array length: {0}")]
-    InvalidArrayLength(String),
+    InvalidArrayLength(Box<str>),
     #[error("Invalid fixed bytes size: {0}")]
-    InvalidBytesSize(String),
+    InvalidBytesSize(Box<str>),
     #[error("Parse error: {0}")]
-    ParseError(String),
+    ParseError(Box<str>),
 }
 
 impl From<ConversionError> for syn::Error {
@@ -29,7 +29,7 @@ pub fn rust_to_sol(ty: &Type) -> Result<SolType, ConversionError> {
         Type::Slice(slice) => convert_slice_type(slice),
         _ => Err(ConversionError::UnsupportedType(format!(
             "Unsupported type: {ty:?}"
-        ))),
+        ).into())),
     }
 }
 
@@ -77,7 +77,7 @@ fn convert_path_type(type_path: &syn::TypePath) -> Result<SolType, ConversionErr
             if !matches!(last_segment.arguments, PathArguments::None) {
                 return Err(ConversionError::UnsupportedType(format!(
                     "Generic parameters are not supported for type: {type_name}"
-                )));
+                ).into()));
             }
 
             // Get full path for better type identification
@@ -213,7 +213,7 @@ fn convert_fixed_bytes(type_name: &str, args: &PathArguments) -> Result<SolType,
     }
     Err(ConversionError::InvalidBytesSize(format!(
         "{type_name} requires a size parameter between 1 and 32"
-    )))
+    ).into()))
 }
 #[cfg(test)]
 mod tests {

--- a/crates/sdk-derive/derive-core/src/abi/types/conversion/sol_to_rust.rs
+++ b/crates/sdk-derive/derive-core/src/abi/types/conversion/sol_to_rust.rs
@@ -72,7 +72,7 @@ fn to_rust_uint(bits: usize) -> Result<Type, ABIError> {
         248 => Ok(parse_quote!(U248)),
         256 => Ok(parse_quote!(U256)),
         512 => Ok(parse_quote!(U512)),
-        _ => Err(ABIError::UnsupportedType(format!("uint{bits}"))),
+        _ => Err(ABIError::UnsupportedType(format!("uint{bits}").into())),
     }
 }
 
@@ -111,7 +111,7 @@ fn to_rust_int(bits: usize) -> Result<Type, ABIError> {
         248 => Ok(parse_quote!(I248)),
         256 => Ok(parse_quote!(I256)),
         512 => Ok(parse_quote!(I512)),
-        _ => Err(ABIError::UnsupportedType(format!("int{bits}"))),
+        _ => Err(ABIError::UnsupportedType(format!("int{bits}").into())),
     }
 }
 
@@ -119,7 +119,7 @@ fn to_rust_fixed_bytes(size: usize) -> Result<Type, ABIError> {
     if !(1..=32).contains(&size) {
         return Err(ABIError::UnsupportedType(format!(
             "FixedBytes size must be between 1 and 32, got {size}"
-        )));
+        ).into()));
     }
     Ok(parse_quote!(FixedBytes<#size>))
 }

--- a/crates/sdk-derive/derive-core/src/abi/types/conversion/syn_sol_to_internal.rs
+++ b/crates/sdk-derive/derive-core/src/abi/types/conversion/syn_sol_to_internal.rs
@@ -25,7 +25,7 @@ pub fn convert_solidity_type(sol_ty: &SolidityAstType) -> Result<SolType, ABIErr
                             ABIError::UnsupportedType(format!(
                                 "Invalid array size: {:?}",
                                 lit_num.base10_digits()
-                            ))
+                            ).into())
                         })?;
                         Ok(SolType::FixedArray(Box::new(inner), size))
                     }


### PR DESCRIPTION
A large enum used in several places can cause a negative runtime impact. In fact, this is so common that the community created several lints to prevent such a scenario.

- [large_enum_variant](https://rust-lang.github.io/rust-clippy/master/?groups=perf#large_enum_variant)
- [result_large_err](https://rust-lang.github.io/rust-clippy/master/?groups=perf#result_large_err)
- [variant_size_differences](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/types/static.VARIANT_SIZE_DIFFERENCES.html)

This PR cuts 8 bytes from 2 different error enums through the use of `Box<str>`, which doesn't change any intended behavior.

Of course, 8 bytes probably won't make much of a difference but it is still worth the change IMO.
