### PR TITLE
fix(syscall): add static context checks to metadata syscalls

### DIFF
--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -778,6 +778,8 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             let Some(account_owner_address) = account_owner_address else {
                 return_result!(MalformedBuiltinParams);
             };
+
+            assert_return!(!inputs.is_static, StateChangeDuringStaticCall);
             // read an account from its address
             let salt = U256::from_be_slice(&inputs.syscall_params.input[..32]);
             let metadata = inputs.syscall_params.input.slice(32..);
@@ -832,6 +834,8 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                         inputs.syscall_params.input.len() >= 20 + 4,
                         MalformedBuiltinParams
                     );
+                    assert_return!(!inputs.is_static, StateChangeDuringStaticCall);
+
                     let offset =
                         LittleEndian::read_u32(&inputs.syscall_params.input[20..24]) as usize;
                     let length = inputs.syscall_params.input[24..].len();
@@ -911,6 +915,9 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             else {
                 return_result!(MalformedBuiltinParams)
             };
+
+            assert_return!(!inputs.is_static, StateChangeDuringStaticCall);
+            
             let slot_u256 = U256::from_le_bytes(slot);
             let value_u256 = U256::from_le_bytes(value);
             ctx.journal_mut()


### PR DESCRIPTION
Context: Three metadata syscalls were missing 'is_static' validation, allowing state modifications during STATICCALL contexts, which violates EVM semantics where static calls must be read-only.

Change: Added 'StateChangeDuringStaticCall' guards to:
- SYSCALL_ID_METADATA_CREATE (before 'set_code')
- SYSCALL_ID_METADATA_WRITE (before metadata modification)
- SYSCALL_ID_METADATA_STORAGE_WRITE (before 'sstore')

Rationale: Aligns metadata syscalls with existing pattern used in STORAGE_WRITE, EMIT_LOG, DESTROY_ACCOUNT, and CREATE operations. Prevents malicious contracts from persisting changes through view/pure functions.

Verification: Checks placed after parameter validation but before any journal mutations, consistent with other state-changing syscalls.

Impact: Contracts attempting metadata mutations during STATICCALL will now correctly revert with StateChangeDuringStaticCall error.