### PR TITLE
feat: publish permissive EVM runtime artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
           mkdir -p artifacts
           gzip -c ./crates/genesis/genesis-devnet.json > ./artifacts/genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz
           gzip -c ./crates/genesis/genesis-mainnet.json > ./artifacts/genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz
+          gzip -c ./crates/genesis/evm-runtime-permissive.rwasm > ./artifacts/evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
 
       - name: Configure GPG and sign genesis artifacts
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -166,6 +167,13 @@ jobs:
         with:
           name: genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz
           path: genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz
+
+      - name: Upload permissive EVM runtime
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
+          path: evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
 
       - name: Upload devnet genesis signature
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -333,6 +341,9 @@ jobs:
             assets+=("$d/$(basename "$d")")
           done
           for d in ./*genesis-*.json.gz*; do
+            assets+=("$d/$(basename "$d")")
+          done
+          for d in ./*evm-runtime-permissive-*.rwasm.gz*; do
             assets+=("$d/$(basename "$d")")
           done
           tag_name="${{ env.VERSION }}"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ libzktrie.so
 
 # exclude all wat, wasm and genesis files
 *.wat
+crates/genesis/evm-runtime-permissive.rwasm
 contracts/**/lib.wasm
 contracts/**/lib.rwasm
 contracts/**/foundry.json

--- a/contracts/evm/Cargo.toml
+++ b/contracts/evm/Cargo.toml
@@ -19,3 +19,4 @@ path = "src/lib.rs"
 default = ["std"]
 std = ["fluentbase-sdk/std", "fluentbase-evm/std", "fluentbase-testing/std"]
 debug-print = ["fluentbase-sdk/debug-print", "fluentbase-testing/debug-print", "fluentbase-evm/debug-print"]
+permissive-contract-size = []

--- a/contracts/evm/src/lib.rs
+++ b/contracts/evm/src/lib.rs
@@ -12,10 +12,12 @@ use fluentbase_evm::{
     types::{exit_code_from_instruction_result, InterruptionOutcome},
     EthVM, EthereumMetadata, ExecutionResult, InterpreterAction,
 };
+#[cfg(not(feature = "permissive-contract-size"))]
+use fluentbase_sdk::EVM_MAX_CODE_SIZE;
 use fluentbase_sdk::{
     crypto::crypto_keccak256, rwasm_core::N_MAX_RECURSION_DEPTH,
     system::RuntimeInterruptionOutcomeV1, Bytes, ExitCode, HashMap, SystemAPI, B256,
-    EVM_MAX_CODE_SIZE, EVM_MAX_INITCODE_SIZE, FUEL_DENOM_RATE,
+    EVM_MAX_INITCODE_SIZE, FUEL_DENOM_RATE,
 };
 use spin::{Mutex, MutexGuard, Once};
 
@@ -120,7 +122,9 @@ pub fn deploy_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
                 // EIP-3541 and EIP-170 checks
                 if result.output.first() == Some(&0xEF) {
                     return Err(ExitCode::CreateContractStartingWithEF);
-                } else if result.output.len() > EVM_MAX_CODE_SIZE {
+                }
+                #[cfg(not(feature = "permissive-contract-size"))]
+                if result.output.len() > EVM_MAX_CODE_SIZE {
                     return Err(ExitCode::CreateContractSizeLimit);
                 }
                 let gas_for_code = result.output.len() as u64 * gas::CODEDEPOSIT;

