### PR TITLE
fix(revm): inspect storage writes before mutation

### DIFF
--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -1,5 +1,5 @@
 use crate::RwasmFrame;
-use core::mem::take;
+use core::mem::{replace, take};
 use fluentbase_sdk::U256;
 use revm::{
     bytecode::Bytecode,
@@ -7,6 +7,52 @@ use revm::{
     interpreter::{interpreter::ExtBytecode, Stack},
     Inspector,
 };
+
+pub(crate) struct SyscallInspectionState {
+    prev_bytecode: ExtBytecode,
+    prev_stack: Stack,
+}
+
+pub(crate) fn inspect_syscall_start<
+    CTX: ContextTr,
+    INSP: Inspector<CTX>,
+    IN: IntoIterator<Item = U256>,
+>(
+    frame: &mut RwasmFrame,
+    ctx: &mut CTX,
+    inspector: &mut INSP,
+    evm_opcode: u8,
+    input: IN,
+) -> SyscallInspectionState
+where
+    <IN as IntoIterator>::IntoIter: DoubleEndedIterator,
+{
+    let prev_bytecode = take(&mut frame.interpreter.bytecode);
+    let prev_stack = replace(&mut frame.interpreter.stack, Stack::new());
+
+    let bytecode = Bytecode::new_raw([evm_opcode].into());
+    frame.interpreter.bytecode = ExtBytecode::new(bytecode);
+    for x in input.into_iter().rev() {
+        _ = frame.interpreter.stack.push(x);
+    }
+    inspector.step(&mut frame.interpreter, ctx);
+
+    SyscallInspectionState {
+        prev_bytecode,
+        prev_stack,
+    }
+}
+
+pub(crate) fn inspect_syscall_end<CTX: ContextTr, INSP: Inspector<CTX>>(
+    frame: &mut RwasmFrame,
+    ctx: &mut CTX,
+    inspector: &mut INSP,
+    state: SyscallInspectionState,
+) {
+    inspector.step_end(&mut frame.interpreter, ctx);
+    frame.interpreter.bytecode = state.prev_bytecode;
+    frame.interpreter.stack = state.prev_stack;
+}
 
 pub(crate) fn inspect_syscall<CTX: ContextTr, INSP: Inspector<CTX>, IN: IntoIterator<Item = U256>>(
     frame: &mut RwasmFrame,
@@ -17,18 +63,6 @@ pub(crate) fn inspect_syscall<CTX: ContextTr, INSP: Inspector<CTX>, IN: IntoIter
 ) where
     <IN as IntoIterator>::IntoIter: DoubleEndedIterator,
 {
-    // Save previous bytecode (we return it after)
-    let prev_bytecode = take(&mut frame.interpreter.bytecode);
-    // Execute inspector steps with modified bytecode and stack
-    let bytecode = Bytecode::new_raw([evm_opcode].into());
-    frame.interpreter.bytecode = ExtBytecode::new(bytecode);
-    frame.interpreter.stack = Stack::new();
-    for x in input.into_iter().rev() {
-        _ = frame.interpreter.stack.push(x);
-    }
-    inspector.step(&mut frame.interpreter, ctx);
-    // TODO: We should call `step_end` once instruction is over for proper gas & output stack calculation.
-    inspector.step_end(&mut frame.interpreter, ctx);
-    // Return original bytecode back
-    frame.interpreter.bytecode = prev_bytecode;
+    let state = inspect_syscall_start(frame, ctx, inspector, evm_opcode, input);
+    inspect_syscall_end(frame, ctx, inspector, state);
 }

--- a/crates/revm/src/inspector.rs
+++ b/crates/revm/src/inspector.rs
@@ -54,6 +54,17 @@ pub(crate) fn inspect_syscall_end<CTX: ContextTr, INSP: Inspector<CTX>>(
     frame.interpreter.stack = state.prev_stack;
 }
 
+pub(crate) fn inspect_syscall_end_if_started<CTX: ContextTr, INSP: Inspector<CTX>>(
+    frame: &mut RwasmFrame,
+    ctx: &mut CTX,
+    inspector: Option<&mut INSP>,
+    state: &mut Option<SyscallInspectionState>,
+) {
+    if let (Some(inspector), Some(state)) = (inspector, state.take()) {
+        inspect_syscall_end(frame, ctx, inspector, state);
+    }
+}
+
 pub(crate) fn inspect_syscall<CTX: ContextTr, INSP: Inspector<CTX>, IN: IntoIterator<Item = U256>>(
     frame: &mut RwasmFrame,
     ctx: &mut CTX,

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -334,9 +334,7 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             let input = get_input_validated!(== 64);
             let slot = U256::from_le_slice(&input[0..32]);
             let new_value = U256::from_le_slice(&input[32..64]);
-            let skip_cold =
-                frame.interpreter.gas.remaining() < ctx.cfg().gas_params().cold_storage_cost();
-            let inspection_state = inspector.as_mut().map(|inspector| {
+            let mut inspection_state = inspector.as_mut().map(|inspector| {
                 crate::inspector::inspect_syscall_start(
                     frame,
                     ctx,
@@ -345,6 +343,34 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                     [slot, new_value],
                 )
             });
+
+            macro_rules! finish_inspection {
+                () => {{
+                    crate::inspector::inspect_syscall_end_if_started(
+                        frame,
+                        ctx,
+                        inspector.as_mut().map(|inspector| &mut **inspector),
+                        &mut inspection_state,
+                    );
+                }};
+            }
+
+            if frame.interpreter.gas.remaining() <= ctx.cfg().gas_params().call_stipend() {
+                finish_inspection!();
+                return_halt!(OutOfFuel);
+            }
+
+            if !frame
+                .interpreter
+                .gas
+                .record_cost(ctx.cfg().gas_params().sstore_static_gas())
+            {
+                finish_inspection!();
+                return_halt!(OutOfFuel);
+            }
+
+            let skip_cold =
+                frame.interpreter.gas.remaining() < ctx.cfg().gas_params().cold_storage_cost();
             let result = ctx.journal_mut().sstore_skip_cold_load(
                 current_target_address,
                 slot,
@@ -354,40 +380,25 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             let state_load = match result {
                 Ok(v) => v,
                 Err(e) => {
-                    if let (Some(inspector), Some(inspection_state)) =
-                        (inspector.as_mut(), inspection_state)
-                    {
-                        crate::inspector::inspect_syscall_end(
-                            frame,
-                            ctx,
-                            inspector,
-                            inspection_state,
-                        );
-                    }
+                    finish_inspection!();
                     match e {
                         JournalLoadError::ColdLoadSkipped => return_halt!(OutOfFuel),
                         JournalLoadError::DBError(e) => return Err(ContextError::Db(e)),
                     }
                 }
             };
-            if let (Some(inspector), Some(inspection_state)) =
-                (inspector.as_mut(), inspection_state)
-            {
-                crate::inspector::inspect_syscall_end(frame, ctx, inspector, inspection_state);
-            }
-            assert_halt!(
-                frame.interpreter.gas.remaining() > ctx.cfg().gas_params().call_stipend(),
-                OutOfFuel
+            let gas_cost = ctx.cfg().gas_params().sstore_dynamic_gas(
+                true,
+                &state_load.data,
+                state_load.is_cold,
             );
-            let gas_cost = ctx.cfg().gas_params().sstore_static_gas()
-                + ctx.cfg().gas_params().sstore_dynamic_gas(
-                    true,
-                    &state_load.data,
-                    state_load.is_cold,
-                );
-            charge_gas!(gas_cost);
+            if !frame.interpreter.gas.record_cost(gas_cost) {
+                finish_inspection!();
+                return_halt!(OutOfFuel);
+            }
             let gas_refund = ctx.cfg().gas_params().sstore_refund(true, &state_load.data);
             frame.interpreter.gas.record_refund(gas_refund);
+            finish_inspection!();
             return_result!(Ok)
         }
 

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -18,8 +18,8 @@ use fluentbase_sdk::{
     byteorder::{ByteOrder, LittleEndian, ReadBytesExt},
     bytes::Buf,
     calc_create_metadata_address, is_execute_using_system_runtime, Address, Bytes, ExitCode, Log,
-    LogData, B256, EXT_CODE_COPY_MAX_COPY_SIZE, FUEL_DENOM_RATE,
-    KECCAK_EMPTY, PRECOMPILE_EVM_RUNTIME, PRECOMPILE_RUNTIME_UPGRADE, STATE_MAIN, U256,
+    LogData, B256, EXT_CODE_COPY_MAX_COPY_SIZE, FUEL_DENOM_RATE, KECCAK_EMPTY,
+    PRECOMPILE_EVM_RUNTIME, PRECOMPILE_RUNTIME_UPGRADE, STATE_MAIN, U256,
 };
 use revm::{
     bytecode::{opcode, ownable_account::OwnableAccountBytecode, rwasm::RwasmBytecode, Bytecode},
@@ -336,13 +336,45 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             let new_value = U256::from_le_slice(&input[32..64]);
             let skip_cold =
                 frame.interpreter.gas.remaining() < ctx.cfg().gas_params().cold_storage_cost();
+            let inspection_state = inspector.as_mut().map(|inspector| {
+                crate::inspector::inspect_syscall_start(
+                    frame,
+                    ctx,
+                    inspector,
+                    opcode::SSTORE,
+                    [slot, new_value],
+                )
+            });
             let result = ctx.journal_mut().sstore_skip_cold_load(
                 current_target_address,
                 slot,
                 new_value,
                 skip_cold,
             );
-            let state_load = unwrap_journal_load_error!(result);
+            let state_load = match result {
+                Ok(v) => v,
+                Err(e) => {
+                    if let (Some(inspector), Some(inspection_state)) =
+                        (inspector.as_mut(), inspection_state)
+                    {
+                        crate::inspector::inspect_syscall_end(
+                            frame,
+                            ctx,
+                            inspector,
+                            inspection_state,
+                        );
+                    }
+                    match e {
+                        JournalLoadError::ColdLoadSkipped => return_halt!(OutOfFuel),
+                        JournalLoadError::DBError(e) => return Err(ContextError::Db(e)),
+                    }
+                }
+            };
+            if let (Some(inspector), Some(inspection_state)) =
+                (inspector.as_mut(), inspection_state)
+            {
+                crate::inspector::inspect_syscall_end(frame, ctx, inspector, inspection_state);
+            }
             assert_halt!(
                 frame.interpreter.gas.remaining() > ctx.cfg().gas_params().call_stipend(),
                 OutOfFuel
@@ -356,7 +388,6 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             charge_gas!(gas_cost);
             let gas_refund = ctx.cfg().gas_params().sstore_refund(true, &state_load.data);
             frame.interpreter.gas.record_refund(gas_refund);
-            inspect!(opcode::SSTORE, [slot, new_value], []);
             return_result!(Ok)
         }
 

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -687,6 +687,7 @@ mod storage_inspector_tests {
     use super::*;
     use revm::{
         bytecode::opcode,
+        context::JournalEntry,
         interpreter::{interpreter_types::Jumps, Interpreter},
         state::{Account, EvmStorageSlot},
         Inspector,
@@ -724,6 +725,20 @@ mod storage_inspector_tests {
                 return;
             }
             self.step_end_value = self.read_cached_present_value(context);
+            let Some(JournalEntry::StorageChanged {
+                address,
+                key,
+                had_value,
+            }) = context.journal_ref().inner.journal.last()
+            else {
+                panic!("SSTORE step_end must see the storage journal entry");
+            };
+            let present_value =
+                context.journal_ref().inner.state[address].storage[key].present_value();
+            assert_eq!(*address, self.target);
+            assert_eq!(*key, self.slot);
+            assert_eq!(Some(*had_value), self.step_value);
+            assert_eq!(Some(present_value), self.step_end_value);
         }
     }
 

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -11,7 +11,7 @@ use fluentbase_sdk::{
     calc_create_metadata_address,
     syscall::{
         SYSCALL_ID_BLOCK_HASH, SYSCALL_ID_CODE_COPY, SYSCALL_ID_METADATA_COPY,
-        SYSCALL_ID_METADATA_CREATE, SYSCALL_ID_METADATA_WRITE,
+        SYSCALL_ID_METADATA_CREATE, SYSCALL_ID_METADATA_WRITE, SYSCALL_ID_STORAGE_WRITE,
     },
     Address, Bytes, SyscallInvocationParams, PRECOMPILE_WASM_RUNTIME, STATE_MAIN, U256,
 };
@@ -679,5 +679,119 @@ mod block_hash_tests {
                 .unwrap(),
             InstructionResult::StateChangeDuringStaticCall
         );
+    }
+}
+
+#[cfg(test)]
+mod storage_inspector_tests {
+    use super::*;
+    use revm::{
+        bytecode::opcode,
+        interpreter::{interpreter_types::Jumps, Interpreter},
+        state::{Account, EvmStorageSlot},
+        Inspector,
+    };
+
+    struct StorageWriteInspector {
+        target: Address,
+        slot: U256,
+        step_value: Option<U256>,
+        step_end_value: Option<U256>,
+    }
+
+    impl StorageWriteInspector {
+        fn read_cached_present_value(&self, context: &RwasmContext<InMemoryDB>) -> Option<U256> {
+            context
+                .journaled_state
+                .inner
+                .state
+                .get(&self.target)
+                .and_then(|account| account.storage.get(&self.slot))
+                .map(|slot| slot.present_value)
+        }
+    }
+
+    impl Inspector<RwasmContext<InMemoryDB>> for StorageWriteInspector {
+        fn step(&mut self, interp: &mut Interpreter, context: &mut RwasmContext<InMemoryDB>) {
+            if interp.bytecode.opcode() != opcode::SSTORE {
+                return;
+            }
+            self.step_value = self.read_cached_present_value(context);
+        }
+
+        fn step_end(&mut self, interp: &mut Interpreter, context: &mut RwasmContext<InMemoryDB>) {
+            if interp.bytecode.opcode() != opcode::SSTORE {
+                return;
+            }
+            self.step_end_value = self.read_cached_present_value(context);
+        }
+    }
+
+    #[test]
+    fn storage_write_syscall_inspector_sees_non_zero_prestate_before_zeroing_slot() {
+        let target = address!("1111111111111111111111111111111111111111");
+        let slot = U256::from(7);
+        let old_value = U256::from(0xbeefu64);
+        let new_value = U256::ZERO;
+
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(target, AccountInfo::default());
+        db.insert_account_storage(target, slot, old_value).unwrap();
+
+        let mut ctx: RwasmContext<InMemoryDB> = RwasmContext::new(db, RwasmSpecId::PRAGUE);
+        ctx.cfg = CfgEnv::new_with_spec(RwasmSpecId::PRAGUE);
+        ctx.block = BlockEnv::default();
+        ctx.tx = TxEnv::default();
+        let transaction_id = ctx.journaled_state.inner.transaction_id;
+        let mut account = Account {
+            info: AccountInfo::default(),
+            original_info: Box::<AccountInfo>::default(),
+            transaction_id,
+            storage: Default::default(),
+            status: Default::default(),
+        };
+        account
+            .storage
+            .insert(slot, EvmStorageSlot::new(old_value, transaction_id));
+        ctx.journaled_state.inner.state.insert(target, account);
+
+        let mut frame = RwasmFrame::default();
+        frame.interpreter.input.target_address = target;
+        frame.interpreter.gas = Gas::new(10_000_000);
+
+        let mut syscall_input = vec![0u8; 64];
+        syscall_input[0..32].copy_from_slice(&slot.to_le_bytes::<32>());
+        syscall_input[32..64].copy_from_slice(&new_value.to_le_bytes::<32>());
+        let mr = ForwardInputMemoryReader(syscall_input.into());
+
+        let interruption_inputs = SystemInterruptionInputs {
+            call_id: 0,
+            syscall_params: SyscallInvocationParams {
+                code_hash: SYSCALL_ID_STORAGE_WRITE,
+                input: 0..mr.0.len(),
+                state: STATE_MAIN,
+                ..Default::default()
+            },
+            gas: Gas::new(10_000_000),
+            preloaded_slot_costs: None,
+        };
+
+        let mut inspector = StorageWriteInspector {
+            target,
+            slot,
+            step_value: None,
+            step_end_value: None,
+        };
+        execute_rwasm_interruption(
+            &mut frame,
+            Some(&mut inspector),
+            &mut ctx,
+            interruption_inputs,
+            mr,
+        )
+        .unwrap();
+
+        assert_eq!(inspector.step_value, Some(old_value));
+        assert_eq!(inspector.step_end_value, Some(new_value));
     }
 }


### PR DESCRIPTION
## Summary
- preserve the normal inspector boundary for `SYSCALL_ID_STORAGE_WRITE` by starting synthetic `SSTORE` inspection before the storage mutation and ending it after mutation, dynamic gas, and refund handling
- add a shared helper for safely closing optional syscall inspection state
- add regression coverage for non-zero -> zero storage rewrites, including the `StorageChanged` journal entry visible at `step_end`

## Root cause
The syscall path did not fully bracket the real `sstore_skip_cold_load(...)` operation with inspector callbacks. Tracing-style inspectors could miss zeroing writes because the synthetic `SSTORE` event did not expose the journal mutation at the expected instruction boundary.

## Validation
- `cargo test -p fluentbase-revm`