### PR TITLE
fix(bridge): support receiveFailedMessage re-execution in REVM hooks

### DIFF
--- a/crates/revm/src/bridge.rs
+++ b/crates/revm/src/bridge.rs
@@ -1,6 +1,6 @@
 use alloy_sol_types::{sol, SolCall, SolEvent};
 use fluentbase_evm::{InterpreterAction, InterpreterResult};
-use fluentbase_sdk::{Bytes, PRECOMPILE_ROLLUP_BRIDGE};
+use fluentbase_sdk::{Bytes, U256, PRECOMPILE_ROLLUP_BRIDGE};
 use revm::{
     context::{
         journaled_state::account::JournaledAccountTr, ContextError, ContextTr, JournalTr,
@@ -35,6 +35,16 @@ sol! {
         bytes calldata message
     ) external;
 
+    function receiveFailedMessage(
+        address from,
+        address to,
+        uint256 value,
+        uint256 chainId,
+        uint256 blockNumber,
+        uint256 messageNonce,
+        bytes calldata message
+    ) external;
+
     function sendMessage(address to, bytes calldata message) external payable;
 }
 
@@ -53,13 +63,10 @@ pub(crate) fn apply_bridge_pre_invocation_hook<CTX: ContextTr>(
         .load_account_with_code_mut(PRECOMPILE_ROLLUP_BRIDGE)?
         .data;
 
-    // Mint an extra value for bridge since these funds are required for rollup deposit
-    if tx.input().starts_with(&receiveMessageCall::SELECTOR) {
-        let Ok(message) = receiveMessageCall::abi_decode(tx.input().as_ref()) else {
-            return Ok(());
-        };
+    // Mint an extra value for bridge since these funds are required for rollup receive/re-execution
+    if let Some(message_value) = decode_receive_message_value(tx.input().as_ref()) {
         // Note: overflow here can't happen, we can't have more than 2**256 on bridge balance
-        _ = bridge_account.incr_balance(message.value)
+        _ = bridge_account.incr_balance(message_value)
     }
     Ok(())
 }
@@ -80,12 +87,7 @@ pub(crate) fn apply_bridge_post_invocation_hook<CTX: ContextTr>(
         return Ok(());
     };
 
-    if tx.input().starts_with(&receiveMessageCall::SELECTOR) {
-        let Ok(message) = receiveMessageCall::abi_decode(tx.input().as_ref()) else {
-            // If we can't decode the message, it's not a valid receiveMessageCall
-            return Ok(());
-        };
-
+    if let Some(message_value) = decode_receive_message_value(tx.input().as_ref()) {
         let receive_message_logs = journal
             .logs()
             .iter()
@@ -129,12 +131,12 @@ pub(crate) fn apply_bridge_post_invocation_hook<CTX: ContextTr>(
             .data;
 
         // Decrease balance back if execution failed
-        if !was_call_successful && !bridge_account.decr_balance(message.value) {
+        if !was_call_successful && !bridge_account.decr_balance(message_value) {
             let bridge_balance = bridge_account.balance();
             warn!(
                 %bridge_balance,
-                value = %message.value,
-                "Failed to decrease bridge balance on receive message"
+                value = %message_value,
+                "Failed to decrease bridge balance on receive/receiveFailed message"
             );
             *next_action = malformed_interpreter_action();
             return Ok(());
@@ -213,6 +215,24 @@ pub(crate) fn apply_bridge_post_invocation_hook<CTX: ContextTr>(
     }
 
     Ok(())
+}
+
+fn decode_receive_message_value(input: &[u8]) -> Option<U256> {
+    if input.starts_with(&receiveMessageCall::SELECTOR) {
+        let Ok(message) = receiveMessageCall::abi_decode(input) else {
+            return None;
+        };
+        return Some(message.value);
+    }
+
+    if input.starts_with(&receiveFailedMessageCall::SELECTOR) {
+        let Ok(message) = receiveFailedMessageCall::abi_decode(input) else {
+            return None;
+        };
+        return Some(message.value);
+    }
+
+    None
 }
 
 fn malformed_interpreter_action() -> InterpreterAction {

--- a/e2e/src/bridge.rs
+++ b/e2e/src/bridge.rs
@@ -36,6 +36,16 @@ sol! {
         bytes calldata message
     ) external payable;
 
+    function receiveFailedMessage(
+        address from,
+        address to,
+        uint256 value,
+        uint256 chainId,
+        uint256 blockNumber,
+        uint256 messageNonce,
+        bytes calldata message
+    ) external payable;
+
     function sendMessage(address to, bytes calldata message) external payable;
 }
 
@@ -424,6 +434,184 @@ fn test_receive_message_burns_balance_when_log_marks_unsuccessful_call() {
     );
 
     assert!(result.is_success());
+    let new_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, new_balance);
+}
+
+#[test]
+fn test_receive_failed_message_mints_on_successful_valid_log() {
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+
+    let log_data = ReceivedMessage {
+        messageHash: B256::ZERO,
+        successfulCall: true,
+        returnData: Bytes::new(),
+    }
+    .encode_data();
+
+    let mut bytecode = Vec::new();
+    const LOG_DATA_OFFSET: usize = 6 + 2 + 32 + 3 + 1;
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(log_data.len()).unwrap());
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(LOG_DATA_OFFSET).unwrap());
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::CODECOPY);
+    bytecode.push(opcode::PUSH32);
+    bytecode.extend_from_slice(ReceivedMessage::SIGNATURE_HASH.as_slice());
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(log_data.len()).unwrap());
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::LOG1);
+    bytecode.push(opcode::STOP);
+    assert_eq!(bytecode.len(), LOG_DATA_OFFSET);
+    bytecode.extend(log_data);
+
+    ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
+
+    let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    let input = receiveFailedMessageCall {
+        from: Address::repeat_byte(0x01),
+        to: Address::repeat_byte(0x01),
+        value: U256::from(1_000),
+        chainId: U256::ONE,
+        blockNumber: U256::ZERO,
+        messageNonce: U256::ZERO,
+        message: Bytes::new(),
+    }
+    .abi_encode();
+
+    let result = ctx.call_evm_tx(
+        Address::repeat_byte(0x01),
+        PRECOMPILE_ROLLUP_BRIDGE,
+        input.into(),
+        None,
+        None,
+    );
+
+    assert!(result.is_success());
+    let new_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance + U256::from(1_000), new_balance);
+}
+
+#[test]
+fn test_receive_failed_message_unsuccessful_log_restores_balance() {
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+
+    let log_data = ReceivedMessage {
+        messageHash: B256::ZERO,
+        successfulCall: false,
+        returnData: Bytes::new(),
+    }
+    .encode_data();
+
+    let mut bytecode = Vec::new();
+    const LOG_DATA_OFFSET: usize = 6 + 2 + 32 + 3 + 1;
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(log_data.len()).unwrap());
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(LOG_DATA_OFFSET).unwrap());
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::CODECOPY);
+    bytecode.push(opcode::PUSH32);
+    bytecode.extend_from_slice(ReceivedMessage::SIGNATURE_HASH.as_slice());
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(log_data.len()).unwrap());
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::LOG1);
+    bytecode.push(opcode::STOP);
+    assert_eq!(bytecode.len(), LOG_DATA_OFFSET);
+    bytecode.extend(log_data);
+
+    ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
+
+    let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    let input = receiveFailedMessageCall {
+        from: Address::repeat_byte(0x01),
+        to: Address::repeat_byte(0x01),
+        value: U256::from(1_000),
+        chainId: U256::ONE,
+        blockNumber: U256::ZERO,
+        messageNonce: U256::ZERO,
+        message: Bytes::new(),
+    }
+    .abi_encode();
+
+    let result = ctx.call_evm_tx(
+        Address::repeat_byte(0x01),
+        PRECOMPILE_ROLLUP_BRIDGE,
+        input.into(),
+        None,
+        None,
+    );
+
+    assert!(result.is_success());
+    let new_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, new_balance);
+}
+
+#[test]
+fn test_receive_failed_message_revert_restores_bridge_balance() {
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+
+    let mut bytecode = Vec::new();
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::REVERT);
+    ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
+
+    let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    let input = receiveFailedMessageCall {
+        from: Address::repeat_byte(0x01),
+        to: Address::repeat_byte(0x01),
+        value: U256::from(1_000),
+        chainId: U256::ONE,
+        blockNumber: U256::ZERO,
+        messageNonce: U256::ZERO,
+        message: Bytes::new(),
+    }
+    .abi_encode();
+
+    let result = ctx.call_evm_tx(
+        Address::repeat_byte(0x01),
+        PRECOMPILE_ROLLUP_BRIDGE,
+        input.into(),
+        None,
+        None,
+    );
+
+    assert!(!result.is_success());
+    let new_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, new_balance);
+}
+
+#[test]
+fn test_receive_failed_message_fails_when_success_log_missing() {
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+
+    ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, vec![opcode::STOP]);
+
+    let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    let input = receiveFailedMessageCall {
+        from: Address::repeat_byte(0x01),
+        to: Address::repeat_byte(0x01),
+        value: U256::from(1_000),
+        chainId: U256::ONE,
+        blockNumber: U256::ZERO,
+        messageNonce: U256::ZERO,
+        message: Bytes::new(),
+    }
+    .abi_encode();
+
+    let result = ctx.call_evm_tx(
+        Address::repeat_byte(0x01),
+        PRECOMPILE_ROLLUP_BRIDGE,
+        input.into(),
+        None,
+        None,
+    );
+
+    assert!(!result.is_success());
     let new_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
     assert_eq!(old_balance, new_balance);
 }


