### PR TITLE
fix(runtime): replace panics with ExitCode in write_fd & fix typos

### DIFF
--- a/crates/runtime/src/syscall_handler/host/write_fd.rs
+++ b/crates/runtime/src/syscall_handler/host/write_fd.rs
@@ -66,7 +66,7 @@ pub fn syscall_write_fd_impl(
 /// The input should be of the form [(`curve_id_u8` | `r_is_y_odd_u8` << 7) || `r` || `alpha`]
 /// where:
 /// * `curve_id` is 1 for secp256k1 and 2 for secp256r1
-/// * `r_is_y_odd` is 0 if r is even and 1 if r is is odd
+/// * `r_is_y_odd` is 0 if r is even and 1 if r is odd
 /// * r is the x-coordinate of the point, which should be 32 bytes,
 /// * alpha := r * r * r * (a * r) + b, which should be 32 bytes.
 ///
@@ -86,7 +86,7 @@ fn hook_ecrecover(buf: &[u8]) -> Result<Vec<u8>, ExitCode> {
     Ok(match curve_id {
         1 => ecrecover::handle_secp256k1(r_bytes, alpha_bytes, r_is_y_odd),
         2 => ecrecover::handle_secp256r1(r_bytes, alpha_bytes, r_is_y_odd),
-        _ => unimplemented!("Unsupported curve id: {}", curve_id),
+        _ => return Err(ExitCode::MalformedBuiltinParams),
     })
 }
 
@@ -406,7 +406,9 @@ mod fp_ops {
         let element = BigUint::from_bytes_be(&buf[..len]);
         let modulus = BigUint::from_bytes_be(&buf[len..2 * len]);
 
-        assert!(!element.is_zero(), "FpOp: Inverse called with zero");
+        if element.is_zero() {
+            return Err(ExitCode::MalformedBuiltinParams);
+        }
 
         let inverse = element.modpow(&(&modulus - BigUint::from(2u64)), &modulus);
 


### PR DESCRIPTION
## Summary
This PR replaces panic-inducing macros (`unimplemented!` and `assert!`) with proper error handling in `write_fd.rs`.

## Changes
- **`hook_ecrecover`**: Now returns `ExitCode::MalformedBuiltinParams` instead of panicking when an unsupported curve ID is provided.
- **`hook_fp_inverse`**: Now returns `ExitCode::MalformedBuiltinParams` instead of panicking on zero input.
- **Docs**: Fixed a minor typo ("is is") in the comments.

This ensures the runtime handles invalid inputs gracefully by returning an error code rather than causing a crash, aligning with the file's intended design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified descriptions for cryptographic operation parameters.

* **Bug Fixes**
  * Enhanced system robustness by replacing potential crashes with proper error handling in cryptographic operations, improving stability for unsupported configurations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->