### PR TITLE
docs: update broken doc link in storage.md

### DIFF
--- a/crates/sdk-derive/docs/storage.md
+++ b/crates/sdk-derive/docs/storage.md
@@ -43,4 +43,4 @@ For each variable `Name`, the macro generates:
 - A struct `Name` with `SLOT` constant
 - Methods `get(sdk, ...)` and `set(sdk, ..., value)`
 
-For examples, see the [fluentbase examples repository](https://github.com/fluentlabs-xyz/fluentbase/tree/devel/contracts/examples/storage).
+For examples, see the [fluentbase examples repository](https://github.com/fluentlabs-xyz/fluentbase/tree/devel/examples/storage).


### PR DESCRIPTION
https://github.com/fluentlabs-xyz/fluentbase/tree/devel/contracts/examples/storage - broken
https://github.com/fluentlabs-xyz/fluentbase/tree/devel/examples/storage - new
Changed in https://github.com/fluentlabs-xyz/fluentbase/pull/171

before:
<img width="2148" height="1144" alt="image" src="https://github.com/user-attachments/assets/02232c4b-ea06-4358-8190-2cb13389f2d5" />

after:
<img width="2478" height="1432" alt="image" src="https://github.com/user-attachments/assets/a4990788-f936-4bde-8cab-bf12303df3a0" />
