### PR TITLE
fix: use gas constants from revm v103

### DIFF
--- a/evm-e2e/Cargo.lock
+++ b/evm-e2e/Cargo.lock
@@ -4022,7 +4022,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4040,7 +4040,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "bitvec",
  "phf",
@@ -4052,7 +4052,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4068,7 +4068,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4083,7 +4083,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -4096,7 +4096,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "auto_impl",
  "either",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "auto_impl",
  "either",
@@ -4144,7 +4144,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4156,7 +4156,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4179,7 +4179,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -4190,7 +4190,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#d720e97991ee50394ef5c7d5fc5ef17dc0c704b2"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#645584c0ccbfc3ef61e1e9690d2680b7a69fc614"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.10.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gas parameters for syscall operations are now configuration-driven, enabling flexible customization of system costs without code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->