### PR TITLE
feat(sdk-derive): event derive macro for solidity-compatible logs

### DIFF
--- a/crates/sdk-derive/derive-core/src/event.rs
+++ b/crates/sdk-derive/derive-core/src/event.rs
@@ -1,0 +1,354 @@
+//! Event derive macro for Solidity-compatible event emission.
+//!
+//! Generates `emit()` method that produces EVM logs matching Solidity event ABI.
+//!
+//! # Example
+//! ```ignore
+//! #[derive(Event)]
+//! struct Transfer {
+//!     #[indexed]
+//!     from: Address,
+//!     #[indexed]
+//!     to: Address,
+//!     value: U256,
+//! }
+//!
+//! // Emits log with:
+//! // topics[0] = keccak256("Transfer(address,address,uint256)")
+//! // topics[1] = from
+//! // topics[2] = to
+//! // data = abi.encode(value)
+//! Transfer { from, to, value }.emit(&mut sdk);
+//! ```
+
+use crate::abi::types::rust_to_sol;
+use proc_macro2::{Span, TokenStream as TokenStream2};
+use quote::quote;
+use syn::{Attribute, Data, DeriveInput, Error, Fields, Ident, Result, Type};
+
+/// EVM allows maximum 4 topics per log.
+/// Regular events use topic[0] for signature, leaving 3 for indexed fields.
+const MAX_INDEXED_FIELDS: usize = 3;
+
+/// Anonymous events have no signature topic, all 4 available for indexed fields.
+const MAX_INDEXED_FIELDS_ANONYMOUS: usize = 4;
+
+struct EventField {
+    name: Ident,
+    ty: Type,
+    /// Indexed fields go to topics (filterable via bloom filter).
+    /// Non-indexed fields go to data (cheaper, but requires full scan to filter).
+    indexed: bool,
+}
+
+struct ParsedEvent {
+    name: Ident,
+    fields: Vec<EventField>,
+    /// Anonymous events omit signature from topics, saving gas and allowing 4 indexed fields.
+    anonymous: bool,
+}
+
+/// Main entry point for the Event derive macro.
+pub fn process_event(input: DeriveInput) -> Result<TokenStream2> {
+    let event = parse_event(input)?;
+    validate_event(&event)?;
+    generate_event_impl(&event)
+}
+
+fn parse_event(input: DeriveInput) -> Result<ParsedEvent> {
+    let name = input.ident;
+    let anonymous = has_attribute(&input.attrs, "anonymous");
+
+    let fields = match input.data {
+        Data::Struct(data) => match data.fields {
+            Fields::Named(named) => named
+                .named
+                .into_iter()
+                .map(|f| {
+                    // Validate type is convertible to Solidity (for signature generation)
+                    rust_to_sol(&f.ty).map_err(|e| {
+                        Error::new_spanned(&f.ty, format!("Cannot convert type: {}", e))
+                    })?;
+
+                    Ok(EventField {
+                        name: f.ident.expect("Named field"),
+                        ty: f.ty,
+                        indexed: has_attribute(&f.attrs, "indexed"),
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
+            _ => return Err(Error::new(Span::call_site(), "Only named fields supported")),
+        },
+        _ => return Err(Error::new(Span::call_site(), "Only structs supported")),
+    };
+
+    Ok(ParsedEvent { name, fields, anonymous })
+}
+
+fn has_attribute(attrs: &[Attribute], name: &str) -> bool {
+    attrs.iter().any(|attr| attr.path().is_ident(name))
+}
+
+fn validate_event(event: &ParsedEvent) -> Result<()> {
+    let indexed_count = event.fields.iter().filter(|f| f.indexed).count();
+    let max = if event.anonymous {
+        MAX_INDEXED_FIELDS_ANONYMOUS
+    } else {
+        MAX_INDEXED_FIELDS
+    };
+
+    if indexed_count > max {
+        return Err(Error::new(
+            Span::call_site(),
+            format!(
+                "Too many indexed fields: {} (max {} for {} events)",
+                indexed_count,
+                max,
+                if event.anonymous { "anonymous" } else { "regular" }
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Compile-time keccak256 for event signature hashing.
+fn keccak256(input: &[u8]) -> [u8; 32] {
+    use crypto_hashes::{digest::Digest, sha3::Keccak256};
+    let mut hasher = Keccak256::new();
+    hasher.update(input);
+    let mut output = [0u8; 32];
+    output.copy_from_slice(&hasher.finalize());
+    output
+}
+
+fn generate_event_impl(event: &ParsedEvent) -> Result<TokenStream2> {
+    let name = &event.name;
+
+    // Build Solidity signature: "EventName(type1,type2,...)"
+    let sol_types: Vec<String> = event
+        .fields
+        .iter()
+        .map(|f| {
+            rust_to_sol(&f.ty)
+                .map(|t| t.abi_type())
+                .unwrap_or_else(|_| "unknown".to_string())
+        })
+        .collect();
+    let signature = format!("{}({})", name, sol_types.join(","));
+
+    // Computed at compile-time by proc-macro
+    let selector = keccak256(signature.as_bytes());
+
+    let indexed: Vec<_> = event.fields.iter().filter(|f| f.indexed).collect();
+    let data_fields: Vec<_> = event.fields.iter().filter(|f| !f.indexed).collect();
+
+    let topic_count = indexed.len() + if event.anonymous { 0 } else { 1 };
+    let topics_code = generate_topics(&indexed, event.anonymous, &selector);
+    let data_code = generate_data(&data_fields);
+
+    Ok(quote! {
+        impl #name {
+            /// Solidity event signature.
+            pub const SIGNATURE: &'static str = #signature;
+
+            /// Keccak256 hash of signature, computed at compile-time.
+            pub const SELECTOR: [u8; 32] = [#(#selector),*];
+
+            /// Emits this event as an EVM log.
+            pub fn emit<SDK: fluentbase_sdk::SharedAPI>(&self, sdk: &mut SDK) {
+                use fluentbase_sdk::codec::SolidityABI;
+
+                let topics: [fluentbase_sdk::B256; #topic_count] = #topics_code;
+                #data_code
+                sdk.emit_log(&topics, &data);
+            }
+        }
+    })
+}
+
+/// Generates topic encoding for indexed fields.
+///
+/// Topics are 32-byte values used for bloom filter indexing:
+/// - Static types (address, uint256, bool, etc.): ABI-encoded directly (always 32 bytes)
+/// - Dynamic types (string, bytes, arrays, dynamic structs): keccak256 of ABI-encoded value
+///   (computed at runtime via SDK::keccak256)
+///
+/// This distinction exists because bloom filters require fixed-size data.
+/// Dynamic types are hashed, losing original value but enabling equality filtering.
+fn generate_topics(indexed: &[&EventField], anonymous: bool, selector: &[u8; 32]) -> TokenStream2 {
+    let mut exprs = Vec::new();
+
+    // topics[0] = event signature hash (unless anonymous)
+    if !anonymous {
+        exprs.push(quote! { fluentbase_sdk::B256::new([#(#selector),*]) });
+    }
+
+    for field in indexed {
+        let name = &field.name;
+        let ty = &field.ty;
+
+        exprs.push(quote! {
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.#name.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+
+                if SolidityABI::<#ty>::is_dynamic() {
+                    // Dynamic type: hash at runtime via SDK
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    // Static type: use ABI-encoded value directly (32 bytes)
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            }
+        });
+    }
+
+    quote! { [#(#exprs),*] }
+}
+
+/// Generates data encoding for non-indexed fields.
+///
+/// Data section contains ABI-encoded tuple of all non-indexed fields.
+/// Unlike topics, data preserves full values but cannot be filtered via bloom filter.
+fn generate_data(fields: &[&EventField]) -> TokenStream2 {
+    if fields.is_empty() {
+        return quote! { let data: &[u8] = &[]; };
+    }
+
+    let names: Vec<_> = fields.iter().map(|f| &f.name).collect();
+
+    quote! {
+        let data = {
+            let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+            let values = (#(self.#names.clone(),)*);
+            SolidityABI::encode(&values, &mut buf, 0).expect("encode data fields");
+            buf.freeze()
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+    use syn::parse_quote;
+
+    fn generate(input: DeriveInput) -> String {
+        let tokens = process_event(input).unwrap();
+        let file = syn::parse_file(&tokens.to_string()).unwrap();
+        prettyplease::unparse(&file)
+    }
+
+    #[test]
+    fn test_basic_transfer() {
+        let input: DeriveInput = parse_quote! {
+            struct Transfer {
+                #[indexed]
+                from: Address,
+                #[indexed]
+                to: Address,
+                value: U256,
+            }
+        };
+        assert_snapshot!(generate(input));
+    }
+
+    #[test]
+    fn test_all_indexed() {
+        let input: DeriveInput = parse_quote! {
+            struct Approval {
+                #[indexed]
+                owner: Address,
+                #[indexed]
+                spender: Address,
+                #[indexed]
+                value: U256,
+            }
+        };
+        assert_snapshot!(generate(input));
+    }
+
+    #[test]
+    fn test_no_indexed() {
+        let input: DeriveInput = parse_quote! {
+            struct DataStored {
+                key: U256,
+                value: U256,
+            }
+        };
+        assert_snapshot!(generate(input));
+    }
+
+    #[test]
+    fn test_anonymous() {
+        let input: DeriveInput = parse_quote! {
+            #[anonymous]
+            struct Anonymous {
+                #[indexed]
+                a: Address,
+                #[indexed]
+                b: Address,
+                #[indexed]
+                c: Address,
+                #[indexed]
+                d: Address,
+            }
+        };
+        assert_snapshot!(generate(input));
+    }
+
+    #[test]
+    fn test_dynamic_indexed() {
+        let input: DeriveInput = parse_quote! {
+            struct Message {
+                #[indexed]
+                sender: Address,
+                #[indexed]
+                text: String,
+            }
+        };
+        assert_snapshot!(generate(input));
+    }
+
+    #[test]
+    fn test_too_many_indexed_regular() {
+        let input: DeriveInput = parse_quote! {
+            struct TooMany {
+                #[indexed]
+                a: Address,
+                #[indexed]
+                b: Address,
+                #[indexed]
+                c: Address,
+                #[indexed]
+                d: Address,
+            }
+        };
+        let err = process_event(input).unwrap_err();
+        assert!(err.to_string().contains("Too many indexed"));
+    }
+
+    #[test]
+    fn test_too_many_indexed_anonymous() {
+        let input: DeriveInput = parse_quote! {
+            #[anonymous]
+            struct TooManyAnon {
+                #[indexed]
+                a: Address,
+                #[indexed]
+                b: Address,
+                #[indexed]
+                c: Address,
+                #[indexed]
+                d: Address,
+                #[indexed]
+                e: Address,
+            }
+        };
+        let err = process_event(input).unwrap_err();
+        assert!(err.to_string().contains("Too many indexed"));
+    }
+}

--- a/crates/sdk-derive/derive-core/src/lib.rs
+++ b/crates/sdk-derive/derive-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod attr;
 pub mod client;
 mod codec;
 pub mod constructor;
+pub mod event;
 mod method;
 pub mod router;
 mod signature;

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__all_indexed.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__all_indexed.snap
@@ -1,0 +1,63 @@
+---
+source: crates/sdk-derive/derive-core/src/event.rs
+expression: generate(input)
+---
+impl Approval {
+    /// Solidity event signature.
+    pub const SIGNATURE: &'static str = "Approval(address,address,uint256)";
+    /// Keccak256 hash of signature, computed at compile-time.
+    pub const SELECTOR: [u8; 32] = [
+        140u8, 91u8, 225u8, 229u8, 235u8, 236u8, 125u8, 91u8, 209u8, 79u8, 113u8, 66u8,
+        125u8, 30u8, 132u8, 243u8, 221u8, 3u8, 20u8, 192u8, 247u8, 178u8, 41u8, 30u8,
+        91u8, 32u8, 10u8, 200u8, 199u8, 195u8, 185u8, 37u8,
+    ];
+    /// Emits this event as an EVM log.
+    pub fn emit<SDK: fluentbase_sdk::SharedAPI>(&self, sdk: &mut SDK) {
+        use fluentbase_sdk::codec::SolidityABI;
+        let topics: [fluentbase_sdk::B256; 4usize] = [
+            fluentbase_sdk::B256::new([
+                140u8, 91u8, 225u8, 229u8, 235u8, 236u8, 125u8, 91u8, 209u8, 79u8, 113u8,
+                66u8, 125u8, 30u8, 132u8, 243u8, 221u8, 3u8, 20u8, 192u8, 247u8, 178u8,
+                41u8, 30u8, 91u8, 32u8, 10u8, 200u8, 199u8, 195u8, 185u8, 37u8,
+            ]),
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.owner.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.spender.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.value.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<U256>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+        ];
+        let data: &[u8] = &[];
+        sdk.emit_log(&topics, &data);
+    }
+}

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__anonymous.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__anonymous.snap
@@ -1,0 +1,70 @@
+---
+source: crates/sdk-derive/derive-core/src/event.rs
+expression: generate(input)
+---
+impl Anonymous {
+    /// Solidity event signature.
+    pub const SIGNATURE: &'static str = "Anonymous(address,address,address,address)";
+    /// Keccak256 hash of signature, computed at compile-time.
+    pub const SELECTOR: [u8; 32] = [
+        194u8, 194u8, 236u8, 190u8, 127u8, 121u8, 27u8, 225u8, 23u8, 197u8, 199u8, 131u8,
+        255u8, 2u8, 181u8, 13u8, 186u8, 133u8, 102u8, 77u8, 231u8, 214u8, 68u8, 230u8,
+        224u8, 184u8, 183u8, 3u8, 142u8, 236u8, 193u8, 29u8,
+    ];
+    /// Emits this event as an EVM log.
+    pub fn emit<SDK: fluentbase_sdk::SharedAPI>(&self, sdk: &mut SDK) {
+        use fluentbase_sdk::codec::SolidityABI;
+        let topics: [fluentbase_sdk::B256; 4usize] = [
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.a.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.b.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.c.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.d.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+        ];
+        let data: &[u8] = &[];
+        sdk.emit_log(&topics, &data);
+    }
+}

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__basic_transfer.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__basic_transfer.snap
@@ -1,0 +1,56 @@
+---
+source: crates/sdk-derive/derive-core/src/event.rs
+expression: generate(input)
+---
+impl Transfer {
+    /// Solidity event signature.
+    pub const SIGNATURE: &'static str = "Transfer(address,address,uint256)";
+    /// Keccak256 hash of signature, computed at compile-time.
+    pub const SELECTOR: [u8; 32] = [
+        221u8, 242u8, 82u8, 173u8, 27u8, 226u8, 200u8, 155u8, 105u8, 194u8, 176u8, 104u8,
+        252u8, 55u8, 141u8, 170u8, 149u8, 43u8, 167u8, 241u8, 99u8, 196u8, 161u8, 22u8,
+        40u8, 245u8, 90u8, 77u8, 245u8, 35u8, 179u8, 239u8,
+    ];
+    /// Emits this event as an EVM log.
+    pub fn emit<SDK: fluentbase_sdk::SharedAPI>(&self, sdk: &mut SDK) {
+        use fluentbase_sdk::codec::SolidityABI;
+        let topics: [fluentbase_sdk::B256; 3usize] = [
+            fluentbase_sdk::B256::new([
+                221u8, 242u8, 82u8, 173u8, 27u8, 226u8, 200u8, 155u8, 105u8, 194u8,
+                176u8, 104u8, 252u8, 55u8, 141u8, 170u8, 149u8, 43u8, 167u8, 241u8, 99u8,
+                196u8, 161u8, 22u8, 40u8, 245u8, 90u8, 77u8, 245u8, 35u8, 179u8, 239u8,
+            ]),
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.from.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.to.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+        ];
+        let data = {
+            let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+            let values = (self.value.clone(),);
+            SolidityABI::encode(&values, &mut buf, 0).expect("encode data fields");
+            buf.freeze()
+        };
+        sdk.emit_log(&topics, &data);
+    }
+}

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__dynamic_indexed.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__dynamic_indexed.snap
@@ -1,0 +1,51 @@
+---
+source: crates/sdk-derive/derive-core/src/event.rs
+expression: generate(input)
+---
+impl Message {
+    /// Solidity event signature.
+    pub const SIGNATURE: &'static str = "Message(address,string)";
+    /// Keccak256 hash of signature, computed at compile-time.
+    pub const SELECTOR: [u8; 32] = [
+        129u8, 31u8, 124u8, 255u8, 10u8, 51u8, 116u8, 255u8, 103u8, 204u8, 204u8, 55u8,
+        38u8, 3u8, 93u8, 52u8, 186u8, 112u8, 65u8, 14u8, 2u8, 86u8, 129u8, 138u8, 137u8,
+        30u8, 77u8, 106u8, 204u8, 1u8, 216u8, 142u8,
+    ];
+    /// Emits this event as an EVM log.
+    pub fn emit<SDK: fluentbase_sdk::SharedAPI>(&self, sdk: &mut SDK) {
+        use fluentbase_sdk::codec::SolidityABI;
+        let topics: [fluentbase_sdk::B256; 3usize] = [
+            fluentbase_sdk::B256::new([
+                129u8, 31u8, 124u8, 255u8, 10u8, 51u8, 116u8, 255u8, 103u8, 204u8, 204u8,
+                55u8, 38u8, 3u8, 93u8, 52u8, 186u8, 112u8, 65u8, 14u8, 2u8, 86u8, 129u8,
+                138u8, 137u8, 30u8, 77u8, 106u8, 204u8, 1u8, 216u8, 142u8,
+            ]),
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.sender.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<Address>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+            {
+                let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+                let value = self.text.clone();
+                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                if SolidityABI::<String>::is_dynamic() {
+                    fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
+                } else {
+                    let mut bytes = [0u8; 32];
+                    bytes.copy_from_slice(&buf[..32]);
+                    fluentbase_sdk::B256::new(bytes)
+                }
+            },
+        ];
+        let data: &[u8] = &[];
+        sdk.emit_log(&topics, &data);
+    }
+}

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__no_indexed.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__no_indexed.snap
@@ -1,0 +1,32 @@
+---
+source: crates/sdk-derive/derive-core/src/event.rs
+expression: generate(input)
+---
+impl DataStored {
+    /// Solidity event signature.
+    pub const SIGNATURE: &'static str = "DataStored(uint256,uint256)";
+    /// Keccak256 hash of signature, computed at compile-time.
+    pub const SELECTOR: [u8; 32] = [
+        211u8, 182u8, 197u8, 148u8, 69u8, 27u8, 234u8, 50u8, 4u8, 113u8, 108u8, 158u8,
+        52u8, 101u8, 59u8, 82u8, 26u8, 206u8, 57u8, 0u8, 21u8, 123u8, 167u8, 78u8, 171u8,
+        193u8, 57u8, 12u8, 32u8, 187u8, 140u8, 152u8,
+    ];
+    /// Emits this event as an EVM log.
+    pub fn emit<SDK: fluentbase_sdk::SharedAPI>(&self, sdk: &mut SDK) {
+        use fluentbase_sdk::codec::SolidityABI;
+        let topics: [fluentbase_sdk::B256; 1usize] = [
+            fluentbase_sdk::B256::new([
+                211u8, 182u8, 197u8, 148u8, 69u8, 27u8, 234u8, 50u8, 4u8, 113u8, 108u8,
+                158u8, 52u8, 101u8, 59u8, 82u8, 26u8, 206u8, 57u8, 0u8, 21u8, 123u8,
+                167u8, 78u8, 171u8, 193u8, 57u8, 12u8, 32u8, 187u8, 140u8, 152u8,
+            ]),
+        ];
+        let data = {
+            let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
+            let values = (self.key.clone(), self.value.clone());
+            SolidityABI::encode(&values, &mut buf, 0).expect("encode data fields");
+            buf.freeze()
+        };
+        sdk.emit_log(&topics, &data);
+    }
+}

--- a/crates/sdk-derive/src/lib.rs
+++ b/crates/sdk-derive/src/lib.rs
@@ -1,4 +1,4 @@
-use fluentbase_sdk_derive_core::{client, router, storage_legacy};
+use fluentbase_sdk_derive_core::{client, event, router, storage_legacy};
 use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
 use quote::{quote, ToTokens};
@@ -462,6 +462,31 @@ pub fn derive_contract(input: TokenStream) -> TokenStream {
 pub fn constructor(attr: TokenStream, input: TokenStream) -> TokenStream {
     match fluentbase_sdk_derive_core::constructor::process_constructor(attr.into(), input.into()) {
         Ok(constructor) => constructor.to_token_stream().into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}
+
+/// Derives Solidity-compatible event emission for structs.
+///
+/// # Example
+/// ```rust,ignore
+/// #[derive(Event)]
+/// struct Transfer {
+///     #[indexed]
+///     from: Address,
+///     #[indexed]
+///     to: Address,
+///     value: U256,
+/// }
+///
+/// Transfer { from, to, value }.emit(&mut sdk);
+/// ```
+#[proc_macro_derive(Event, attributes(indexed, anonymous))]
+#[proc_macro_error]
+pub fn derive_event(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as syn::DeriveInput);
+    match event::process_event(input) {
+        Ok(tokens) => tokens.into(),
         Err(err) => err.to_compile_error().into(),
     }
 }

--- a/crates/testing/src/host.rs
+++ b/crates/testing/src/host.rs
@@ -106,6 +106,17 @@ impl HostTestingContext {
     pub fn visit_inner_storage<F: Fn(&HashMap<(Address, U256), U256>)>(&self, f: F) {
         f(&self.inner.borrow_mut().persistent_storage)
     }
+
+    /// Returns and clears all emitted logs.
+    /// Each log is (data, topics).
+    pub fn take_logs(&self) -> Vec<(Bytes, Vec<B256>)> {
+        take(&mut self.inner.borrow_mut().logs)
+    }
+
+    /// Returns logs without clearing.
+    pub fn logs(&self) -> Vec<(Bytes, Vec<B256>)> {
+        self.inner.borrow().logs.clone()
+    }
 }
 
 struct TestingContextInner {

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1778,11 +1778,8 @@ dependencies = [
 name = "fluentbase-examples-erc20"
 version = "0.1.0"
 dependencies = [
- "alloy-sol-types",
  "fluentbase-sdk",
  "fluentbase-testing",
- "hex-literal 0.4.1",
- "serial_test",
 ]
 
 [[package]]

--- a/examples/erc20/Cargo.toml
+++ b/examples/erc20/Cargo.toml
@@ -5,12 +5,9 @@ edition = "2021"
 
 [dependencies]
 fluentbase-sdk = { workspace = true }
-alloy-sol-types = { workspace = true }
-hex-literal = { version = "0.4.1", default-features = false }
 
 [dev-dependencies]
 fluentbase-testing = { workspace = true }
-serial_test = "3.0.0"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
- #[derive(Event)] generates emit() for EVM logs
- #[indexed] for topic fields, #[anonymous] for no-signature events
- compile-time selector, runtime encoding via SolidityABI
- replaces alloy-sol-types in ERC20 example