### PR TITLE
ci(test): make cargo/rustup paths runner-managed for persistent Docker caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  CARGO_HOME: ${{ github.workspace }}/.cargo
-  RUSTUP_HOME: ${{ github.workspace }}/.rustup
+  # Keep CARGO_HOME/RUSTUP_HOME runner-configurable (for persistent Docker volumes).
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
   CARGO_INCREMENTAL: "0"


### PR DESCRIPTION
## Why
The test workflow currently overrides `CARGO_HOME` and `RUSTUP_HOME` to `${{ github.workspace }}`, which is ephemeral for containerized self-hosted runners. That defeats persistent local caches between runs.

## What changed
- removed workflow-level overrides of `CARGO_HOME` and `RUSTUP_HOME` in `.github/workflows/ci.yml`
- kept `RUSTC_WRAPPER=sccache` and `SCCACHE_GHA_ENABLED=true`

This allows runner/container-level env + mounted volumes to persist cargo/rustup/sccache data across ephemeral job containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for improved build environment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->