### PR TITLE
ci: use sudo to install clang in docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,6 @@ jobs:
           docker buildx create --use --name cross-builder
       - name: Install clang and build tools
         run: |
-          apt-get update && apt-get install -y libclang-dev pkg-config
+          sudo apt-get update && sudo apt-get install -y libclang-dev pkg-config
       - name: Build and push ${{ matrix.build.name }}
         run: ${{ matrix.build.command }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to ensure proper permission handling during installation of build dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->