### PR TITLE
feat: enable nitro-verifier and webauthn contracts

### DIFF
--- a/contracts/nitro/README.md
+++ b/contracts/nitro/README.md
@@ -1,10 +1,48 @@
-# NITRO
+# Nitro Verifier Contract
 
-Nitro integration wrapper. Provides a thin entrypoint that bridges Fluentbase contracts to a Nitro-style execution
-environment via host syscalls.
+AWS Nitro Enclaves attestation document verifier for Fluentbase genesis/system-contract usage.
 
-- Entrypoint: main_entry. Parses input, invokes host/native execution where appropriate, and returns results.
-- Inputs/Outputs: binary format defined by this crate to match Nitro host expectations.
-- Gas/fuel: Accounted by host; entrypoint performs final settlement if needed.
+## Overview
 
-Note: This is environment-specific. Ensure your host exposes the expected Nitro syscalls/APIs.
+The contract accepts a COSE_Sign1-wrapped Nitro attestation document, parses the signed CBOR payload, validates the attestation document shape, validates the AWS Nitro certificate chain against the pinned Nitro root certificate, and verifies the COSE signature with the leaf certificate.
+
+The implementation follows the AWS Nitro Enclaves attestation validation flow:
+
+- [AWS Nitro Enclaves root of trust](https://docs.aws.amazon.com/enclaves/latest/user/verify-root.html)
+- [AWS Nitro Enclaves attestation process](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/docs/attestation_process.md)
+
+## What This Verifier Checks
+
+- Input size is capped before calldata is copied into memory.
+- The input is valid COSE_Sign1 with a present payload.
+- The payload is a Nitro attestation document with required fields.
+- The digest is `SHA384`.
+- PCR count, PCR indexes, PCR byte lengths, and optional field sizes are within expected bounds.
+- The cabundle starts with the pinned AWS Nitro root certificate.
+- Certificates parse as DER, are valid at the block timestamp, carry required extensions, and form a valid chain.
+- The COSE_Sign1 signature verifies with the attestation leaf certificate.
+
+## Caller Policy
+
+This contract verifies that an attestation document is genuinely signed by the AWS Nitro attestation PKI. That is necessary, but not sufficient, for application-level trust.
+
+Callers must compare policy-critical fields against values they control:
+
+- `nonce`: bind the attestation to a caller-generated challenge and reject replay.
+- `pcrs`: require the exact expected enclave measurements.
+- `public_key`: require the expected key when using attestation to bootstrap encrypted sessions or account ownership.
+- `user_data`: require exact expected application data if the protocol uses it.
+- `module_id`: require the expected module identity if relevant.
+- `timestamp`: enforce a freshness window appropriate for the protocol.
+
+The attestation document's optional `nonce`, `public_key`, and `user_data` fields are user-controlled by the enclave/protocol. They must not be trusted simply because the attestation signature is valid; callers must compare them to expected values supplied by their own protocol.
+
+## Standards Compliance Notes
+
+The verifier covers the base AWS attestation document validation path and root-of-trust verification. It does not perform application-specific authorization or freshness checks, because those require caller-provided policy. It also does not perform CRL/OCSP revocation checks.
+
+A future strict selector should accept expected nonce, PCR policy, public key, user data, module id, and max age as calldata, then reject any mismatch inside the contract.
+
+## Gas/Fuel
+
+The entrypoint charges a fixed manual fuel amount before parsing. This prevents oversized or malformed attestations from being free to execute.

--- a/contracts/nitro/src/lib.rs
+++ b/contracts/nitro/src/lib.rs
@@ -2,36 +2,44 @@
 #![allow(clippy::useless_conversion, clippy::vec_init_then_push)]
 #![allow(dead_code)]
 
-use fluentbase_sdk::{system_entrypoint, ExitCode, SystemAPI};
+extern crate alloc;
+extern crate fluentbase_sdk;
 
-pub fn main_entry<SDK: SystemAPI>(_sdk: &mut SDK) -> Result<(), ExitCode> {
-    // Temporarily disabled
-    Err(ExitCode::UnreachableCodeReached)
+mod attestation;
+#[cfg(test)]
+mod tests;
+
+use crate::attestation::parse_attestation_and_verify;
+use fluentbase_sdk::{
+    evm::write_evm_panic_message, system_entrypoint, ContextReader, ExitCode, SystemAPI,
+};
+
+/// Estimated Nitro attestation verification cost, in EVM gas units.
+const NITRO_VERIFY_GAS: u64 = 1_250_000;
+
+// Nitro attestation documents are bounded by their schema: this verifier caps
+// public_key at 1024 bytes, user_data and nonce at 512 bytes each, PCR count at
+// 32, and cabundle certs at 1024 bytes each. The bundled real fixtures are
+// below 5 KiB, so 16 KiB leaves operational headroom while rejecting calldata
+// large enough to force expensive allocation before parsing.
+const NITRO_MAX_INPUT_SIZE: u32 = 16 * 1024;
+
+pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    sdk.sync_evm_gas(NITRO_VERIFY_GAS)?;
+
+    if sdk.input_size() > NITRO_MAX_INPUT_SIZE {
+        return Err(ExitCode::MalformedBuiltinParams);
+    }
+
+    let input = sdk.bytes_input();
+    let current_timestamp = sdk.context().block_timestamp();
+    if let Err(err) = parse_attestation_and_verify(input.as_ref(), current_timestamp) {
+        write_evm_panic_message(err, |slice| {
+            sdk.write(slice);
+        });
+        return Err(ExitCode::Panic);
+    }
+    Ok(())
 }
-
-// extern crate alloc;
-// extern crate fluentbase_sdk;
-//
-// mod attestation;
-// #[cfg(test)]
-// mod tests;
-//
-// use crate::attestation::parse_attestation_and_verify;
-// use fluentbase_sdk::{
-//     evm::write_evm_panic_message, system_entrypoint, ContextReader, ExitCode, SystemAPI,
-// };
-//
-// pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-//     let input = sdk.bytes_input();
-//     let current_timestamp = sdk.context().block_timestamp();
-//     if let Err(err) = parse_attestation_and_verify(input.as_ref(), current_timestamp) {
-//         // write an EVM-compatible panic message
-//         write_evm_panic_message(err, |slice| {
-//             sdk.write(slice);
-//         });
-//         return Err(ExitCode::Panic);
-//     }
-//     Ok(())
-// }
 
 system_entrypoint!(main_entry);

--- a/contracts/nitro/src/tests.rs
+++ b/contracts/nitro/src/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::attestation::AttestationDoc;
 use coset::CborSerializable;
 use der::{Decode, DecodePem, Encode};
-use fluentbase_sdk::SharedContextInputV1;
+use fluentbase_sdk::{Bytes, SharedContextInputV1};
 use fluentbase_testing::TestingContextImpl;
 use x509_cert::certificate::Certificate;
 
@@ -35,9 +35,14 @@ fn test_nitro_attestation_verification() {
 
     let mut sdk = TestingContextImpl::default()
         .with_shared_context_input(shared_ctx)
-        .with_input(data.clone());
+        .with_input(data.clone())
+        .with_gas_limit(NITRO_VERIFY_GAS);
 
     main_entry(&mut sdk).unwrap();
+    assert_eq!(
+        sdk.consumed_fuel(),
+        NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE
+    );
     _ = sdk.take_output();
 }
 
@@ -66,10 +71,78 @@ fn test_nitro_attestation_stf_keygen() {
 
     let mut sdk = TestingContextImpl::default()
         .with_shared_context_input(shared_ctx)
-        .with_input(data.clone());
+        .with_input(data.clone())
+        .with_gas_limit(NITRO_VERIFY_GAS);
 
     main_entry(&mut sdk).unwrap();
+    assert_eq!(
+        sdk.consumed_fuel(),
+        NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE
+    );
     _ = sdk.take_output();
+}
+
+#[test]
+#[ignore = "local fuel estimate benchmark"]
+fn bench_nitro_fuel_estimate() {
+    for (name, data) in [
+        (
+            "sample",
+            include_bytes!("../testdata/sample.bin").as_slice(),
+        ),
+        (
+            "stf_keygen",
+            include_bytes!("../testdata/stf-keygen.bin").as_slice(),
+        ),
+    ] {
+        let sign1 = coset::CoseSign1::from_slice(data).unwrap();
+        let payload = sign1.payload.as_ref().unwrap();
+        let doc = AttestationDoc::from_slice(payload).unwrap();
+        let current_timestamp = if doc.timestamp >= 1_000_000_000_000 {
+            doc.timestamp / 1000
+        } else {
+            doc.timestamp
+        };
+
+        let mut shared_ctx = SharedContextInputV1::default();
+        shared_ctx.block.timestamp = current_timestamp;
+
+        let started = std::time::Instant::now();
+        let iterations = 10u32;
+        for _ in 0..iterations {
+            let mut sdk = TestingContextImpl::default()
+                .with_shared_context_input(shared_ctx.clone())
+                .with_input(data.to_vec())
+                .with_gas_limit(NITRO_VERIFY_GAS);
+
+            main_entry(&mut sdk).unwrap();
+            assert_eq!(
+                sdk.consumed_fuel(),
+                NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE
+            );
+        }
+
+        println!(
+            "nitro {name}: gas={NITRO_VERIFY_GAS}, fuel={}, iterations={iterations}, elapsed={:?}",
+            NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE,
+            started.elapsed()
+        );
+    }
+}
+
+#[test]
+fn oversized_input_is_rejected_before_copying_full_payload() {
+    let mut sdk = TestingContextImpl::default()
+        .with_input(Bytes::from(vec![0u8; NITRO_MAX_INPUT_SIZE as usize + 1]))
+        .with_gas_limit(NITRO_VERIFY_GAS);
+
+    let err = main_entry(&mut sdk).unwrap_err();
+    assert_eq!(err, ExitCode::MalformedBuiltinParams);
+    assert_eq!(
+        sdk.consumed_fuel(),
+        NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE
+    );
+    assert!(sdk.take_output().is_empty());
 }
 
 /// Test that validates attestation document field requirements.

--- a/contracts/webauthn/README.md
+++ b/contracts/webauthn/README.md
@@ -1,16 +1,18 @@
 # WebAuthn Contract for Fluentbase
 
-A WebAuthn verification contract for blockchain authentication, enabling secure, passwordless authentication using the W3C WebAuthn standard.
+A WebAuthn assertion verification contract for blockchain authentication.
 
 ## Overview
 
 This contract implements WebAuthn verification for blockchain applications, allowing users to authenticate using their device's secure hardware (like TouchID, FaceID, or security keys) instead of traditional passwords or private keys.
 
-The implementation follows the [W3C WebAuthn Level 2](https://www.w3.org/TR/webauthn-2/) specification and is based on reference implementations from:
+The implementation follows the cryptographic assertion-verification subset of the [W3C WebAuthn Level 2](https://www.w3.org/TR/webauthn-2/) specification and is based on reference implementations from:
 
 - [Solady](https://github.com/vectorized/solady/blob/main/src/utils/WebAuthn.sol)
 - [Daimo](https://github.com/daimo-eth/p256-verifier/blob/master/src/WebAuthn.sol)
 - [Coinbase](https://github.com/base-org/webauthn-sol/blob/main/src/WebAuthn.sol)
+
+This contract is not a complete WebAuthn Relying Party implementation by itself. Callers must bind the assertion to their own account, origin/RP policy, challenge lifecycle, and credential state.
 
 ## Features
 
@@ -70,17 +72,36 @@ The contract performs the following verification steps:
    - Computes the message hash: SHA-256(authenticator_data || SHA-256(client_data_json))
    - Verifies the signature using the secp256r1 precompile
 
+## Standards Compliance and Caller Policy
+
+The W3C assertion verification procedure includes checks that require Relying Party state and policy. This contract verifies:
+
+- `clientDataJSON.type == "webauthn.get"` at the supplied `type_index`
+- the expected challenge at the supplied `challenge_index`
+- User Present (UP), optional User Verified (UV), and backup-state flag consistency
+- the P-256 signature over `authenticator_data || SHA-256(client_data_json)`
+
+The caller is still responsible for enforcing:
+
+- Expected origin and RP ID policy. In particular, verify the RP ID hash in `authenticator_data` against the caller's expected RP ID hash.
+- Credential binding. The supplied public key coordinates must be the registered credential public key for the authenticated account.
+- Challenge freshness and single use. A valid old assertion must not be replayable.
+- Signature counter policy, if the application relies on clone detection.
+- Credential ID lookup, allow-list policy, and account ownership.
+- Client extension outputs, token binding, and cross-origin policy if these are relevant to the application.
+
+The `client_data_json`, `authenticator_data`, indexes, and public key are user-supplied inputs. They must not be treated as trusted application data merely because this contract returns `true`; the application must compare policy-critical fields against values it controls.
+
 ## Security Considerations
 
-This implementation deliberately omits certain WebAuthn verifications that are less relevant in a blockchain context:
+This implementation deliberately omits some full Relying Party validations from the current ABI:
 
 - Origin and RP ID validation (delegated to authenticator)
-- Credential backup state
 - Extension outputs
 - Signature counter
 - Attestation objects
 
-These omissions optimize gas usage while maintaining the security properties essential for blockchain authentication.
+These omissions optimize gas usage for the current selector, but they mean the selector should be treated as a cryptographic assertion primitive. A future strict selector should take caller-controlled policy inputs such as expected origin, expected RP ID hash, credential ID/public key binding, and counter policy, then reject mismatches inside the contract.
 
 ## License
 

--- a/contracts/webauthn/src/lib.rs
+++ b/contracts/webauthn/src/lib.rs
@@ -1,111 +1,209 @@
 #![cfg_attr(target_arch = "wasm32", no_std, no_main)]
-use fluentbase_sdk::{system_entrypoint, ExitCode, SystemAPI};
+extern crate alloc;
+extern crate fluentbase_sdk;
 
-pub fn main_entry<SDK: SystemAPI>(_sdk: &mut SDK) -> Result<(), ExitCode> {
-    // Temporarily disabled
-    Err(ExitCode::UnreachableCodeReached)
+mod webauthn;
+
+use fluentbase_sdk::{
+    codec::SolidityABI, system_entrypoint, Bytes, ContextReader, ExitCode, SystemAPI, B256, U256,
+};
+use webauthn::{verify_webauthn, WebAuthnAuth};
+
+/// Function selector: 0x94516dde
+/// Derived from:
+/// keccak256("verify(bytes,bool,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256,uint256)")
+const VERIFY_SELECTOR: [u8; 4] = [0x94, 0x51, 0x6d, 0xde];
+
+/// Estimated verification cost, in EVM gas units.
+const WEBAUTHN_VERIFY_GAS: u64 = 22_000;
+
+/// WebAuthn verification contract for blockchain authentication.
+///
+/// Based on reference implementations:
+/// - Solady: https://github.com/vectorized/solady/blob/main/src/utils/WebAuthn.sol
+/// - Daimo: https://github.com/daimo-eth/p256-verifier/blob/master/src/WebAuthn.sol
+/// - Coinbase: https://github.com/base-org/webauthn-sol/blob/main/src/WebAuthn.sol
+pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    sdk.sync_evm_gas(WEBAUTHN_VERIFY_GAS)?;
+
+    if sdk.input_size() < 4 {
+        return Err(ExitCode::MalformedBuiltinParams);
+    }
+
+    let input = sdk.bytes_input();
+    let (selector, params) = input.split_at(4);
+    if selector != VERIFY_SELECTOR {
+        return Err(ExitCode::MalformedBuiltinParams);
+    }
+
+    let (challenge, require_user_verification, auth, x, y) =
+        SolidityABI::<(Bytes, bool, WebAuthnAuth, U256, U256)>::decode(&params, 0)
+            .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+
+    let gas_limit = sdk.context().contract_gas_limit();
+    let is_valid = verify_webauthn(
+        &challenge,
+        require_user_verification,
+        &auth,
+        x,
+        y,
+        gas_limit,
+    )?;
+    let result = B256::with_last_byte(if is_valid { 0x01 } else { 0x00 });
+    sdk.write(&result[..]);
+
+    Ok(())
 }
-
-// mod webauthn;
-//
-// use fluentbase_sdk::{
-//     codec::SolidityABI, system_entrypoint, Bytes, ContextReader, ExitCode, SystemAPI, B256, U256,
-// };
-// use webauthn::{verify_webauthn, WebAuthnAuth};
-//
-// /// Function selector: 0x94516dde
-// /// Derived from:
-// /// keccak256("verify(bytes,bool,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256,uint256)")
-// const VERIFY_SELECTOR: [u8; 4] = [0x94, 0x51, 0x6d, 0xde];
-//
-// /// WebAuthn verification contract for blockchain authentication
-// ///
-// /// Based on reference implementations:
-// /// - Solady: https://github.com/vectorized/solady/blob/main/src/utils/WebAuthn.sol
-// /// - Daimo: https://github.com/daimo-eth/p256-verifier/blob/master/src/WebAuthn.sol
-// /// - Coinbase: https://github.com/base-org/webauthn-sol/blob/main/src/WebAuthn.sol
-// pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-//     // Read input
-//     let input_length = sdk.input_size();
-//     assert!(
-//         input_length >= 4,
-//         "webauthn: input should be at least 4 bytes"
-//     );
-//
-//     let input = sdk.bytes_input();
-//
-//     let (selector, params) = input.split_at(4);
-//     if selector != VERIFY_SELECTOR {
-//         return Err(ExitCode::MalformedBuiltinParams);
-//     }
-//
-//     // Decode WebAuthn parameters using Solidity ABI
-//     let (challenge, require_user_verification, auth, x, y) =
-//         SolidityABI::<(Bytes, bool, WebAuthnAuth, U256, U256)>::decode(&params, 0)
-//             .map_err(|_| ExitCode::MalformedBuiltinParams)?;
-//
-//     // Get gas limit for precompiled call
-//     let gas_limit = sdk.context().contract_gas_limit();
-//
-//     let is_valid = verify_webauthn(
-//         &challenge,
-//         require_user_verification,
-//         &auth,
-//         x,
-//         y,
-//         gas_limit,
-//     )?;
-//     // Return 32-byte output with the last byte set to 1 if verification succeeds
-//     let result = B256::with_last_byte(if is_valid { 0x01 } else { 0x00 });
-//
-//     // Write the result
-//     sdk.write(&result[..]);
-//
-//     Ok(())
-// }
 
 system_entrypoint!(main_entry);
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use fluentbase_sdk::{Bytes, ContractContextV1, B256};
-//     use fluentbase_testing::TestingContextImpl;
-//
-//     fn assert_call_eq(input: &[u8], expected: &[u8]) {
-//         let gas_limit = 100_000;
-//         let mut sdk = TestingContextImpl::default()
-//             .with_input(Bytes::copy_from_slice(input))
-//             .with_contract_context(ContractContextV1 {
-//                 gas_limit,
-//                 ..Default::default()
-//             });
-//
-//         main_entry(&mut sdk).unwrap();
-//
-//         let output = sdk.take_output();
-//         assert_eq!(output.len(), expected.len(), "Output length mismatch");
-//         println!("Output: {:?}", hex::encode(&output));
-//
-//         assert_eq!(output, expected, "Verification result mismatch");
-//     }
-//
-//     #[test]
-//     fn test_valid_signature() {
-//         // Create test parameters with valid WebAuthn data
-//         let input = hex::decode("94516dde000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000e0e867625216bc4bbd847780a7647c1e1cf1c6b036f1cc917a189f85789914329ee7eaf13acb291279c9a974a1f12209924f61e9731d74f56bdb0d0b49ae3658b80000000000000000000000000000000000000000000000000000000000000020f631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf00000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000000170000000000000000000000000000000000000000000000000000000000000001041d2ba6320443e34a94700c83f8a65a49c647a679cd481b4756445e7994d3a26b9513bd0a2bf00fbf11973f7cd435fb62d529aeeb78243f84889deb6e4b5995000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d9763050000010100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000727b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22396a4546696a75684557724d34534f572d7443684a625545484550343456636a634a2d42716f3166544d38222c226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303035227d0000000000000000000000000000").expect("Failed to decode webauthn params from hex");
-//
-//         println!("Input: {:?}", hex::encode(&input));
-//
-//         // Execute precompile with valid input
-//         assert_call_eq(&input, &B256::with_last_byte(1)[..]);
-//     }
-//
-//     #[test]
-//     fn test_invalid_signature() {
-//         // Create test parameters with invalid WebAuthn data
-//         let input = hex::decode("94516dde000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000e02c15fa3dcecbd28795321d8e14f30c0a09cb0a5fbb02b6860c264514502672ba513136f66506523bd369730ef1274b0e95f2d03b5bf26808921b5d97fff8f7de0000000000000000000000000000000000000000000000000000000000000020f631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf00000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000001200000000000000000000000000000000000000000000000000000000000000017000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002549960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d9763050000010100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000727b2274797065223a22776562617574686e2e676574222c226368616c6c656e6765223a22396a4546696a75684557724d34534f572d7443684a625545484550343456636a634a2d42716f3166544d38222c226f726967696e223a22687474703a2f2f6c6f63616c686f73743a33303035227d0000000000000000000000000000").unwrap();
-//
-//         assert_call_eq(&input, &B256::default()[..]);
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluentbase_sdk::{
+        codec::bytes::BytesMut, crypto::crypto_sha256, Bytes, ContractContextV1, FUEL_DENOM_RATE,
+    };
+    use fluentbase_testing::TestingContextImpl;
+    use p256::{
+        ecdsa::{signature::SignerMut, SigningKey, VerifyingKey},
+        elliptic_curve::rand_core::OsRng,
+    };
+
+    fn valid_call_params(
+        require_user_verification: bool,
+    ) -> (Bytes, bool, WebAuthnAuth, U256, U256) {
+        let challenge = Bytes::copy_from_slice(
+            &hex::decode("f631058a3ba1116acce12396fad0a125b5041c43f8e15723709f81aa8d5f4ccf")
+                .unwrap(),
+        );
+        let authenticator_data = Bytes::copy_from_slice(
+            &hex::decode(
+                "49960de5880e8c687434170f6476605b8fe4aeb9a28632c7995cf3ba831d97630500000101",
+            )
+            .unwrap(),
+        );
+        let client_data_json = Bytes::copy_from_slice(
+            format!(
+                "{{\"type\":\"webauthn.get\",\"challenge\":\"{}\",\"origin\":\"http://localhost:3005\"}}",
+                webauthn::base64url_encode(&challenge)
+            )
+            .as_bytes(),
+        );
+
+        let mut signing_key = SigningKey::random(&mut OsRng);
+        let verifying_key = VerifyingKey::from(&signing_key);
+        let public_key = verifying_key.to_encoded_point(false);
+        let public_key = public_key.as_bytes();
+
+        let client_data_hash = crypto_sha256(&client_data_json).0;
+        let mut signed_message =
+            Vec::with_capacity(authenticator_data.len() + client_data_hash.len());
+        signed_message.extend_from_slice(&authenticator_data);
+        signed_message.extend_from_slice(&client_data_hash);
+        let signature: p256::ecdsa::Signature = signing_key.sign(&signed_message);
+        let signature = signature.to_bytes();
+
+        (
+            challenge,
+            require_user_verification,
+            WebAuthnAuth {
+                authenticator_data,
+                client_data_json,
+                challenge_index: U256::from(23),
+                type_index: U256::from(1),
+                r: U256::from_be_slice(&signature[..32]),
+                s: U256::from_be_slice(&signature[32..]),
+            },
+            U256::from_be_slice(&public_key[1..33]),
+            U256::from_be_slice(&public_key[33..65]),
+        )
+    }
+
+    fn encode_call(params_tuple: &(Bytes, bool, WebAuthnAuth, U256, U256)) -> Vec<u8> {
+        let mut params = BytesMut::new();
+        SolidityABI::<(Bytes, bool, WebAuthnAuth, U256, U256)>::encode(
+            params_tuple,
+            &mut params,
+            0,
+        )
+        .unwrap();
+
+        let mut input = VERIFY_SELECTOR.to_vec();
+        input.extend_from_slice(&params);
+        input
+    }
+
+    fn valid_call_input(require_user_verification: bool) -> Vec<u8> {
+        encode_call(&valid_call_params(require_user_verification))
+    }
+
+    fn exec(input: &[u8], gas_limit: u64) -> Result<(Vec<u8>, u64), ExitCode> {
+        let mut sdk = TestingContextImpl::default()
+            .with_input(Bytes::copy_from_slice(input))
+            .with_contract_context(ContractContextV1 {
+                gas_limit,
+                ..Default::default()
+            })
+            .with_gas_limit(gas_limit);
+        let result = main_entry(&mut sdk);
+        Ok((sdk.take_output(), sdk.consumed_fuel())).and_then(|success| result.map(|_| success))
+    }
+
+    #[test]
+    fn valid_signature_returns_true_and_charges_fuel() {
+        let (output, fuel) = exec(&valid_call_input(true), WEBAUTHN_VERIFY_GAS).unwrap();
+        assert_eq!(output, B256::with_last_byte(1)[..]);
+        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+    }
+
+    #[test]
+    fn missing_user_verification_returns_false_when_required() {
+        let mut params = valid_call_params(true);
+        let mut authenticator_data = params.2.authenticator_data.to_vec();
+        authenticator_data[webauthn::AUTH_DATA_FLAGS_INDEX] = webauthn::AUTH_DATA_FLAGS_UP;
+        params.2.authenticator_data = Bytes::copy_from_slice(&authenticator_data);
+
+        let (output, fuel) = exec(&encode_call(&params), WEBAUTHN_VERIFY_GAS).unwrap();
+        assert_eq!(output, B256::default()[..]);
+        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+    }
+
+    #[test]
+    fn malformed_selector_is_rejected_after_fuel_charge() {
+        let mut input = valid_call_input(true);
+        input[0] ^= 0xff;
+
+        let err = exec(&input, WEBAUTHN_VERIFY_GAS).unwrap_err();
+        assert_eq!(err, ExitCode::MalformedBuiltinParams);
+    }
+
+    #[test]
+    fn insufficient_fuel_fails_before_verification() {
+        let err = exec(&valid_call_input(true), WEBAUTHN_VERIFY_GAS - 1).unwrap_err();
+        assert_eq!(err, ExitCode::OutOfFuel);
+    }
+
+    #[test]
+    #[ignore = "local fuel estimate benchmark"]
+    fn bench_webauthn_fuel_estimate() {
+        let valid_input = valid_call_input(true);
+        let mut invalid_params = valid_call_params(true);
+        invalid_params.2.r = U256::ZERO;
+        invalid_params.2.s = U256::ZERO;
+        let invalid_input = encode_call(&invalid_params);
+
+        for (name, input) in [("valid", valid_input), ("invalid_signature", invalid_input)] {
+            let started = std::time::Instant::now();
+            let iterations = 100u32;
+            for _ in 0..iterations {
+                let (_, fuel) = exec(&input, WEBAUTHN_VERIFY_GAS).unwrap();
+                assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+            }
+            println!(
+                "webauthn {name}: gas={WEBAUTHN_VERIFY_GAS}, fuel={}, iterations={iterations}, elapsed={:?}",
+                WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE,
+                started.elapsed()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Re-enable WebAuthn and Nitro genesis verifier entrypoints.
- Add fixed manual fuel charging plus focused unit coverage.
- Add Nitro input-size guard before calldata copying and ignored local fuel estimate benchmarks.

## Validation
- `cargo fmt --manifest-path contracts/Cargo.toml --package fluentbase-contracts-webauthn --package fluentbase-contracts-nitro`
- `cargo test --manifest-path contracts/Cargo.toml -p fluentbase-contracts-webauthn`
- `cargo test --manifest-path contracts/Cargo.toml -p fluentbase-contracts-nitro`
- `cargo test --manifest-path contracts/Cargo.toml -p fluentbase-contracts-webauthn bench_webauthn_fuel_estimate -- --ignored --nocapture`
- `cargo test --manifest-path contracts/Cargo.toml -p fluentbase-contracts-nitro bench_nitro_fuel_estimate -- --ignored --nocapture`
- `cargo clippy --manifest-path contracts/Cargo.toml -p fluentbase-contracts-webauthn -p fluentbase-contracts-nitro --all-targets -- -D warnings`
- `cargo check --manifest-path contracts/Cargo.toml -p fluentbase-contracts-webauthn --no-default-features --target wasm32-unknown-unknown`
- `cargo check --manifest-path contracts/Cargo.toml -p fluentbase-contracts-nitro --no-default-features --target wasm32-unknown-unknown`

## Notes
- Full `make pr` was not run locally.
- Host `--no-default-features` checks still fail in existing `fluentbase-crypto` mode gating; wasm-target checks pass for both touched contracts.