### PR TITLE
test: unify e2e tx builder API

### DIFF
--- a/crates/testing/README.md
+++ b/crates/testing/README.md
@@ -8,4 +8,34 @@ binary during tests.
 The EVM test harness is powered by a forked `revm` and can run Solidity contracts
 or EVM compatibility precompiles directly.
 
+## EVM transaction tests
+
+Prefer `TxBuilder` for new EVM-style tests. It keeps transaction setup in one
+place and returns assertion helpers that make expected outcomes explicit:
+
+```rust
+let tx = TxBuilder::call(&mut ctx, callee)
+    .caller(caller)
+    .input(calldata)
+    .gas_limit(3_000_000)
+    .execute();
+
+tx.expect_ok().expect_gas_used(21_000);
+
+let deploy = TxBuilder::create(&mut ctx, deployer, init_code).execute();
+let contract = deploy.expect_ok().expect_expected_created_address().created_address();
+
+let failure = TxBuilder::call(&mut ctx, callee)
+    .caller(caller)
+    .gas_limit(100_000)
+    .execute();
+failure
+    .expect_halt()
+    .expect_reason(HaltReason::OutOfGas)
+    .expect_gas_used(100_000);
+```
+
+Existing helpers that return raw `ExecutionResult` can use `TxResultExt` for the
+same `expect_*` assertion style.
+
 This crate is part of the [Fluentbase](https://github.com/fluentlabs-xyz/fluentbase) project.

--- a/crates/testing/src/evm.rs
+++ b/crates/testing/src/evm.rs
@@ -324,7 +324,10 @@ impl EvmTestingContext {
         gas_limit: Option<u64>,
         value: Option<U256>,
     ) -> ExecutionResult<RwasmHaltReason> {
-        let mut tx_builder = TxBuilder::call(self, caller, callee, value).input(input);
+        let mut tx_builder = TxBuilder::call(self, callee).caller(caller).input(input);
+        if let Some(value) = value {
+            tx_builder = tx_builder.value(value);
+        }
         if let Some(gas_limit) = gas_limit {
             tx_builder = tx_builder.gas_limit(gas_limit);
         }
@@ -367,18 +370,9 @@ impl<'a> TxBuilder<'a> {
         Self { ctx, tx, block }
     }
 
-    pub fn call(
-        ctx: &'a mut EvmTestingContext,
-        caller: Address,
-        callee: Address,
-        value: Option<U256>,
-    ) -> Self {
+    pub fn call(ctx: &'a mut EvmTestingContext, callee: Address) -> Self {
         let mut tx = TxEnv::default();
-        if let Some(value) = value {
-            tx.value = value;
-        }
         tx.gas_price = 1;
-        tx.caller = caller;
         tx.kind = TransactTo::Call(callee);
         tx.gas_limit = 3_000_000;
         let block = Self::block_env(ctx);
@@ -418,6 +412,11 @@ impl<'a> TxBuilder<'a> {
 
     pub fn input(mut self, input: Bytes) -> Self {
         self.tx.data = input;
+        self
+    }
+
+    pub fn caller(mut self, caller: Address) -> Self {
+        self.tx.caller = caller;
         self
     }
 
@@ -471,6 +470,312 @@ impl<'a> TxBuilder<'a> {
             let new_db = &mut evm.0.journaled_state.database;
             self.ctx.db = take(new_db);
             result.map_haltreason(RwasmHaltReason::from)
+        }
+    }
+
+    pub fn execute(mut self) -> TxExecution {
+        let expected_created_address = match self.tx.kind {
+            TransactTo::Create => Some(calc_create_address(
+                &self.tx.caller,
+                self.ctx.nonce(self.tx.caller),
+            )),
+            TransactTo::Call(_) => None,
+        };
+        let result = self.exec();
+        let created_address = match &result {
+            Success {
+                output: Output::Create(_, address),
+                ..
+            } => *address,
+            _ => None,
+        };
+        TxExecution {
+            result,
+            expected_created_address,
+            created_address,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TxExecution {
+    result: ExecutionResult<RwasmHaltReason>,
+    expected_created_address: Option<Address>,
+    created_address: Option<Address>,
+}
+
+impl TxExecution {
+    pub fn result(&self) -> &ExecutionResult<RwasmHaltReason> {
+        &self.result
+    }
+
+    pub fn into_result(self) -> ExecutionResult<RwasmHaltReason> {
+        self.result
+    }
+
+    pub fn gas_used(&self) -> u64 {
+        self.result.gas_used()
+    }
+
+    pub fn output(&self) -> Option<&Bytes> {
+        self.result.output()
+    }
+
+    pub fn created_address(&self) -> Option<Address> {
+        self.created_address
+    }
+
+    pub fn expect_ok(&self) -> TxSuccess<'_> {
+        match &self.result {
+            Success { .. } => TxSuccess { tx: self },
+            _ => panic!("expected successful transaction, got: {:?}", self.result),
+        }
+    }
+
+    pub fn expect_halt(&self) -> TxHalt<'_> {
+        match &self.result {
+            ExecutionResult::Halt { .. } => TxHalt { tx: self },
+            _ => panic!("expected halted transaction, got: {:?}", self.result),
+        }
+    }
+
+    pub fn expect_revert(&self) -> TxRevert<'_> {
+        match &self.result {
+            ExecutionResult::Revert { .. } => TxRevert { tx: self },
+            _ => panic!("expected reverted transaction, got: {:?}", self.result),
+        }
+    }
+
+    pub fn expect_gas_used(&self, expected: u64) -> &Self {
+        assert_eq!(
+            self.result.gas_used(),
+            expected,
+            "unexpected transaction gas used: {:?}",
+            self.result
+        );
+        self
+    }
+}
+
+pub trait TxResultExt {
+    fn expect_ok(&self) -> TxResultSuccess<'_>;
+    fn expect_halt(&self) -> TxResultHalt<'_>;
+    fn expect_revert(&self) -> TxResultRevert<'_>;
+    fn expect_gas_used(&self, expected: u64) -> &Self;
+}
+
+impl TxResultExt for ExecutionResult<RwasmHaltReason> {
+    fn expect_ok(&self) -> TxResultSuccess<'_> {
+        match self {
+            Success { .. } => TxResultSuccess { result: self },
+            _ => panic!("expected successful transaction, got: {:?}", self),
+        }
+    }
+
+    fn expect_halt(&self) -> TxResultHalt<'_> {
+        match self {
+            ExecutionResult::Halt { .. } => TxResultHalt { result: self },
+            _ => panic!("expected halted transaction, got: {:?}", self),
+        }
+    }
+
+    fn expect_revert(&self) -> TxResultRevert<'_> {
+        match self {
+            ExecutionResult::Revert { .. } => TxResultRevert { result: self },
+            _ => panic!("expected reverted transaction, got: {:?}", self),
+        }
+    }
+
+    fn expect_gas_used(&self, expected: u64) -> &Self {
+        assert_eq!(
+            self.gas_used(),
+            expected,
+            "unexpected transaction gas used: {:?}",
+            self
+        );
+        self
+    }
+}
+
+pub struct TxResultSuccess<'a> {
+    result: &'a ExecutionResult<RwasmHaltReason>,
+}
+
+impl<'a> TxResultSuccess<'a> {
+    pub fn expect_gas_used(self, expected: u64) -> Self {
+        self.result.expect_gas_used(expected);
+        self
+    }
+
+    pub fn expect_output(self, expected: impl AsRef<[u8]>) -> Self {
+        let output = self.result.output().unwrap_or_default();
+        assert_eq!(
+            output.as_ref(),
+            expected.as_ref(),
+            "unexpected transaction output: {:?}",
+            self.result
+        );
+        self
+    }
+
+    pub fn output(&self) -> Option<&'a Bytes> {
+        self.result.output()
+    }
+}
+
+pub struct TxResultHalt<'a> {
+    result: &'a ExecutionResult<RwasmHaltReason>,
+}
+
+impl TxResultHalt<'_> {
+    pub fn expect_reason(self, expected: RwasmHaltReason) -> Self {
+        match self.result {
+            ExecutionResult::Halt { reason, .. } => assert_eq!(
+                *reason, expected,
+                "unexpected transaction halt reason: {:?}",
+                self.result
+            ),
+            _ => unreachable!(),
+        }
+        self
+    }
+
+    pub fn expect_gas_used(self, expected: u64) -> Self {
+        self.result.expect_gas_used(expected);
+        self
+    }
+}
+
+pub struct TxResultRevert<'a> {
+    result: &'a ExecutionResult<RwasmHaltReason>,
+}
+
+impl<'a> TxResultRevert<'a> {
+    pub fn expect_gas_used(self, expected: u64) -> Self {
+        self.result.expect_gas_used(expected);
+        self
+    }
+
+    pub fn expect_output(self, expected: impl AsRef<[u8]>) -> Self {
+        match self.result {
+            ExecutionResult::Revert { output, .. } => assert_eq!(
+                output.as_ref(),
+                expected.as_ref(),
+                "unexpected revert output: {:?}",
+                self.result
+            ),
+            _ => unreachable!(),
+        }
+        self
+    }
+
+    pub fn output(&self) -> &'a Bytes {
+        match self.result {
+            ExecutionResult::Revert { output, .. } => output,
+            _ => unreachable!(),
+        }
+    }
+}
+
+pub struct TxSuccess<'a> {
+    tx: &'a TxExecution,
+}
+
+impl<'a> TxSuccess<'a> {
+    pub fn expect_gas_used(self, expected: u64) -> Self {
+        self.tx.expect_gas_used(expected);
+        self
+    }
+
+    pub fn expect_output(self, expected: impl AsRef<[u8]>) -> Self {
+        let output = self.tx.result.output().unwrap_or_default();
+        assert_eq!(
+            output.as_ref(),
+            expected.as_ref(),
+            "unexpected transaction output: {:?}",
+            self.tx.result
+        );
+        self
+    }
+
+    pub fn expect_created_address(self, expected: Address) -> Self {
+        assert_eq!(
+            self.tx.created_address,
+            Some(expected),
+            "unexpected created address: {:?}",
+            self.tx.result
+        );
+        self
+    }
+
+    pub fn expect_expected_created_address(self) -> Self {
+        assert_eq!(
+            self.tx.created_address, self.tx.expected_created_address,
+            "created address did not match caller nonce prediction: {:?}",
+            self.tx.result
+        );
+        self
+    }
+
+    pub fn output(&self) -> Option<&'a Bytes> {
+        self.tx.output()
+    }
+
+    pub fn created_address(&self) -> Option<Address> {
+        self.tx.created_address()
+    }
+}
+
+pub struct TxHalt<'a> {
+    tx: &'a TxExecution,
+}
+
+impl TxHalt<'_> {
+    pub fn expect_reason(self, expected: RwasmHaltReason) -> Self {
+        match &self.tx.result {
+            ExecutionResult::Halt { reason, .. } => assert_eq!(
+                *reason, expected,
+                "unexpected transaction halt reason: {:?}",
+                self.tx.result
+            ),
+            _ => unreachable!(),
+        }
+        self
+    }
+
+    pub fn expect_gas_used(self, expected: u64) -> Self {
+        self.tx.expect_gas_used(expected);
+        self
+    }
+}
+
+pub struct TxRevert<'a> {
+    tx: &'a TxExecution,
+}
+
+impl<'a> TxRevert<'a> {
+    pub fn expect_gas_used(self, expected: u64) -> Self {
+        self.tx.expect_gas_used(expected);
+        self
+    }
+
+    pub fn expect_output(self, expected: impl AsRef<[u8]>) -> Self {
+        match &self.tx.result {
+            ExecutionResult::Revert { output, .. } => assert_eq!(
+                output.as_ref(),
+                expected.as_ref(),
+                "unexpected revert output: {:?}",
+                self.tx.result
+            ),
+            _ => unreachable!(),
+        }
+        self
+    }
+
+    pub fn output(&self) -> &'a Bytes {
+        match &self.tx.result {
+            ExecutionResult::Revert { output, .. } => output,
+            _ => unreachable!(),
         }
     }
 }

