### PR TITLE
docs(ust20): add Solidity and Rust token deployment examples

### DIFF
--- a/docs/08-universal-token.md
+++ b/docs/08-universal-token.md
@@ -57,7 +57,7 @@ So constructor data should encode human text in the front of the 32-byte value, 
 Solidity helper (mload-only) to convert `string` -> `bytes32`:
 
 ```solidity
-function toBytes32Mload(string memory s) internal pure returns (bytes32 out) {
+function stringToBytes32(string memory s) internal pure returns (bytes32 out) {
     // UST20 expects max 32-byte fixed text fields.
     require(bytes(s).length <= 32, "string too long");
     assembly {
@@ -71,8 +71,8 @@ function toBytes32Mload(string memory s) internal pure returns (bytes32 out) {
 Use it in deployment call as:
 
 ```solidity
-bytes32 name32 = toBytes32Mload("My Token");
-bytes32 symbol32 = toBytes32Mload("MTK");
+bytes32 name32 = stringToBytes32("My Token");
+bytes32 symbol32 = stringToBytes32("MTK");
 ```
 
 ---


### PR DESCRIPTION
## Summary

Follow-up docs update after merged PR #365.

This PR revises `docs/08-universal-token.md` and adds concrete deployment examples requested by maintainers.

## Changes

- Reworked Universal Token doc for clarity.
- Added **Solidity** deployment examples:
  - `CREATE`
  - `CREATE2`
- Added **Rust** deployment examples:
  - payload creation via `create_deployment_tx_with_roles(...)`
  - deployment via `sdk.create(None, ...)` and `sdk.create(Some(salt), ...)`

## Why new PR

PR #365 is already merged, so this change is submitted as a separate follow-up PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified UST20 shared-runtime behavior, deployment semantics, and how initial token supply and deployer balance are set.
  * Standardized ERC20-like method signatures and tightened role-based access wording.
  * Specified name/symbol formatting rules and input validation.
  * Added Solidity, Rust, and SDK deployment examples and updated compatibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->