### PR TITLE
docs(contracts): fix incorrect link

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -72,4 +72,4 @@ Shared configuration and dependencies are defined in contracts/Cargo.toml:
 ## Repository
 
 For more information, visit the repository:
-https://github.com/fluentlabs-xyz/fuentbase
+https://github.com/fluentlabs-xyz/fluentbase


### PR DESCRIPTION
https://github.com/fluentlabs-xyz/fuentbase - incorrect 
https://github.com/fluentlabs-xyz/fluentbase - correct 