### PR TITLE
ci: install clang before building docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -84,5 +84,8 @@ jobs:
         run: |
           docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
           docker buildx create --use --name cross-builder
+      - name: Install clang and build tools
+        run: |
+          apt-get update && apt-get install -y libclang-dev pkg-config
       - name: Build and push ${{ matrix.build.name }}
         run: ${{ matrix.build.command }}

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ docker-build-push-nightly-edge-profiling: ## Build and push cross-arch Docker im
 # Create a cross-arch Docker image with the given tags and push it
 define docker_build_push
 	rustup target add wasm32-unknown-unknown
+
 	$(MAKE) FEATURES="$(FEATURES)" build-x86_64-unknown-linux-gnu
 	mkdir -p $(BIN_DIR)/amd64
 	cp $(CARGO_TARGET_DIR)/x86_64-unknown-linux-gnu/$(PROFILE)/fluent $(BIN_DIR)/amd64/fluent


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build configuration to include necessary build tools for Docker builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->