--- a/crates/contracts/build.rs
+++ b/crates/contracts/build.rs
@@ -80,6 +80,38 @@ fn run_workspace_build(
     target_dir: &Path,
     is_debug_profile: bool,
 ) {
+    run_cargo_build(
+        build_args,
+        workspace_manifest_path,
+        target_dir,
+        is_debug_profile,
+        None,
+    );
+}
+
+fn run_package_build(
+    build_args: &BuildArgs,
+    workspace_manifest_path: &Path,
+    target_dir: &Path,
+    is_debug_profile: bool,
+    package: &str,
+) {
+    run_cargo_build(
+        build_args,
+        workspace_manifest_path,
+        target_dir,
+        is_debug_profile,
+        Some(package),
+    );
+}
+
+fn run_cargo_build(
+    build_args: &BuildArgs,
+    workspace_manifest_path: &Path,
+    target_dir: &Path,
+    is_debug_profile: bool,
+    package: Option<&str>,
+) {
     let work_dir = workspace_manifest_path.parent().unwrap();
     let mount_dir = build_args
         .mount_dir
@@ -111,6 +143,11 @@ fn run_workspace_build(
         effective_target_dir.to_string_lossy().to_string(),
         "--color=always".to_string(),
     ];
+
+    if let Some(package) = package {
+        cargo_args.push("--package".to_string());
+        cargo_args.push(package.to_string());
+    }
 
     if !is_debug_profile {
         cargo_args.push("--release".to_string());
@@ -211,7 +248,23 @@ fn main() {
         );
     }
 
+    let permissive_target_dir = target2_dir.join("permissive");
+    let mut permissive_build_args = build_args.clone();
+    permissive_build_args
+        .features
+        .push("permissive-contract-size".to_string());
+    run_package_build(
+        &permissive_build_args,
+        &fluentbase_root_dir.join("contracts/Cargo.toml"),
+        &permissive_target_dir,
+        is_debug_profile,
+        "fluentbase-contracts-evm",
+    );
+
     let artifacts_dir = target2_dir
+        .join("wasm32-unknown-unknown")
+        .join(if is_debug_profile { "debug" } else { "release" });
+    let permissive_artifacts_dir = permissive_target_dir
         .join("wasm32-unknown-unknown")
         .join(if is_debug_profile { "debug" } else { "release" });
 
@@ -259,6 +312,16 @@ fn main() {
         code.push(format!("    wasm_bytecode: include_bytes!(\"{path}\"),"));
         code.push("};".to_string());
     }
+    let permissive_evm_path = permissive_artifacts_dir.join("fluentbase_contracts_evm.wasm");
+    code.push(
+        "pub const FLUENTBASE_CONTRACTS_EVM_PERMISSIVE: BuildOutput = BuildOutput {".to_string(),
+    );
+    code.push("    name: \"fluentbase-contracts-evm-permissive\",".to_string());
+    code.push(format!(
+        "    wasm_bytecode: include_bytes!(\"{}\"),",
+        permissive_evm_path.to_str().unwrap()
+    ));
+    code.push("};".to_string());
     let code = code.join("\n");
     let build_output_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("build_output.rs");
 

--- a/crates/genesis/build.rs
+++ b/crates/genesis/build.rs
@@ -121,6 +121,19 @@ fn compile_all_contracts() -> HashMap<&'static [u8], (B256, Bytes)> {
     cache
 }
 
+fn write_permissive_evm_runtime() {
+    let rwasm_bytecode = compile_rwasm_maybe_system(
+        &PRECOMPILE_EVM_RUNTIME,
+        fluentbase_contracts::FLUENTBASE_CONTRACTS_EVM_PERMISSIVE.wasm_bytecode,
+    )
+    .expect("failed to compile permissive EVM runtime");
+    assert_eq!(rwasm_bytecode.constructor_params.len(), 0);
+    let rwasm_bytecode: Bytes = rwasm_bytecode.rwasm_module.serialize().into();
+    let runtime_path =
+        PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()).join("evm-runtime-permissive.rwasm");
+    fs::write(&runtime_path, rwasm_bytecode.as_ref()).unwrap();
+}
+
 fn init_contract(
     code: &mut Vec<String>,
     genesis: &mut BTreeMap<Address, GenesisAccount>,
@@ -188,6 +201,7 @@ fn main() {
     code.push("static BUILD_OUTPUTS: &[BuildOutput] = &[".to_string());
 
     let rwasm_artifacts = compile_all_contracts();
+    write_permissive_evm_runtime();
 
     for (address, contract) in GENESIS_CONTRACTS {
         let (rwasm_bytecode_hash, rwasm_bytecode) =


### PR DESCRIPTION
## Summary
- adds a permissive EVM runtime contract feature that skips only the deployed-code EIP-170 check
- builds a separate permissive EVM WASM/rWASM artifact without changing the strict genesis runtime path
- publishes evm-runtime-permissive-VERSION.rwasm.gz as a release asset for gblend consumption

## Verification
- rustfmt --check --edition 2021 contracts/evm/src/lib.rs crates/contracts/build.rs crates/genesis/build.rs
- cargo check -p fluentbase-contracts --locked
- cargo check -p fluentbase-genesis --locked
- cargo build --manifest-path contracts/Cargo.toml --target wasm32-unknown-unknown --target-dir target/contracts/permissive-check --release --no-default-features --features permissive-contract-size --locked --package fluentbase-contracts-evm
- git diff --check

## Notes
- Full cargo fmt --check currently reports baseline formatting diffs in untouched codec/sdk files under stable rustfmt; touched Rust files pass rustfmt check directly.

Linear: FLU-9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a permissive EVM runtime variant available in release artifacts
  * Added option to relax contract size limits via new feature configuration

* **Chores**
  * Updated artifact management for release packaging and distribution
  * Enhanced build system to generate permissive runtime variant alongside standard artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluentlabs-xyz/fluentbase/pull/418?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->