### PR DESCRIPTION
## Summary

Adds `receiveFailedMessage` support in REVM bridge hooks and extends bridge e2e coverage for re-execution paths.

## Changes

### 1) REVM bridge hook support for failed-message replay

File: `crates/revm/src/bridge.rs`

- Added ABI declaration for:
  - `receiveFailedMessage(address,address,uint256,uint256,uint256,uint256,bytes)`
- Introduced shared selector/value decoder:
  - `decode_receive_message_value(input)`
  - handles both `receiveMessage` and `receiveFailedMessage`
- Updated **pre-invocation hook** to mint bridge balance for both receive paths.
- Updated **post-invocation hook** to apply the same reconciliation logic for both receive paths:
  - require exactly one `ReceivedMessage` event on success
  - burn minted value back when `successfulCall == false`
  - fail with `MalformedBuiltinParams` on malformed/multi-event cases

### 2) e2e coverage expansion

File: `e2e/src/bridge.rs`

Added tests for `receiveFailedMessage` hook semantics:

- `test_receive_failed_message_mints_on_successful_valid_log`
- `test_receive_failed_message_unsuccessful_log_restores_balance`
- `test_receive_failed_message_revert_restores_bridge_balance`
- `test_receive_failed_message_fails_when_success_log_missing`

Also added ABI declaration for `receiveFailedMessage` in e2e bridge test contract interface.

## Security review notes (bridge hook scope)

### Verified/covered

- Replay path now has symmetric mint/reconcile behavior with receive path.
- Failed replay attempts do not leave minted residue (revert/missing-log/unsuccessful-call test coverage added).
- Hook remains scoped to `PRECOMPILE_ROLLUP_BRIDGE` only.

### Remaining hardening recommendations

- Hook validates event count/type but does not fully cross-check all `SentMessage`/`ReceivedMessage` fields against tx input/context.
- `assert!` branches in hook are currently treated as invariant checks; can be converted to graceful malformed-action returns for stricter panic-hardening.

## Validation

- Local static review performed.
- Could not run `cargo test` in this environment because `cargo` binary is unavailable in PATH.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling failed cross-chain bridge messages with proper balance restoration and event logging.

* **Tests**
  * Added comprehensive end-to-end tests covering failed message handling scenarios and balance restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->