--- a/e2e/src/ddos.rs
+++ b/e2e/src/ddos.rs
@@ -68,7 +68,8 @@ fn call_with_len(
     len: u32,
 ) -> revm::context::result::ExecutionResult<fluentbase_revm::RwasmHaltReason> {
     let calldata = Bytes::from(len.to_le_bytes().to_vec());
-    TxBuilder::call(ctx, Address::ZERO, contract, None)
+    TxBuilder::call(ctx, contract)
+        .caller(Address::ZERO)
         .gas_price(0)
         .gas_limit(22_000)
         .input(calldata)

--- a/e2e/src/eip7702.rs
+++ b/e2e/src/eip7702.rs
@@ -94,7 +94,8 @@ fn test_evm_eip7702_call_delegated_account() {
         hex!("773acdef000000000000000000000000000000000000000000000000000000000000007b").to_vec(),
     );
 
-    let call_result = TxBuilder::call(&mut ctx, sender, sender, None)
+    let call_result = TxBuilder::call(&mut ctx, sender)
+        .caller(sender)
         .input(ping_input)
         .gas_limit(100_000)
         .exec();
@@ -115,7 +116,8 @@ fn test_evm_eip7702_call_delegated_account() {
 
     // 4. call sender.value() → should reflect storage written in sender's context
     // value() selector = 0x3fa4f245
-    let value_result = TxBuilder::call(&mut ctx, sender, sender, None)
+    let value_result = TxBuilder::call(&mut ctx, sender)
+        .caller(sender)
         .input(Bytes::from(hex!("3fa4f245").to_vec()))
         .gas_limit(100_000)
         .exec();
@@ -179,7 +181,8 @@ fn test_evm_eip7702_internal_call_delegated_account() {
     .abi_encode();
 
     // Call Caller.callExternal(authority, ping(0x7b)) — internal CALL to delegated account
-    let result = TxBuilder::call(&mut ctx, caller_eoa, caller_contract, None)
+    let result = TxBuilder::call(&mut ctx, caller_contract)
+        .caller(caller_eoa)
         .input(Bytes::from(call_input))
         .gas_limit(1_000_000)
         .exec();
@@ -233,7 +236,9 @@ fn test_evm_eip7702_state_override_like_estimate_gas_case() {
             .to_vec(),
     );
 
-    let result = TxBuilder::call(&mut ctx, deadbeef, deadbeef, Some(U256::ZERO))
+    let result = TxBuilder::call(&mut ctx, deadbeef)
+        .caller(deadbeef)
+        .value(U256::ZERO)
         .gas_limit(1_000_000)
         .input(input)
         .exec();

--- a/e2e/src/evm.rs
+++ b/e2e/src/evm.rs
@@ -20,7 +20,8 @@ fn test_evm_greeting() {
     // call greeting EVM contract
     println!("\n\n\n");
     ctx.add_balance(DEPLOYER_ADDRESS, U256::from(1e18));
-    let result = TxBuilder::call(&mut ctx, DEPLOYER_ADDRESS, contract_address, None)
+    let result = TxBuilder::call(&mut ctx, contract_address)
+        .caller(DEPLOYER_ADDRESS)
         .input(bytes!("45773e4e"))
         .exec();
     println!("{:?}", result);
@@ -106,7 +107,8 @@ fn test_evm_simple_send() {
     const RECIPIENT_ADDRESS: Address = address!("1092381297182319023812093812312309123132");
     ctx.add_balance(SENDER_ADDRESS, U256::from(2e18));
     let gas_price = 1e9 as u128;
-    let result = TxBuilder::call(&mut ctx, SENDER_ADDRESS, RECIPIENT_ADDRESS, None)
+    let result = TxBuilder::call(&mut ctx, RECIPIENT_ADDRESS)
+        .caller(SENDER_ADDRESS)
         .gas_price(gas_price)
         .value(U256::from(1e18))
         .exec();
@@ -194,7 +196,8 @@ fn test_evm_self_destruct() {
     assert_eq!(ctx.get_balance(SENDER_ADDRESS), U256::from(1e18));
     assert_eq!(ctx.get_balance(contract_address), U256::from(1e18));
     // call self-destructed contract
-    let result = TxBuilder::call(&mut ctx, SENDER_ADDRESS, contract_address, None)
+    let result = TxBuilder::call(&mut ctx, contract_address)
+        .caller(SENDER_ADDRESS)
         .gas_price(gas_price)
         .exec();
     if !result.is_success() {

--- a/e2e/src/exec_input.rs
+++ b/e2e/src/exec_input.rs
@@ -175,7 +175,8 @@ fn measure_call_gas(payload_size: usize) -> (u64, Duration) {
 
     // Execute and measure
     let start = Instant::now();
-    let call = TxBuilder::call(&mut ctx, deployer, caller, None)
+    let call = TxBuilder::call(&mut ctx, caller)
+        .caller(deployer)
         .gas_limit(500_000_000)
         .exec();
     let elapsed = start.elapsed();

--- a/e2e/src/fuel.rs
+++ b/e2e/src/fuel.rs
@@ -33,7 +33,8 @@ fn fuel_nitro_verifier_evm_ctx() {
 
     // Execute via EVM
     let start = Instant::now();
-    let result = TxBuilder::call(&mut ctx, caller, PRECOMPILE_NITRO_VERIFIER, None)
+    let result = TxBuilder::call(&mut ctx, PRECOMPILE_NITRO_VERIFIER)
+        .caller(caller)
         .input(Bytes::from(input))
         .gas_limit(100_000_000_000)
         .timestamp(1695050165) // ensure correct block timestamp to match certificate time window

--- a/e2e/src/gas.rs
+++ b/e2e/src/gas.rs
@@ -131,7 +131,8 @@ fn test_simple_nested_call() {
             ..Default::default()
         },
     );
-    let result = TxBuilder::call(&mut ctx, Address::ZERO, ACCOUNT3_ADDRESS, None)
+    let result = TxBuilder::call(&mut ctx, ACCOUNT3_ADDRESS)
+        .caller(Address::ZERO)
         .gas_price(0)
         .gas_limit(26219)
         .exec();
@@ -224,14 +225,10 @@ fn test_blended_gas_spend_wasm_from_evm() {
         _ => panic!("expected 'success'"),
     };
     println!("Contract address: {:?}", address);
-    let result = TxBuilder::call(
-        &mut ctx,
-        address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
-        address,
-        None,
-    )
-    .input(bytes!("65becaf3"))
-    .exec();
+    let result = TxBuilder::call(&mut ctx, address)
+        .caller(address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"))
+        .input(bytes!("65becaf3"))
+        .exec();
 
     assert!(result.is_success());
     println!("Result: {:?}", result);
@@ -313,14 +310,10 @@ fn test_blended_gas_spend_evm_from_wasm() {
             ..Default::default()
         },
     );
-    let result = TxBuilder::call(
-        &mut ctx,
-        address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"),
-        ACCOUNT3_ADDRESS,
-        None,
-    )
-    .gas_price(0)
-    .exec();
+    let result = TxBuilder::call(&mut ctx, ACCOUNT3_ADDRESS)
+        .caller(address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266"))
+        .gas_price(0)
+        .exec();
 
     println!("Result: {:?}", result);
     assert!(result.is_success());

--- a/e2e/src/nitro.rs
+++ b/e2e/src/nitro.rs
@@ -16,7 +16,8 @@ fn test_nitro_verifier_precompiled_version() {
     let start = Instant::now();
     let mut total_gas = 0;
     let attestation_doc: Vec<u8> = hex::decode(ATTESTATION_EXAMPLE).unwrap().into();
-    let result = TxBuilder::call(&mut ctx, caller, PRECOMPILE_NITRO_VERIFIER, None)
+    let result = TxBuilder::call(&mut ctx, PRECOMPILE_NITRO_VERIFIER)
+        .caller(caller)
         .input(attestation_doc.into())
         .gas_limit(1_000_000_000)
         .exec();
@@ -74,7 +75,8 @@ fn test_nitro_verifier_original_version() {
         attestation: attestation_bytes.into(),
     }
     .abi_encode();
-    let result = TxBuilder::call(&mut ctx, OWNER_ADDRESS, nitro_validator_address, None)
+    let result = TxBuilder::call(&mut ctx, nitro_validator_address)
+        .caller(OWNER_ADDRESS)
         .input(input.into())
         .exec();
     if !result.is_success() {
@@ -105,7 +107,8 @@ fn test_nitro_verifier_original_version() {
         signature: parsed_attestation.signature.into(),
     }
     .abi_encode();
-    let result = TxBuilder::call(&mut ctx, OWNER_ADDRESS, nitro_validator_address, None)
+    let result = TxBuilder::call(&mut ctx, nitro_validator_address)
+        .caller(OWNER_ADDRESS)
         .gas_limit(70_000_000)
         .input(input.into())
         .timestamp(1695050165) // ensure correct block timestamp to match certificate time window.
@@ -166,7 +169,8 @@ fn test_nitro_verifier_solidity_version() {
         attestation: attestation_bytes.into(),
     }
     .abi_encode();
-    let result = TxBuilder::call(&mut ctx, OWNER_ADDRESS, nitro_validator_address, None)
+    let result = TxBuilder::call(&mut ctx, nitro_validator_address)
+        .caller(OWNER_ADDRESS)
         .input(input.into())
         .exec();
     if !result.is_success() {
@@ -197,7 +201,8 @@ fn test_nitro_verifier_solidity_version() {
         signature: parsed_attestation.signature.into(),
     }
     .abi_encode();
-    let result = TxBuilder::call(&mut ctx, OWNER_ADDRESS, nitro_validator_address, None)
+    let result = TxBuilder::call(&mut ctx, nitro_validator_address)
+        .caller(OWNER_ADDRESS)
         .gas_limit(70_000_000)
         .input(input.into())
         .timestamp(1695050165) // ensure correct block timestamp to match certificate time window.

--- a/e2e/src/oauth2.rs
+++ b/e2e/src/oauth2.rs
@@ -1,7 +1,7 @@
 use crate::EvmTestingContextWithGenesis;
 use fluentbase_sdk::{Address, Bytes, PRECOMPILE_OAUTH2_VERIFIER};
-use fluentbase_testing::EvmTestingContext;
-use revm::context::result::{ExecutionResult, HaltReason};
+use fluentbase_testing::{EvmTestingContext, TxResultExt};
+use revm::context::result::HaltReason;
 
 #[test]
 fn test_oauth2_should_not_panic() {
@@ -14,11 +14,8 @@ fn test_oauth2_should_not_panic() {
         None,
         None,
     );
-    assert_eq!(
-        result,
-        ExecutionResult::Halt {
-            reason: HaltReason::UnreachableCodeReached,
-            gas_used: 3_000_000
-        }
-    );
+    result
+        .expect_halt()
+        .expect_reason(HaltReason::UnreachableCodeReached)
+        .expect_gas_used(3_000_000);
 }

--- a/e2e/src/oom.rs
+++ b/e2e/src/oom.rs
@@ -1,8 +1,8 @@
 use crate::EvmTestingContextWithGenesis;
 use fluentbase_contracts::FLUENTBASE_EXAMPLES_MEMORY_OOM;
-use fluentbase_sdk::{Address, Bytes, ExitCode::MalformedBuiltinParams};
+use fluentbase_sdk::{Address, Bytes, ExitCode::MalformedBuiltinParams, U256};
 use fluentbase_testing::{EvmTestingContext, TxBuilder};
-use revm::context::result::{ExecutionResult, HaltReason};
+use revm::context::result::HaltReason;
 
 #[test]
 fn test_oom_has_proper_exit_code() {
@@ -13,15 +13,15 @@ fn test_oom_has_proper_exit_code() {
         FLUENTBASE_EXAMPLES_MEMORY_OOM.wasm_bytecode,
     );
     const CALLER: Address = Address::with_last_byte(81);
-    // call greeting WASM contract
-    let result = ctx.call_evm_tx(CALLER, contract_address, Bytes::default(), None, None);
-    assert_eq!(
-        result,
-        ExecutionResult::Halt {
-            reason: HaltReason::MemoryOutOfBounds,
-            gas_used: 3_000_000
-        }
-    );
+    ctx.add_balance(CALLER, U256::from(1e18));
+
+    TxBuilder::call(&mut ctx, contract_address)
+        .caller(CALLER)
+        .input(Bytes::default())
+        .execute()
+        .expect_halt()
+        .expect_reason(HaltReason::MemoryOutOfBounds)
+        .expect_gas_used(3_000_000);
 }
 
 #[test]
@@ -45,12 +45,9 @@ fn test_negative_write_output_params_cant_cause_oom() {
     .unwrap()
     .into();
     let mut ctx = EvmTestingContext::default().with_full_genesis();
-    let result = TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module).exec();
-    assert_eq!(
-        result,
-        ExecutionResult::Halt {
-            reason: HaltReason::MemoryOutOfBounds,
-            gas_used: 100_000_000
-        }
-    )
+    TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module)
+        .execute()
+        .expect_halt()
+        .expect_reason(HaltReason::MemoryOutOfBounds)
+        .expect_gas_used(100_000_000);
 }

--- a/e2e/src/universal_token.rs
+++ b/e2e/src/universal_token.rs
@@ -50,7 +50,8 @@ fn call_with_sig_no_funding(
     caller: &Address,
     callee: &Address,
 ) -> Vec<u8> {
-    let mut tx = TxBuilder::call(ctx, *caller, *callee, None)
+    let mut tx = TxBuilder::call(ctx, *callee)
+        .caller(*caller)
         .input(input)
         .gas_price(0);
     let result = tx.exec();
@@ -66,7 +67,8 @@ fn call_with_sig_funding(
     callee: &Address,
     value: U256,
 ) -> Vec<u8> {
-    let mut tx = TxBuilder::call(ctx, *caller, *callee, None)
+    let mut tx = TxBuilder::call(ctx, *callee)
+        .caller(*caller)
         .input(input)
         .value(value)
         .gas_price(0);
@@ -82,7 +84,8 @@ fn call_with_sig_revert_no_funding(
     caller: &Address,
     callee: &Address,
 ) -> Bytes {
-    let mut tx = TxBuilder::call(ctx, *caller, *callee, None)
+    let mut tx = TxBuilder::call(ctx, *callee)
+        .caller(*caller)
         .input(input)
         .gas_price(0);
     let result = tx.exec();
@@ -690,7 +693,9 @@ fn wrapped_withdraw_transfers_native_and_updates_supply_consistently() {
     let user_before = ctx.get_balance(user);
     let token_before = ctx.get_balance(token);
 
-    let mut deposit_tx = TxBuilder::call(&mut ctx, user, token, Some(deposit))
+    let mut deposit_tx = TxBuilder::call(&mut ctx, token)
+        .caller(user)
+        .value(deposit)
         .input(bytes!("0xd0e30db0"))
         .gas_price(0);
     let deposit_result = deposit_tx.exec();
@@ -701,7 +706,8 @@ fn wrapped_withdraw_transfers_native_and_updates_supply_consistently() {
 
     let mut input = Vec::new();
     WithdrawCommand { amount: withdraw }.encode_for_send(&mut input);
-    let mut withdraw_tx = TxBuilder::call(&mut ctx, user, token, None)
+    let mut withdraw_tx = TxBuilder::call(&mut ctx, token)
+        .caller(user)
         .input(input.into())
         .gas_price(0);
     let withdraw_result = withdraw_tx.exec();
@@ -738,7 +744,9 @@ fn wrapped_withdraw_insufficient_balance_reverts_without_state_changes() {
     let withdraw = U256::from(9u64);
 
     ctx.add_balance(user, U256::from(100u64));
-    let mut deposit_tx = TxBuilder::call(&mut ctx, user, token, Some(deposit))
+    let mut deposit_tx = TxBuilder::call(&mut ctx, token)
+        .caller(user)
+        .value(deposit)
         .input(bytes!("0xd0e30db0"))
         .gas_price(0);
     assert!(deposit_tx.exec().is_success());
@@ -776,7 +784,9 @@ fn wrapped_withdraw_when_paused_reverts_without_state_changes() {
 
     let deposit = U256::from(11u64);
     ctx.add_balance(user, U256::from(100u64));
-    let mut deposit_tx = TxBuilder::call(&mut ctx, user, token, Some(deposit))
+    let mut deposit_tx = TxBuilder::call(&mut ctx, token)
+        .caller(user)
+        .value(deposit)
         .input(bytes!("0xd0e30db0"))
         .gas_price(0);
     assert!(deposit_tx.exec().is_success());
@@ -830,7 +840,8 @@ fn wrapped_withdraw_halts_on_native_balance_underflow_and_preserves_storage() {
         amount: U256::from(200),
     }
     .encode_for_send(&mut input);
-    let mut tx = TxBuilder::call(&mut ctx, user, token, None)
+    let mut tx = TxBuilder::call(&mut ctx, token)
+        .caller(user)
         .input(input.into())
         .gas_price(0);
     let result = tx.exec();

--- a/e2e/src/universal_token_solidity.rs
+++ b/e2e/src/universal_token_solidity.rs
@@ -277,7 +277,8 @@ fn test_deploy_factory_and_universal_token() {
     );
 
     // Step 5: Verify token was deployed by calling totalSupply()
-    let result = TxBuilder::call(&mut ctx, DEPLOYER, deployed_address, None)
+    let result = TxBuilder::call(&mut ctx, deployed_address)
+        .caller(DEPLOYER)
         .input(bytes!("18160ddd")) // totalSupply() selector
         .exec();
     assert!(
@@ -293,7 +294,8 @@ fn test_deploy_factory_and_universal_token() {
     );
 
     // Step 6: Verify token name
-    let result = TxBuilder::call(&mut ctx, DEPLOYER, deployed_address, None)
+    let result = TxBuilder::call(&mut ctx, deployed_address)
+        .caller(DEPLOYER)
         .input(bytes!("06fdde03")) // name() selector
         .exec();
     assert!(result.is_success(), "name() call failed: {:?}", result);
@@ -302,7 +304,8 @@ fn test_deploy_factory_and_universal_token() {
     assert_eq!(name, TOKEN_NAME, "Token name mismatch");
 
     // Step 7: Verify token symbol
-    let result = TxBuilder::call(&mut ctx, DEPLOYER, deployed_address, None)
+    let result = TxBuilder::call(&mut ctx, deployed_address)
+        .caller(DEPLOYER)
         .input(bytes!("95d89b41")) // symbol() selector
         .exec();
     assert!(result.is_success(), "symbol() call failed: {:?}", result);
@@ -311,7 +314,8 @@ fn test_deploy_factory_and_universal_token() {
     assert_eq!(symbol, TOKEN_SYMBOL, "Token symbol mismatch");
 
     // Step 8: Verify token decimals
-    let result = TxBuilder::call(&mut ctx, DEPLOYER, deployed_address, None)
+    let result = TxBuilder::call(&mut ctx, deployed_address)
+        .caller(DEPLOYER)
         .input(bytes!("313ce567")) // decimals() selector
         .exec();
     assert!(result.is_success(), "decimals() call failed: {:?}", result);
@@ -320,7 +324,8 @@ fn test_deploy_factory_and_universal_token() {
     assert_eq!(decimals, TOKEN_DECIMALS, "Token decimals mismatch");
 
     // Step 9: Verify token totalSupply
-    let result = TxBuilder::call(&mut ctx, DEPLOYER, deployed_address, None)
+    let result = TxBuilder::call(&mut ctx, deployed_address)
+        .caller(DEPLOYER)
         .input(bytes!("18160ddd")) // totalSupply() selector
         .exec();
     assert!(

--- a/e2e/src/wasm.rs
+++ b/e2e/src/wasm.rs
@@ -11,7 +11,7 @@ use fluentbase_contracts::{
 use fluentbase_sdk::{
     address, bytes, constructor::encode_constructor_params, Address, Bytes, U256,
 };
-use fluentbase_testing::{EvmTestingContext, TxBuilder};
+use fluentbase_testing::{EvmTestingContext, TxBuilder, TxResultExt};
 use hex_literal::hex;
 use revm::{
     bytecode::Bytecode,
@@ -442,13 +442,10 @@ fn test_wasm_cant_use_fatal_exit_code() {
         Some(1_000_000),
         None,
     );
-    assert_eq!(
-        result,
-        ExecutionResult::Halt {
-            reason: HaltReason::UnknownError,
-            gas_used: 1_000_000
-        }
-    );
+    result
+        .expect_halt()
+        .expect_reason(HaltReason::UnknownError)
+        .expect_gas_used(1_000_000);
 }
 
 #[test]
@@ -467,14 +464,11 @@ fn test_wasm_should_not_panic_on_invalid_contract_interface() {
     .unwrap()
     .into();
     let mut ctx = EvmTestingContext::default().with_full_genesis();
-    let result = TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module).exec();
-    assert_eq!(
-        result,
-        ExecutionResult::Halt {
-            reason: HaltReason::MalformedBuiltinParams,
-            gas_used: 100_000_000
-        }
-    )
+    TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module)
+        .execute()
+        .expect_halt()
+        .expect_reason(HaltReason::MalformedBuiltinParams)
+        .expect_gas_used(100_000_000);
 }
 
 #[test]
@@ -502,12 +496,9 @@ fn test_wasm_calling_resume_takes_no_negative_effect() {
     .unwrap()
     .into();
     let mut ctx = EvmTestingContext::default().with_full_genesis();
-    let result = TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module).exec();
-    assert_eq!(
-        result,
-        ExecutionResult::Halt {
-            reason: HaltReason::RootCallOnly,
-            gas_used: 100_000_000
-        }
-    )
+    TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module)
+        .execute()
+        .expect_halt()
+        .expect_reason(HaltReason::RootCallOnly)
+        .expect_gas_used(100_000_000);
 }


### PR DESCRIPTION
## What changed

- Added a higher-level EVM transaction testing API in `fluentbase-testing`, centered on `TxBuilder::execute()` and `expect_*` assertion helpers.
- Changed `TxBuilder::call` to require a callee up front, while caller, value, input, gas, and timestamp remain builder-style configuration.
- Migrated representative e2e tests, including `oom.rs`, and mechanically updated existing `TxBuilder::call` sites to the new call shape.

## Why

The e2e tests repeated raw `ExecutionResult` matching, gas checks, and transaction setup. This makes common test flows easier to read and gives future tests a single helper API for success, halt, revert, gas, output, and create-address expectations.

## Validation

- `cargo fmt --check --package fluentbase-testing --package fluentbase-e2e`
- `cargo check -p fluentbase-testing`
- `cargo test -p fluentbase-e2e --no-run`
- `cargo clippy -p fluentbase-testing -- -D warnings`
- `cargo test -p fluentbase-e2e test_oom_has_proper_exit_code -- --nocapture`
- `make check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added recommended EVM transaction testing patterns guide to help users build and assert test transactions.

* **New Features**
  * Improved `TxBuilder` API with fluent method chaining for simplified transaction setup and configuration.
  * Added assertion helpers for streamlined test result verification (success/halt/revert outcomes, gas usage, and output validation).

* **Tests**
  * Updated test suite to use new fluent transaction builder patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluentlabs-xyz/fluentbase/pull/415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->