### PR TITLE
fix(revm): preserve syscall inspector stack snapshots for call-like traces

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -730,7 +730,7 @@ fn process_halt<CTX: ContextTr, INSP: Inspector<CTX>>(
         };
 
         if let Some(evm_opcode) = evm_opcode {
-            inspect_syscall(frame, ctx, inspector, evm_opcode, []);
+            inspect_syscall(frame, ctx, inspector, evm_opcode, [], []);
         }
     }
 

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -62,7 +62,7 @@ mod tests {
         bytecode::opcode,
         context::{BlockEnv, CfgEnv, ContextTr, TxEnv},
         database::InMemoryDB,
-        interpreter::{interpreter_types::Jumps, Interpreter},
+        interpreter::{interpreter_types::{Jumps, LegacyBytecode}, Interpreter},
     };
 
     #[derive(Default)]
@@ -83,12 +83,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn inspect_syscall_restores_interpreter_state_and_preserves_io_stacks() {
+    fn test_ctx() -> RwasmContext<InMemoryDB> {
         let mut ctx: RwasmContext<InMemoryDB> = RwasmContext::new(InMemoryDB::default(), RwasmSpecId::PRAGUE);
         ctx.cfg = CfgEnv::new_with_spec(RwasmSpecId::PRAGUE);
         ctx.block = BlockEnv::default();
         ctx.tx = TxEnv::default();
+        ctx
+    }
+
+    #[test]
+    fn inspect_syscall_restores_interpreter_state_and_preserves_io_stacks() {
+        let mut ctx = test_ctx();
 
         let mut frame = RwasmFrame::default();
         _ = frame.interpreter.stack.push(U256::from(0xDEAD_BEEFu64));
@@ -115,5 +120,41 @@ mod tests {
 
         // Original frame stack must be fully restored after synthetic inspection.
         assert_eq!(frame.interpreter.stack.data(), &[U256::from(0xDEAD_BEEFu64)]);
+    }
+
+    #[test]
+    fn inspect_syscall_restores_previous_bytecode() {
+        let mut ctx = test_ctx();
+        let mut frame = RwasmFrame::default();
+
+        frame.interpreter.bytecode = ExtBytecode::new(Bytecode::new_raw([opcode::PUSH1, 0x2A].into()));
+        let prev_code = frame.interpreter.bytecode.bytecode_slice().to_vec();
+
+        let mut inspector = RecordingInspector::default();
+        inspect_syscall(&mut frame, &mut ctx, &mut inspector, opcode::SLOAD, [U256::ZERO], [U256::ZERO]);
+
+        assert_eq!(frame.interpreter.bytecode.bytecode_slice(), prev_code.as_slice());
+    }
+
+    #[test]
+    fn inspect_syscall_uses_output_stack_for_step_end_snapshot() {
+        let mut ctx = test_ctx();
+        let mut frame = RwasmFrame::default();
+        let mut inspector = RecordingInspector::default();
+
+        inspect_syscall(
+            &mut frame,
+            &mut ctx,
+            &mut inspector,
+            opcode::CALL,
+            [U256::from(1u64), U256::from(2u64)],
+            [U256::from(7u64), U256::from(8u64), U256::from(9u64)],
+        );
+
+        assert_eq!(inspector.step_stack, vec![U256::from(2u64), U256::from(1u64)]);
+        assert_eq!(
+            inspector.step_end_stack,
+            vec![U256::from(9u64), U256::from(8u64), U256::from(7u64)]
+        );
     }
 }

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -8,27 +8,112 @@ use revm::{
     Inspector,
 };
 
-pub(crate) fn inspect_syscall<CTX: ContextTr, INSP: Inspector<CTX>, IN: IntoIterator<Item = U256>>(
+pub(crate) fn inspect_syscall<
+    CTX: ContextTr,
+    INSP: Inspector<CTX>,
+    IN: IntoIterator<Item = U256>,
+    OUT: IntoIterator<Item = U256>,
+>(
     frame: &mut RwasmFrame,
     ctx: &mut CTX,
     inspector: &mut INSP,
     evm_opcode: u8,
     input: IN,
+    output: OUT,
 ) where
     <IN as IntoIterator>::IntoIter: DoubleEndedIterator,
+    <OUT as IntoIterator>::IntoIter: DoubleEndedIterator,
 {
-    // Save previous bytecode (we return it after)
+    // Save previous state so synthetic syscall-inspection does not mutate the live frame.
     let prev_bytecode = take(&mut frame.interpreter.bytecode);
-    // Execute inspector steps with modified bytecode and stack
+    let prev_stack = take(&mut frame.interpreter.stack);
+
+    // Execute inspector steps with synthetic bytecode and input stack snapshot.
     let bytecode = Bytecode::new_raw([evm_opcode].into());
     frame.interpreter.bytecode = ExtBytecode::new(bytecode);
     frame.interpreter.stack = Stack::new();
+
+    // EVM stack top must be the first popped argument, so we push in reverse.
     for x in input.into_iter().rev() {
         _ = frame.interpreter.stack.push(x);
     }
+
     inspector.step(&mut frame.interpreter, ctx);
-    // TODO: We should call `step_end` once instruction is over for proper gas & output stack calculation.
+
+    // Provide post-op stack shape for inspectors that persist `step_end` stack snapshots.
+    frame.interpreter.stack = Stack::new();
+    for x in output.into_iter().rev() {
+        _ = frame.interpreter.stack.push(x);
+    }
+
+    // TODO: For CALL*/CREATE* opcodes this should ideally run once the child frame settles.
     inspector.step_end(&mut frame.interpreter, ctx);
-    // Return original bytecode back
+
+    // Restore original interpreter state.
     frame.interpreter.bytecode = prev_bytecode;
+    frame.interpreter.stack = prev_stack;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RwasmContext, RwasmFrame, RwasmSpecId};
+    use revm::{
+        bytecode::opcode,
+        context::{BlockEnv, CfgEnv, ContextTr, TxEnv},
+        database::InMemoryDB,
+        interpreter::{interpreter_types::StackTr, Interpreter},
+    };
+
+    #[derive(Default)]
+    struct RecordingInspector {
+        step_opcode: Option<u8>,
+        step_stack: Vec<U256>,
+        step_end_stack: Vec<U256>,
+    }
+
+    impl<CTX: ContextTr> Inspector<CTX> for RecordingInspector {
+        fn step(&mut self, interp: &mut Interpreter, _context: &mut CTX) {
+            self.step_opcode = Some(interp.bytecode.opcode());
+            self.step_stack = interp.stack.data().to_vec();
+        }
+
+        fn step_end(&mut self, interp: &mut Interpreter, _context: &mut CTX) {
+            self.step_end_stack = interp.stack.data().to_vec();
+        }
+    }
+
+    #[test]
+    fn inspect_syscall_restores_interpreter_state_and_preserves_io_stacks() {
+        let mut ctx: RwasmContext<InMemoryDB> = RwasmContext::new(InMemoryDB::default(), RwasmSpecId::PRAGUE);
+        ctx.cfg = CfgEnv::new_with_spec(RwasmSpecId::PRAGUE);
+        ctx.block = BlockEnv::default();
+        ctx.tx = TxEnv::default();
+
+        let mut frame = RwasmFrame::default();
+        _ = frame.interpreter.stack.push(U256::from(0xDEAD_BEEFu64));
+
+        let mut inspector = RecordingInspector::default();
+        let gas = U256::from(123_456u64);
+        let target = U256::from(0xCAFEu64);
+
+        inspect_syscall(
+            &mut frame,
+            &mut ctx,
+            &mut inspector,
+            opcode::DELEGATECALL,
+            [gas, target, U256::ZERO, U256::ZERO, U256::ZERO, U256::ZERO],
+            [U256::ONE],
+        );
+
+        assert_eq!(inspector.step_opcode, Some(opcode::DELEGATECALL));
+        assert_eq!(inspector.step_stack.len(), 6);
+        // Stack layout is bottom..top, so gas must be at the top (last element).
+        assert_eq!(inspector.step_stack[5], gas);
+        assert_eq!(inspector.step_stack[4], target);
+        assert_eq!(inspector.step_end_stack, vec![U256::ONE]);
+
+        // Original frame stack must be fully restored after synthetic inspection.
+        assert_eq!(frame.interpreter.stack.data(), &[U256::from(0xDEAD_BEEFu64)]);
+    }
 }

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -62,7 +62,7 @@ mod tests {
         bytecode::opcode,
         context::{BlockEnv, CfgEnv, ContextTr, TxEnv},
         database::InMemoryDB,
-        interpreter::{interpreter_types::StackTr, Interpreter},
+        interpreter::{interpreter_types::Jumps, Interpreter},
     };
 
     #[derive(Default)]

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -206,7 +206,14 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
     macro_rules! inspect {
         ($evm_opcode:expr, $inputs:expr, $outputs:expr) => {{
             if let Some(inspector) = inspector.as_mut() {
-                crate::inspector::inspect_syscall(frame, ctx, inspector, $evm_opcode, $inputs);
+                crate::inspector::inspect_syscall(
+                    frame,
+                    ctx,
+                    inspector,
+                    $evm_opcode,
+                    $inputs,
+                    $outputs,
+                );
             }
         }};
     }


### PR DESCRIPTION
## Summary

When syscall interruptions are inspected in `crates/revm/src/syscall.rs`, we were only forwarding synthetic *input* stack values to `inspect_syscall`, and never forwarding synthetic output stack values.

For call-like opcodes (`CALL*`/`CREATE*`), this makes inspector `step/step_end` snapshots inconsistent and can cause missing/incomplete nested call metadata in tracers that derive details from stack snapshots.

## Root cause

- `inspect!` macro accepted `($inputs, $outputs)` but only passed `$inputs`.
- `inspect_syscall` did not preserve/restore the interpreter stack around synthetic inspection.

## Fix

- Extend `inspect_syscall` to accept both `input` and `output` iterators.
- Save/restore interpreter bytecode and stack around synthetic inspection.
- Feed input stack before `inspector.step`, and output stack before `inspector.step_end`.
- Update all call sites (`syscall.rs`, `executor.rs`).

## Test

Added a unit test in `crates/revm/src/inspector.rs` that verifies:

- `DELEGATECALL` synthetic opcode is observed by inspector step hook
- input stack ordering is preserved (top-of-stack semantics)
- output stack is visible in `step_end`
- original interpreter stack is restored after inspection

## Notes

I couldn't run Rust tests in this environment because `cargo` is unavailable in PATH, but the changes are localized and covered by the new unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system call inspection to prevent unintended state mutations during debugging operations.

* **Refactor**
  * Enhanced inspection mechanism to capture and validate input/output parameters more accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->