### PR TITLE
fix: fix incorrect termination halt reason

### DIFF
--- a/contracts/kzg/lib.rs
+++ b/contracts/kzg/lib.rs
@@ -3,14 +3,18 @@ extern crate alloc;
 extern crate fluentbase_sdk;
 
 use fluentbase_sdk::{system_entrypoint, ContextReader, ExitCode, SharedAPI};
+use revm_precompile::PrecompileError;
 
 pub fn main_entry(sdk: &mut impl SharedAPI) -> Result<(), ExitCode> {
     // read full input data
     let gas_limit = sdk.context().contract_gas_limit();
     let input = sdk.bytes_input().clone();
     // call blake2 function
-    let result = revm_precompile::kzg_point_evaluation::run(&input, gas_limit)
-        .map_err(|_| ExitCode::PrecompileError)?;
+    let result =
+        revm_precompile::kzg_point_evaluation::run(&input, gas_limit).map_err(|err| match err {
+            PrecompileError::OutOfGas => ExitCode::OutOfFuel,
+            _ => ExitCode::PrecompileError,
+        })?;
     sdk.sync_evm_gas(result.gas_used)?;
     // write output
     sdk.write(result.bytes);

--- a/crates/evm/src/types.rs
+++ b/crates/evm/src/types.rs
@@ -39,7 +39,7 @@ pub fn instruction_result_from_exit_code(
         ExitCode::UnknownError => InstructionResult::UnknownError,
         ExitCode::InputOutputOutOfBounds => InstructionResult::InputOutputOutOfBounds,
         ExitCode::PrecompileError => InstructionResult::PrecompileError,
-        ExitCode::NotSupportedBytecode => InstructionResult::CreateContractStartingWithEF,
+        ExitCode::NotSupportedBytecode => InstructionResult::MalformedBuiltinParams,
         ExitCode::StateChangeDuringStaticCall => InstructionResult::StateChangeDuringStaticCall,
         ExitCode::CreateContractSizeLimit => InstructionResult::CreateContractSizeLimit,
         ExitCode::CreateContractCollision => InstructionResult::CreateCollision,

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -939,9 +939,9 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             let account = ctx
                 .journal_mut()
                 .load_account_with_code(derived_metadata_address)?;
-            // Verify no deployment collision exists at derived address.
+            // Verify no deployment collision exists at the derived address.
             // Check only code_hash and nonce - intentionally ignore balance to prevent.
-            // Front-running DoS where attacker funds address before legitimate creation.
+            // Front-running DoS where the attacker funds an address before legitimate creation.
             // This matches Ethereum CREATE/CREATE2 behavior: accounts can be pre-funded.
             if account.info.code_hash != KECCAK_EMPTY || account.info.nonce != 0 {
                 return_result!(CreateContractCollision);

--- a/evm-e2e/src/short_tests.rs
+++ b/evm-e2e/src/short_tests.rs
@@ -19,7 +19,14 @@ mod single_test {
         // fn modexp_modsize0_returndatasize("tests/GeneralStateTests/stReturnDataTest/modexp_modsize0_returndatasize.json");
         // fn access_list_example("tests/GeneralStateTests/stExample/accessListExample.json");
         // fn address_opcodes("tests/GeneralStateTests/stEIP2930/addressOpcodes.json");
-        fn revert_ret_data_size("tests/GeneralStateTests/stReturnDataTest/revertRetDataSize.json");
+        // fn revert_ret_data_size("tests/GeneralStateTests/stReturnDataTest/revertRetDataSize.json");
+        // fn create_name_registrator_out_of_memory_bonds1("tests/GeneralStateTests/stSystemOperationsTest/createNameRegistratorOutOfMemoryBonds1.json");
+        // fn returndatacopy_initial_big_sum("tests/GeneralStateTests/stReturnDataTest/returndatacopy_initial_big_sum.json");
+        // fn create_bounds3("tests/GeneralStateTests/stMemoryStressTest/CREATE_Bounds3.json");
+        // fn create2_bounds3("tests/GeneralStateTests/stCreate2/CREATE2_Bounds3.json");
+        // fn buffer_src_offset("tests/GeneralStateTests/stMemoryTest/bufferSrcOffset.json");
+        // fn random_statetest647("tests/GeneralStateTests/stRandom2/randomStatetest647.json");
+        fn returndatacopy_overrun("tests/GeneralStateTests/stReturnDataTest/returndatacopy_overrun.json");
     }
 }
 


### PR DESCRIPTION
* missing `OutOfFuel` mapping for evm precompiles
* fix incorrect usize cast on 32-bit platforms (like wasm) for CREATE/CREATE2/RETURNDATACOPY opcodes
* add proper exit code mapping for revm executor
* add evm e2e halt reason check (to make sure evm and rwasm halts with the same reason)