### PR TITLE
docs: txpool disallow policy for SDN address feeds

### DIFF
--- a/docs/10-txpool-disallow-sdn-policy.md
+++ b/docs/10-txpool-disallow-sdn-policy.md
@@ -1,0 +1,48 @@
+# txpool disallow policy for SDN-style address feeds
+
+Fluent nodes can run a local transaction policy that prevents selected addresses from entering the txpool. This is intended for sanctions and compliance feeds where an operator must avoid locally mining or proposing transactions that involve listed addresses.
+
+## Why this lives in Fluent docs
+
+The `fluent` binary is built from Fluentbase and ships a patched reth runtime. Operational guidance for node operators belongs in Fluent docs, even when the implementation is in the reth subtree.
+
+## Capability
+
+Fluent-reth adds a txpool policy flag: `--txpool.disallow <PATH>`.
+
+When configured, the node rejects txpool admission for any transaction that matches a disallowed address in one of these roles:
+
+- transaction sender
+- call recipient (`to` for call transactions)
+- EIP-7702 authorization authority (recovered authority signer)
+
+Rejected transactions are excluded from local txpool selection, so the local builder will not include them in blocks it builds.
+
+## Input file format
+
+The disallow file accepts either:
+
+- a JSON array of address strings
+- plain text tokens separated by newline, whitespace, or comma
+
+This is intentionally tolerant for mixed SDN exports. Non-EVM tokens are ignored. Valid EVM addresses are parsed and deduplicated. If a token looks like an EVM address (`0x...`) but is malformed, startup fails with a parse error so the operator does not silently run with a bad policy file.
+
+## Scope and consensus semantics
+
+This is a local txpool policy, not a consensus rule.
+
+- It controls what this node admits into its own pool and therefore what it can locally include.
+- It does not redefine chain validity for blocks produced elsewhere.
+
+This distinction is required to stay consensus-compatible with the network.
+
+## Expected operator workflow
+
+1. Maintain a local SDN source file.
+2. Point `--txpool.disallow` to that file in the node service configuration.
+3. Restart or roll the node after policy updates.
+4. Confirm startup logs report a non-zero count of loaded disallowed addresses.
+
+## Implementation reference
+
+Patched reth change: `fluentlabs-xyz/reth` PR #1.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The goal is practical understanding for contributors and auditors, not API marke
 8. [`07-rwasm-integration.md`](./07-rwasm-integration.md) — Fluentbase integration contract with rWasm.
 9. [`08-universal-token.md`](./08-universal-token.md) — UST20 runtime behavior and constraints.
 10. [`09-rpc-compatibility-vs-reth.md`](./09-rpc-compatibility-vs-reth.md) — Fluent RPC behavior differences from upstream Reth for account code APIs.
+11. [`10-txpool-disallow-sdn-policy.md`](./10-txpool-disallow-sdn-policy.md) — Local txpool disallow policy for SDN-style address feeds.
 
 ## Source-of-truth rule
 


### PR DESCRIPTION
## Summary
- add operator documentation for the new local txpool disallow policy used to block SDN-listed EVM addresses from local inclusion
- document supported input formats (JSON array and mixed plain-text feeds)
- document exact enforcement scope (sender, recipient, EIP-7702 authority)
- explain consensus boundary (local policy, not canonical block invalidation)
- add the new page to docs index

## Context
The Fluent binary is built from Fluentbase, so operator instructions for this patched behavior are documented in Fluent docs.

Implementation PR in reth fork: fluentlabs-xyz/reth#1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a local txpool disallow policy enabling nodes to reject transactions from specified addresses via the new `--txpool.disallow <PATH>` command-line flag. Supports multiple input formats for defining disallowed addresses.

* **Documentation**
  * Added comprehensive guide covering the disallow policy configuration, supported file formats, operational workflow, and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->