### PR TITLE
fix(fluent): use graceful shutdown for validator

### DIFF
--- a/crates/node/src/launcher.rs
+++ b/crates/node/src/launcher.rs
@@ -16,6 +16,7 @@ use reth_payload_primitives::{
 };
 use reth_primitives_traits::{HeaderTy, NodePrimitives, SealedBlock, SealedHeaderFor};
 use reth_storage_api::BlockReader;
+use reth_tasks::shutdown::GracefulShutdown;
 use std::{sync::Arc, time::Duration};
 use tokio::{sync::mpsc, time::Interval};
 use tracing::{error, info};
@@ -45,9 +46,12 @@ where
     handle
         .node
         .task_executor
-        .spawn_critical_task("consensus validator worker", async move {
-            block_producer.run(block_time).await;
-        });
+        .spawn_critical_with_graceful_shutdown_signal(
+            "consensus validator worker",
+            move |shutdown| async move {
+                block_producer.run(block_time, shutdown).await;
+            },
+        );
     Ok(())
 }
 
@@ -87,11 +91,22 @@ where
         }
     }
 
-    pub async fn run(mut self, mut block_time: Interval) {
+    pub async fn run(mut self, mut block_time: Interval, shutdown: GracefulShutdown) {
         let mut fcu_interval = tokio::time::interval(Duration::from_secs(1));
+        tokio::pin!(shutdown);
+
         loop {
             tokio::select! {
-                // Wait for the interval or the pool to receive a transaction
+                biased;
+
+                guard = &mut shutdown => {
+                    info!(target: "engine::local", "Shutting down consensus validator worker");
+                    drop(guard);
+                    break;
+                }
+                // Wait for the interval or the pool to receive a transaction.
+                // If shutdown arrives while this future is in progress, shutdown will wait
+                // until `advance_forkchoice_state()` finishes and only then exit the loop.
                 _ = block_time.tick() => {
                     if let Err(e) = self.advance_forkchoice_state().await {
                         error!(target: "engine::local", "Error advancing the chain: {:?}", e);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validator node and its background workers now honor a graceful shutdown signal, allowing block production and consensus-related tasks to stop cleanly and deterministically.
* **Bug Fixes**
  * Reduces abrupt termination during consensus loops, improving resource cleanup and lowering risk of inconsistent state on shutdown.
* **Improvements**
  * Adds clear shutdown logging so orderly exit of block production is observable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->