### PR TITLE
fix(build): add target_dir fallback for non-build.rs callers

### DIFF
--- a/crates/build/src/build.rs
+++ b/crates/build/src/build.rs
@@ -196,10 +196,21 @@ fn build_wasm(
     docker_image: &Option<String>,
     mount_dir: &Path,
 ) -> Result<PathBuf> {
-    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
-    let target_dir = out_dir.ancestors().nth(4).unwrap();
+    let target_dir = if let Some(dir) = &args.target_dir {
+        dir.clone()
+    } else if let Ok(out_dir) = env::var("OUT_DIR") {
+        PathBuf::from(out_dir)
+            .ancestors()
+            .nth(4)
+            .unwrap()
+            .to_path_buf()
+    } else {
+        contract_dir
+            .join("target")
+            .join(crate::HELPER_TARGET_SUBDIR)
+    };
     eprintln!("Detected target dir: {}", target_dir.display());
-    fs::create_dir_all(target_dir)?;
+    fs::create_dir_all(&target_dir)?;
 
     // Build cargo command
     let mut cargo_args = args.cargo_build_command();
@@ -232,7 +243,7 @@ fn build_wasm(
     )?;
 
     // Find the built WASM file
-    let wasm_path = find_wasm_artifact(target_dir, package)?;
+    let wasm_path = find_wasm_artifact(&target_dir, package)?;
 
     if args.wasm_opt {
         optimize_wasm(&wasm_path, docker_config, &rust_toolchain)?;

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -127,6 +127,11 @@ pub struct BuildArgs {
     )]
     pub output_path: Option<String>,
 
+    /// Custom target directory for WASM compilation output.
+    /// Falls back to OUT_DIR (in build.rs) or contract_dir/target otherwise.
+    #[arg(long)]
+    pub target_dir: Option<PathBuf>,
+
     /// Post process wasm for size optimization
     #[arg(long)]
     pub wasm_opt: bool,
@@ -150,6 +155,7 @@ impl Default for BuildArgs {
             ignore_default_rust_flags: false,
             generate: vec![],
             output_path: Some("./out/{contract_name}/".to_string()),
+            target_dir: None,
             wasm_opt: false,
         }
     }


### PR DESCRIPTION
  - add target_dir field to BuildArgs
  - fall back to contract_dir/target when OUT_DIR is unset
  - fixes crash when execute_build is called at runtime