### PR TITLE
docs(node): add local run guide for testnet and mainnet

### DIFF
--- a/docs/10-running-node-locally-testnet-mainnet.md
+++ b/docs/10-running-node-locally-testnet-mainnet.md
@@ -21,6 +21,13 @@ Binary path used below:
 ./target/release/fluent
 ```
 
+## Prebuilt distribution options
+
+If you do not want to build from source:
+
+- Binaries (GitHub Releases): https://github.com/fluentlabs-xyz/fluentbase/releases
+- Docker image (`fluent` package): https://github.com/fluentlabs-xyz/fluent/pkgs/container/fluent
+
 ## Chain names
 
 - `fluent-testnet` (chain id `20994`)

--- a/docs/10-running-node-locally-testnet-mainnet.md
+++ b/docs/10-running-node-locally-testnet-mainnet.md
@@ -1,0 +1,87 @@
+# Run a Fluent node locally (testnet and mainnet)
+
+This guide shows the minimal commands to run a local Fluent node from this repository.
+
+## Prerequisites
+
+- Rust toolchain installed (project toolchain is pinned by `rust-toolchain`).
+- `git` and build dependencies for Rust crates.
+- Open ports for P2P and RPC if needed.
+
+Build the node binary:
+
+```bash
+cd fluentbase
+cargo build --bin fluent --release
+```
+
+Binary path used below:
+
+```bash
+./target/release/fluent
+```
+
+## Chain names
+
+- `fluent-testnet` (chain id `20994`)
+- `fluent-mainnet` (chain id `25363`)
+
+Use separate data directories per network.
+
+---
+
+## Run local testnet node
+
+Testnet should be bootstrapped from snapshot first.
+
+```bash
+mkdir -p ./datadir/testnet
+
+./target/release/fluent init \
+  --datadir=./datadir/testnet \
+  --chain=fluent-testnet
+
+./target/release/fluent download \
+  --datadir=./datadir/testnet \
+  --chain=fluent-testnet
+
+./target/release/fluent node \
+  --chain=fluent-testnet \
+  --datadir=./datadir/testnet \
+  --http
+```
+
+---
+
+## Run local mainnet node
+
+Mainnet can be started directly with its own datadir:
+
+```bash
+mkdir -p ./datadir/mainnet
+
+./target/release/fluent node \
+  --chain=fluent-mainnet \
+  --datadir=./datadir/mainnet \
+  --http
+```
+
+---
+
+## Quick health check
+
+With `--http` enabled, verify local RPC responds:
+
+```bash
+curl -s -X POST http://127.0.0.1:8545 \
+  -H 'Content-Type: application/json' \
+  --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'
+```
+
+If it returns a hex block number (`0x...`), RPC is up.
+
+## Notes
+
+- Keep testnet and mainnet datadirs separate.
+- First sync can take time and disk space.
+- Stop node with `Ctrl+C` for clean shutdown.

--- a/docs/10-running-node-locally-testnet-mainnet.md
+++ b/docs/10-running-node-locally-testnet-mainnet.md
@@ -26,7 +26,7 @@ Binary path used below:
 If you do not want to build from source:
 
 - Binaries (GitHub Releases): https://github.com/fluentlabs-xyz/fluentbase/releases
-- Docker image (`fluent` package): https://github.com/fluentlabs-xyz/fluent/pkgs/container/fluent
+- Docker image (`fluent` package): https://github.com/fluentlabs-xyz/fluentbase/pkgs/container/fluent
 
 ## Chain names
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The goal is practical understanding for contributors and auditors, not API marke
 8. [`07-rwasm-integration.md`](./07-rwasm-integration.md) — Fluentbase integration contract with rWasm.
 9. [`08-universal-token.md`](./08-universal-token.md) — UST20 runtime behavior and constraints.
 10. [`09-rpc-compatibility-vs-reth.md`](./09-rpc-compatibility-vs-reth.md) — Fluent RPC behavior differences from upstream Reth for account code APIs.
+11. [`10-running-node-locally-testnet-mainnet.md`](./10-running-node-locally-testnet-mainnet.md) — practical local node runbook for Fluent testnet and mainnet.
 
 ## Source-of-truth rule
 


### PR DESCRIPTION
## Summary
- add a new doc for running a local Fluent node on testnet and mainnet
- include build, init/download (testnet), run, and RPC health-check commands
- add the new doc to docs/README reading order
- mention prebuilt distribution locations:
  - binaries: https://github.com/fluentlabs-xyz/fluentbase/releases
  - docker image: https://github.com/fluentlabs-xyz/fluentbase/pkgs/container/fluent

## Scope
Documentation only, no runtime or protocol changes.