### PR TITLE
feat(build): add standalone constructor macro support for abi generation

### DIFF
--- a/crates/build/tests/fixtures/trait_impl_constructor.rs
+++ b/crates/build/tests/fixtures/trait_impl_constructor.rs
@@ -4,10 +4,8 @@ extern crate alloc;
 extern crate fluentbase_sdk;
 
 use fluentbase_sdk::{
-    derive::{router, Contract},
-    Address,
-    SharedAPI,
-    U256,
+    derive::{constructor, router, Contract},
+    Address, SharedAPI, U256,
 };
 
 #[derive(Contract)]
@@ -16,7 +14,6 @@ struct Governance<SDK> {
 }
 
 pub trait GovernanceAPI {
-    fn constructor(&mut self, admin: Address, voting_delay: U256, voting_period: U256);
     fn propose(&mut self, target: Address, value: U256) -> U256;
     fn vote(&mut self, proposal_id: U256, support: bool) -> bool;
     fn execute(&mut self, proposal_id: U256) -> bool;
@@ -24,9 +21,6 @@ pub trait GovernanceAPI {
 
 #[router(mode = "solidity")]
 impl<SDK: SharedAPI> GovernanceAPI for Governance<SDK> {
-    fn constructor(&mut self, admin: Address, voting_delay: U256, voting_period: U256) {
-        // Implementation details
-    }
     fn propose(&mut self, target: Address, value: U256) -> U256 {
         U256::from(1)
     }
@@ -40,6 +34,11 @@ impl<SDK: SharedAPI> GovernanceAPI for Governance<SDK> {
     }
 }
 
-
+#[constructor(mode = "solidity")]
+impl<SDK: SharedAPI> Governance<SDK> {
+    pub fn constructor(&mut self, admin: Address, voting_delay: U256, voting_period: U256) {
+        // Implementation details
+    }
+}
 
 basic_entrypoint!(SimpleToken);

--- a/crates/build/tests/snapshots/interface_generation__interface_with_constructor_args.snap
+++ b/crates/build/tests/snapshots/interface_generation__interface_with_constructor_args.snap
@@ -7,6 +7,12 @@ expression: interface
 pragma solidity ^0.8.0;
 
 interface IAllTypesContract {
+    struct TokenConfig {
+        string name;
+        string symbol;
+        uint256 total_supply;
+    }
+
     function transfer(address to, uint256 amount) external returns (bool _0);
     function balanceOf(address account) external returns (uint256 _0);
     function totalSupply() external returns (uint256 _0);


### PR DESCRIPTION
- Parse #[constructor] attributes in addition to #[router]
- Extract struct definitions from constructor parameters
- Prioritize standalone constructors over router-embedded ones
- Maintain backward compatibility with existing router-only contracts