### PR TITLE
feat(runtime): publish execution metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4725,6 +4725,7 @@ dependencies = [
  "bytemuck",
  "fluentbase-types",
  "k256",
+ "metrics",
  "num",
  "p256",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ static_assertions = { version = "1.1.0", default-features = false }
 memoffset = { version = "0.9.1", default-features = false }
 paste = { version = "1.0", default-features = false }
 auto_impl = { version = "1.2", default-features = false }
+metrics = { version = "0.24.3", default-features = false }
 bytes = { version = "1.10.1", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 hex-literal = { version = "1.0.0" }

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2177,6 +2177,7 @@ dependencies = [
  "bytemuck",
  "fluentbase-types",
  "k256",
+ "metrics",
  "num",
  "p256",
  "rwasm",
@@ -2935,6 +2936,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3475,6 +3486,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postcard"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,6 +27,7 @@ num = "0.4.3"
 sp1-curves = { workspace = true }
 bytemuck = { workspace = true }
 schnellru = { workspace = true }
+metrics = { workspace = true, optional = true }
 amcl = { package = "snowbridge-amcl", version = "1.0.2", default-features = false, features = [
     "bls381",
 ] }
@@ -38,6 +39,7 @@ rand = "0.9.2"
 [features]
 default = ["std"]
 std = [
+    "dep:metrics",
     "rwasm/std",
     "fluentbase-types/std",
 ]

--- a/crates/runtime/src/executor.rs
+++ b/crates/runtime/src/executor.rs
@@ -1,4 +1,5 @@
 use crate::{
+    metrics::{self, RuntimeModeLabel, RuntimeTimer},
     module_factory::ModuleFactory,
     runtime::{ContractRuntime, ExecutionMode, SystemRuntime},
     RuntimeContext,
@@ -230,6 +231,7 @@ impl RuntimeFactoryExecutor {
         self.transaction_call_id_counter += 1;
         let prev = self.recoverable_runtimes.insert(call_id, runtime);
         debug_assert!(prev.is_none());
+        metrics::set_recoverable_runtimes(self.recoverable_runtimes.len());
 
         ExecutionResult {
             // We return `call_id` as exit code (it's safe because exit code can't be positive)
@@ -313,6 +315,8 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         bytecode_or_hash: BytecodeOrHash,
         ctx: RuntimeContext,
     ) -> ExecutionResult {
+        let timer = RuntimeTimer::start();
+        let state = metrics::state_label(ctx.state);
         let system_runtime_params = match &bytecode_or_hash {
             BytecodeOrHash::Bytecode { address, hash, .. } => {
                 fluentbase_types::is_execute_using_system_runtime(address)
@@ -352,16 +356,20 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
             //
             // Ideally, it should never happen.
             if let Some(trap_code) = runtime.as_ref().err() {
-                return ExecutionResult {
+                metrics::record_initialization_error(RuntimeModeLabel::Contract, state, *trap_code);
+                let result = ExecutionResult {
                     exit_code: ExitCode::from(trap_code).into_i32(),
                     fuel_consumed: fuel_limit_value,
                     fuel_refunded: 0,
                     output: vec![],
                     return_data: vec![],
                 };
+                metrics::record_execution(RuntimeModeLabel::Contract, state, &timer, &result);
+                return result;
             }
             ExecutionMode::Contract(runtime.unwrap())
         };
+        let mode = runtime_mode_label(&exec_mode);
 
         // Execute program
         let result = exec_mode.execute();
@@ -372,7 +380,10 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
 
         let runtime_result =
             self.handle_execution_result(result, fuel_consumed, exec_mode.context_mut());
-        self.try_remember_runtime(runtime_result, exec_mode)
+        let result = self.try_remember_runtime(runtime_result, exec_mode);
+        metrics::record_execution(mode, state, &timer, &result);
+        metrics::set_recoverable_runtimes(self.recoverable_runtimes.len());
+        result
     }
 
     fn resume(
@@ -384,12 +395,15 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         fuel_refunded: i64,
         exit_code: i32,
     ) -> ExecutionResult {
+        let timer = RuntimeTimer::start();
         let Some(mut runtime) = self.recoverable_runtimes.remove(&call_id) else {
             unreachable!(
                 "runtime: missing recoverable runtime for resume, this should never happen: call_id={}, fuel_consumed={}, exit_code={}",
                 call_id, fuel_consumed, exit_code
             )
         };
+        metrics::set_recoverable_runtimes(self.recoverable_runtimes.len());
+        let (mode, state) = runtime_labels(&runtime);
         let mut fuel_remaining = runtime.remaining_fuel();
         let resume_inner = |runtime: &mut ExecutionMode| {
             // Copy return data into return data
@@ -413,11 +427,18 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
             .and_then(|remaining_fuel| Some(fuel_remaining? - remaining_fuel));
         let runtime_result =
             self.handle_execution_result(result, fuel_consumed, runtime.context_mut());
-        self.try_remember_runtime(runtime_result, runtime)
+        let result = self.try_remember_runtime(runtime_result, runtime);
+        metrics::record_resume(mode, state, &timer, &result);
+        metrics::set_recoverable_runtimes(self.recoverable_runtimes.len());
+        result
     }
 
     fn forget_runtime(&mut self, call_id: u32) {
-        _ = self.recoverable_runtimes.remove(&call_id);
+        if let Some(runtime) = self.recoverable_runtimes.remove(&call_id) {
+            let (mode, state) = runtime_labels(&runtime);
+            metrics::record_forget_runtime(mode, state);
+        }
+        metrics::set_recoverable_runtimes(self.recoverable_runtimes.len());
     }
 
     fn warmup(&mut self, bytecode: RwasmModule, hash: B256, address: Address) {
@@ -434,6 +455,7 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         self.transaction_call_id_counter = 1;
         // Clear recoverable runtimes, because they are no longer valid
         self.recoverable_runtimes.clear();
+        metrics::set_recoverable_runtimes(0);
     }
 
     fn memory_read(
@@ -447,6 +469,20 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         );
         runtime_ref.memory_read(offset, buffer)
     }
+}
+
+fn runtime_mode_label(runtime: &ExecutionMode) -> RuntimeModeLabel {
+    match runtime {
+        ExecutionMode::Contract(_) => RuntimeModeLabel::Contract,
+        ExecutionMode::System(_) => RuntimeModeLabel::System,
+    }
+}
+
+fn runtime_labels(runtime: &ExecutionMode) -> (RuntimeModeLabel, &'static str) {
+    (
+        runtime_mode_label(runtime),
+        metrics::state_label(runtime.context().state),
+    )
 }
 
 #[cfg(test)]

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -9,6 +9,7 @@ mod context;
 mod context_wrapper;
 mod crypto;
 mod executor;
+mod metrics;
 mod module_factory;
 pub mod runtime;
 pub mod syscall_handler;

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -1,0 +1,199 @@
+//! Prometheus metrics emitted by the runtime executor.
+//!
+//! The node installs the Prometheus recorder via `reth-node-metrics`; this crate only records
+//! low-cardinality runtime observations into that global recorder.
+#![cfg_attr(not(feature = "std"), allow(unused_variables))]
+
+use crate::executor::ExecutionResult;
+use fluentbase_types::{ExitCode, STATE_DEPLOY, STATE_MAIN};
+use rwasm::TrapCode;
+
+#[cfg(feature = "std")]
+use std::time::Instant;
+
+/// Low-cardinality runtime mode label.
+#[derive(Clone, Copy, Debug)]
+pub enum RuntimeModeLabel {
+    Contract,
+    System,
+}
+
+impl RuntimeModeLabel {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Contract => "contract",
+            Self::System => "system",
+        }
+    }
+}
+
+/// Runtime entrypoint/state label.
+pub fn state_label(state: u32) -> &'static str {
+    match state {
+        STATE_MAIN => "main",
+        STATE_DEPLOY => "deploy",
+        _ => "unknown",
+    }
+}
+
+/// Execution timer. In non-std builds metrics are no-ops.
+#[derive(Debug)]
+pub struct RuntimeTimer {
+    #[cfg(feature = "std")]
+    started_at: Instant,
+}
+
+impl RuntimeTimer {
+    pub fn start() -> Self {
+        Self {
+            #[cfg(feature = "std")]
+            started_at: Instant::now(),
+        }
+    }
+
+    #[cfg(feature = "std")]
+    fn elapsed_seconds(&self) -> f64 {
+        self.started_at.elapsed().as_secs_f64()
+    }
+}
+
+/// Records an execution that failed before the runtime could be constructed.
+pub fn record_initialization_error(mode: RuntimeModeLabel, state: &'static str, trap: TrapCode) {
+    #[cfg(feature = "std")]
+    {
+        metrics::counter!(
+            "fluentbase_runtime_initialization_errors_total",
+            "mode" => mode.as_str(),
+            "state" => state,
+            "trap" => trap_label(trap),
+        )
+        .increment(1);
+    }
+}
+
+/// Records one fresh runtime execution.
+pub fn record_execution(
+    mode: RuntimeModeLabel,
+    state: &'static str,
+    timer: &RuntimeTimer,
+    result: &ExecutionResult,
+) {
+    let outcome = result_outcome(result);
+    #[cfg(feature = "std")]
+    {
+        record_common("execution", mode, state, outcome, timer, result);
+        metrics::counter!(
+            "fluentbase_runtime_executions_total",
+            "mode" => mode.as_str(),
+            "state" => state,
+            "outcome" => outcome,
+        )
+        .increment(1);
+        if outcome == "interrupted" {
+            metrics::counter!(
+                "fluentbase_runtime_interruptions_total",
+                "mode" => mode.as_str(),
+                "state" => state,
+            )
+            .increment(1);
+        }
+    }
+}
+
+/// Records one resume attempt.
+pub fn record_resume(
+    mode: RuntimeModeLabel,
+    state: &'static str,
+    timer: &RuntimeTimer,
+    result: &ExecutionResult,
+) {
+    let outcome = result_outcome(result);
+    #[cfg(feature = "std")]
+    {
+        record_common("resume", mode, state, outcome, timer, result);
+        metrics::counter!(
+            "fluentbase_runtime_resumes_total",
+            "mode" => mode.as_str(),
+            "state" => state,
+            "outcome" => outcome,
+        )
+        .increment(1);
+        if outcome == "interrupted" {
+            metrics::counter!(
+                "fluentbase_runtime_interruptions_total",
+                "mode" => mode.as_str(),
+                "state" => state,
+            )
+            .increment(1);
+        }
+    }
+}
+
+/// Records that a suspended runtime was explicitly dropped.
+pub fn record_forget_runtime(mode: RuntimeModeLabel, state: &'static str) {
+    #[cfg(feature = "std")]
+    metrics::counter!(
+        "fluentbase_runtime_forgotten_total",
+        "mode" => mode.as_str(),
+        "state" => state,
+    )
+    .increment(1);
+}
+
+/// Publishes the current number of suspended runtimes held by the executor.
+pub fn set_recoverable_runtimes(count: usize) {
+    #[cfg(feature = "std")]
+    metrics::gauge!("fluentbase_runtime_recoverable_runtimes").set(count as f64);
+}
+
+#[cfg(feature = "std")]
+fn record_common(
+    operation: &'static str,
+    mode: RuntimeModeLabel,
+    state: &'static str,
+    outcome: &'static str,
+    timer: &RuntimeTimer,
+    result: &ExecutionResult,
+) {
+    let labels = [
+        ("operation", operation),
+        ("mode", mode.as_str()),
+        ("state", state),
+        ("outcome", outcome),
+    ];
+    metrics::histogram!("fluentbase_runtime_execution_seconds", &labels)
+        .record(timer.elapsed_seconds());
+    metrics::histogram!("fluentbase_runtime_fuel_consumed", &labels)
+        .record(result.fuel_consumed as f64);
+    metrics::histogram!("fluentbase_runtime_fuel_refunded", &labels)
+        .record(result.fuel_refunded.max(0) as f64);
+    metrics::histogram!("fluentbase_runtime_output_bytes", &labels)
+        .record(result.output.len() as f64);
+    metrics::histogram!("fluentbase_runtime_return_data_bytes", &labels)
+        .record(result.return_data.len() as f64);
+}
+
+fn result_outcome(result: &ExecutionResult) -> &'static str {
+    if result.exit_code > 0 {
+        "interrupted"
+    } else if result.exit_code == ExitCode::Ok.into_i32() {
+        "success"
+    } else if result.exit_code == ExitCode::OutOfFuel.into_i32() {
+        "out_of_fuel"
+    } else if result.exit_code == ExitCode::UnexpectedFatalExecutionFailure.into_i32() {
+        "fatal"
+    } else {
+        "reverted"
+    }
+}
+
+fn trap_label(trap: TrapCode) -> &'static str {
+    match trap {
+        TrapCode::OutOfFuel => "out_of_fuel",
+        TrapCode::InterruptionCalled => "interruption_called",
+        TrapCode::MemoryOutOfBounds => "memory_out_of_bounds",
+        TrapCode::StackOverflow => "stack_overflow",
+        TrapCode::UnreachableCodeReached => "unreachable_code_reached",
+        _ => "other",
+    }
+}

--- a/crates/runtime/src/syscall_handler/tower/tower_fp1_add_sub_mul.rs
+++ b/crates/runtime/src/syscall_handler/tower/tower_fp1_add_sub_mul.rs
@@ -81,11 +81,8 @@ pub(crate) fn syscall_tower_fp1_add_sub_mul_handler<
     let mut y = [0u8; NUM_BYTES];
     ctx.memory_read(y_ptr as usize, &mut y)?;
 
-    let result = syscall_tower_fp1_add_sub_mul_impl::<NUM_BYTES, P, FIELD_OP>(
-        x,
-        y,
-    )
-    .map_err(|exit_code| syscall_process_exit_code(ctx, exit_code))?;
+    let result = syscall_tower_fp1_add_sub_mul_impl::<NUM_BYTES, P, FIELD_OP>(x, y)
+        .map_err(|exit_code| syscall_process_exit_code(ctx, exit_code))?;
 
     ctx.memory_write(x_ptr as usize, &result)?;
     Ok(())

--- a/crates/runtime/src/syscall_handler/tower/tower_fp2_add_sub_mul.rs
+++ b/crates/runtime/src/syscall_handler/tower/tower_fp2_add_sub_mul.rs
@@ -85,13 +85,9 @@ pub(crate) fn syscall_tower_fp2_add_sub_mul_handler<
     ctx.memory_read(y_ptr as usize, &mut bc0)?;
     ctx.memory_read(y_ptr as usize + NUM_BYTES, &mut bc1)?;
 
-    let (res0, res1) = syscall_tower_fp2_add_sub_mul_impl::<NUM_BYTES, P, FIELD_OP>(
-        ac0,
-        ac1,
-        bc0,
-        bc1,
-    )
-    .map_err(|exit_code| syscall_process_exit_code(ctx, exit_code))?;
+    let (res0, res1) =
+        syscall_tower_fp2_add_sub_mul_impl::<NUM_BYTES, P, FIELD_OP>(ac0, ac1, bc0, bc1)
+            .map_err(|exit_code| syscall_process_exit_code(ctx, exit_code))?;
 
     ctx.memory_write(x_ptr as usize, &res0)?;
     ctx.memory_write(x_ptr as usize + NUM_BYTES, &res1)?;

--- a/evm-e2e/Cargo.lock
+++ b/evm-e2e/Cargo.lock
@@ -2082,6 +2082,7 @@ dependencies = [
  "bytemuck",
  "fluentbase-types",
  "k256",
+ "metrics",
  "num",
  "p256",
  "rwasm",
@@ -2850,6 +2851,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
  "rustix",
+]
+
+[[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
 ]
 
 [[package]]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -1996,6 +1996,7 @@ dependencies = [
  "bytemuck",
  "fluentbase-types",
  "k256",
+ "metrics",
  "num",
  "p256",
  "rwasm",
@@ -2838,6 +2839,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,6 +3400,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postcard"


### PR DESCRIPTION
## Summary
- add low-cardinality Prometheus metrics for runtime executions and resumes
- record execution duration, outcome, fuel consumed/refunded, output sizes, interruptions, initialization failures, and active recoverable runtimes
- wire metrics through the existing global metrics recorder used by the node

## Verification
- cargo fmt --package fluentbase-runtime -- --check
- cargo check -p fluentbase-runtime --features std,wasmtime
- cargo test -p fluentbase-runtime --features std,wasmtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime execution metrics instrumentation to track execution duration, fuel consumption, output sizes, and interruption events.

* **Chores**
  * Updated workspace dependencies to support metrics collection in std builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->