### PR TITLE
fix: map rwasm halt reasons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16145,11 +16145,11 @@ version = "14.0.0"
 source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 
 [[patch.unused]]
-name = "revm-statetest-types"
-version = "14.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
-
-[[patch.unused]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "git+https://github.com/fluentlabs-xyz/tiny-keccak.git?branch=rwasm#8cc319a6f53f3275b90871a2037a7a7999940995"
+
+[[patch.unused]]
+name = "revm-statetest-types"
+version = "14.0.0"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16138,18 +16138,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "revm-statetest-types"
-version = "14.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
-
-[[patch.unused]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "git+https://github.com/fluentlabs-xyz/tiny-keccak.git?branch=rwasm#8cc319a6f53f3275b90871a2037a7a7999940995"
-
-[[patch.unused]]
-name = "revm-statetest-types"
-version = "14.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7491,7 +7491,7 @@ dependencies = [
 [[package]]
 name = "op-revm"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "revm",
@@ -11795,7 +11795,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11813,7 +11813,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -11825,7 +11825,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11841,7 +11841,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11856,7 +11856,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -11869,7 +11869,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "either",
@@ -11882,7 +11882,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11900,7 +11900,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "either",
@@ -11937,7 +11937,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11949,7 +11949,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11973,7 +11973,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -11984,7 +11984,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
@@ -13651,9 +13651,9 @@ dependencies = [
 [[package]]
 name = "tiny-keccak"
 version = "2.0.2"
-source = "git+https://github.com/fluentlabs-xyz/tiny-keccak.git?branch=rwasm#8cc319a6f53f3275b90871a2037a7a7999940995"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
- "cfg-if",
  "crunchy",
 ]
 
@@ -16142,4 +16142,14 @@ dependencies = [
 [[patch.unused]]
 name = "revm-statetest-types"
 version = "14.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
+
+[[patch.unused]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "git+https://github.com/fluentlabs-xyz/tiny-keccak.git?branch=rwasm#8cc319a6f53f3275b90871a2037a7a7999940995"
+
+[[patch.unused]]
+name = "revm-statetest-types"
+version = "14.0.0"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16145,11 +16145,11 @@ version = "14.0.0"
 source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 
 [[patch.unused]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "git+https://github.com/fluentlabs-xyz/tiny-keccak.git?branch=rwasm#8cc319a6f53f3275b90871a2037a7a7999940995"
-
-[[patch.unused]]
 name = "revm-statetest-types"
 version = "14.0.0"
 source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
+
+[[patch.unused]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "git+https://github.com/fluentlabs-xyz/tiny-keccak.git?branch=rwasm#8cc319a6f53f3275b90871a2037a7a7999940995"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -374,7 +374,6 @@ revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch 
 revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
-revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 
 [patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
 op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
@@ -389,10 +388,6 @@ revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch 
 revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
-revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
-
-# tiny-keccak
-tiny-keccak = { git = "https://github.com/fluentlabs-xyz/tiny-keccak.git", branch = "rwasm" }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -362,18 +362,34 @@ fluentbase-types = { path = "./crates/types" }
 
 [patch.crates-io]
 # revm
-revm = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-bytecode = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-database = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-state = { package = "revm-state", git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-primitives = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-interpreter = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-inspector = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-context = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-context-interface = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-database-interface = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-revm-statetest-types = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
-op-revm = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched" }
+op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-bytecode = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-inspector = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+
+[patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
+op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-bytecode = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-inspector = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 
 # tiny-keccak
 tiny-keccak = { git = "https://github.com/fluentlabs-xyz/tiny-keccak.git", branch = "rwasm" }

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -3853,7 +3853,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3871,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "bitvec",
  "phf",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3899,7 +3899,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "either",
@@ -3940,7 +3940,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "either",
@@ -3975,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -4020,7 +4020,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -6067,3 +6067,13 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "op-revm"
+version = "15.0.0"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
+
+[[patch.unused]]
+name = "revm-statetest-types"
+version = "14.0.0"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -6067,13 +6067,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "op-revm"
-version = "15.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
-
-[[patch.unused]]
-name = "revm-statetest-types"
-version = "14.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -67,7 +67,6 @@ fluentbase-testing = { path = "../crates/testing" }
 #ecdsa = { path = "../../signatures/ecdsa" }
 
 [patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
-op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-bytecode = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-context = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
@@ -79,4 +78,3 @@ revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch 
 revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
-revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -23,7 +23,7 @@ fluentbase-evm = { path = "../crates/evm", default-features = false }
 #fluentbase-svm = { path = "../crates/svm", default-features = false }
 fluentbase-testing = { path = "../crates/testing", default-features = false }
 # revm
-revm-precompile = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched", default-features = false }
+revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason", default-features = false }
 # solana
 #solana-program-error = { git = "https://github.com/fluentlabs-xyz/agave", branch = "feat/svm", default-features = false }
 #solana-program-option = { git = "https://github.com/fluentlabs-xyz/agave", branch = "feat/svm", default-features = false }
@@ -65,3 +65,18 @@ fluentbase-evm = { path = "../crates/evm" }
 #fluentbase-svm = { path = "../crates/svm" }
 fluentbase-testing = { path = "../crates/testing" }
 #ecdsa = { path = "../../signatures/ecdsa" }
+
+[patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
+op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-bytecode = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-inspector = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }

--- a/crates/node/src/evm.rs
+++ b/crates/node/src/evm.rs
@@ -29,7 +29,7 @@ use fluentbase_revm::{
         primitives::hardfork::SpecId,
         Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
     },
-    DefaultRwasm, RwasmBuilder, RwasmEvm, RwasmFrame, RwasmPrecompiles,
+    DefaultRwasm, RwasmBuilder, RwasmEvm, RwasmFrame, RwasmHaltReason, RwasmPrecompiles,
 };
 use reth_chainspec::ChainSpec;
 use reth_ethereum::engine::EthPayloadAttributes;
@@ -140,6 +140,20 @@ impl<DB: Database, I, PRECOMPILE> DerefMut for FluentEvmExecutor<DB, I, PRECOMPI
     }
 }
 
+fn map_rwasm_result_and_state(result: ResultAndState<RwasmHaltReason>) -> ResultAndState {
+    ResultAndState::new(
+        result.result.map_haltreason(map_rwasm_halt_reason),
+        result.state,
+    )
+}
+
+fn map_rwasm_halt_reason(reason: RwasmHaltReason) -> HaltReason {
+    match reason {
+        RwasmHaltReason::Base(reason) => reason,
+        reason => HaltReason::PrecompileErrorWithContext(format!("{reason:?}")),
+    }
+}
+
 impl<DB, I, PRECOMPILE> Evm for FluentEvmExecutor<DB, I, PRECOMPILE>
 where
     DB: Database,
@@ -164,11 +178,12 @@ where
     }
 
     fn transact_raw(&mut self, tx: Self::Tx) -> Result<ResultAndState, Self::Error> {
-        if self.inspect {
+        let result = if self.inspect {
             self.inner.inspect_tx(tx)
         } else {
             self.inner.transact(tx)
-        }
+        };
+        result.map(map_rwasm_result_and_state)
     }
 
     fn transact_system_call(
@@ -177,7 +192,9 @@ where
         contract: Address,
         data: Bytes,
     ) -> Result<ResultAndState, Self::Error> {
-        self.inner.system_call_with_caller(caller, contract, data)
+        self.inner
+            .system_call_with_caller(caller, contract, data)
+            .map(map_rwasm_result_and_state)
     }
 
     fn db_mut(&mut self) -> &mut Self::DB {

--- a/crates/revm/src/result.rs
+++ b/crates/revm/src/result.rs
@@ -3,7 +3,7 @@ use fluentbase_evm::types::instruction_result_from_exit_code;
 use fluentbase_sdk::{Bytes, ExitCode};
 use revm::{
     context_interface::result::{HaltReason, HaltReasonTr},
-    interpreter::{FrameInput, Gas, InterpreterAction, InterpreterResult},
+    interpreter::{FrameInput, Gas, InstructionResult, InterpreterAction, InterpreterResult},
 };
 
 pub type ExecutionResult = InterpreterResult;
@@ -90,6 +90,30 @@ pub enum RwasmHaltReason {
 impl From<HaltReason> for RwasmHaltReason {
     fn from(value: HaltReason) -> Self {
         Self::Base(value)
+    }
+}
+
+impl From<RwasmHaltReason> for InstructionResult {
+    fn from(value: RwasmHaltReason) -> Self {
+        match value {
+            RwasmHaltReason::Base(reason) => reason.into(),
+            RwasmHaltReason::RootCallOnly => Self::RootCallOnly,
+            RwasmHaltReason::MalformedBuiltinParams => Self::MalformedBuiltinParams,
+            RwasmHaltReason::CallDepthOverflow => Self::CallDepthOverflow,
+            RwasmHaltReason::NonNegativeExitCode => Self::NonNegativeExitCode,
+            RwasmHaltReason::UnknownError => Self::UnknownError,
+            RwasmHaltReason::InputOutputOutOfBounds => Self::InputOutputOutOfBounds,
+            RwasmHaltReason::UnreachableCodeReached => Self::UnreachableCodeReached,
+            RwasmHaltReason::MemoryOutOfBounds => Self::MemoryOutOfBounds,
+            RwasmHaltReason::TableOutOfBounds => Self::TableOutOfBounds,
+            RwasmHaltReason::IndirectCallToNull => Self::IndirectCallToNull,
+            RwasmHaltReason::IntegerDivisionByZero => Self::IntegerDivisionByZero,
+            RwasmHaltReason::IntegerOverflow => Self::IntegerOverflow,
+            RwasmHaltReason::BadConversionToInteger => Self::BadConversionToInteger,
+            RwasmHaltReason::BadSignature => Self::BadSignature,
+            RwasmHaltReason::OutOfFuel => Self::OutOfFuel,
+            RwasmHaltReason::UnknownExternalFunction => Self::UnknownExternalFunction,
+        }
     }
 }
 

--- a/crates/revm/src/result.rs
+++ b/crates/revm/src/result.rs
@@ -2,7 +2,7 @@
 use fluentbase_evm::types::instruction_result_from_exit_code;
 use fluentbase_sdk::{Bytes, ExitCode};
 use revm::{
-    context_interface::result::HaltReason,
+    context_interface::result::{HaltReason, HaltReasonTr},
     interpreter::{FrameInput, Gas, InterpreterAction, InterpreterResult},
 };
 
@@ -47,4 +47,114 @@ pub enum NextActionOrInterruption {
     Interruption,
 }
 
-pub type RwasmHaltReason = HaltReason;
+/// rWasm/Fluentbase-specific halt reason.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum RwasmHaltReason {
+    /// Base EVM halt reason.
+    Base(HaltReason),
+    /// Function can only be invoked as the root entry call.
+    RootCallOnly,
+    /// Builtin function received malformed or invalid parameters.
+    MalformedBuiltinParams,
+    /// Exceeded maximum allowed call stack depth.
+    CallDepthOverflow,
+    /// Exit code must be negative, but a non-negative value was used.
+    NonNegativeExitCode,
+    /// Generic catch-all error for unknown failures.
+    UnknownError,
+    /// I/O operation tried to read/write outside allowed buffer bounds.
+    InputOutputOutOfBounds,
+    /// Execution reached a code path marked as unreachable.
+    UnreachableCodeReached,
+    /// Memory access outside the allocated memory range.
+    MemoryOutOfBounds,
+    /// Table index access outside the allocated table range.
+    TableOutOfBounds,
+    /// Indirect function call attempted with a null function reference.
+    IndirectCallToNull,
+    /// Division or remainder by zero occurred.
+    IntegerDivisionByZero,
+    /// Integer arithmetic operation overflowed the allowed range.
+    IntegerOverflow,
+    /// Invalid conversion to integer.
+    BadConversionToInteger,
+    /// Function signature mismatch in a call.
+    BadSignature,
+    /// Execution ran out of allocated fuel/gas.
+    OutOfFuel,
+    /// Call an undefined or unregistered external function.
+    UnknownExternalFunction,
+}
+
+impl From<HaltReason> for RwasmHaltReason {
+    fn from(value: HaltReason) -> Self {
+        Self::Base(value)
+    }
+}
+
+impl HaltReasonTr for RwasmHaltReason {
+    fn root_call_only() -> Self {
+        Self::RootCallOnly
+    }
+
+    fn malformed_builtin_params() -> Self {
+        Self::MalformedBuiltinParams
+    }
+
+    fn call_depth_overflow() -> Self {
+        Self::CallDepthOverflow
+    }
+
+    fn non_negative_exit_code() -> Self {
+        Self::NonNegativeExitCode
+    }
+
+    fn unknown_error() -> Self {
+        Self::UnknownError
+    }
+
+    fn input_output_out_of_bounds() -> Self {
+        Self::InputOutputOutOfBounds
+    }
+
+    fn unreachable_code_reached() -> Self {
+        Self::UnreachableCodeReached
+    }
+
+    fn memory_out_of_bounds() -> Self {
+        Self::MemoryOutOfBounds
+    }
+
+    fn table_out_of_bounds() -> Self {
+        Self::TableOutOfBounds
+    }
+
+    fn indirect_call_to_null() -> Self {
+        Self::IndirectCallToNull
+    }
+
+    fn integer_division_by_zero() -> Self {
+        Self::IntegerDivisionByZero
+    }
+
+    fn integer_overflow() -> Self {
+        Self::IntegerOverflow
+    }
+
+    fn bad_conversion_to_integer() -> Self {
+        Self::BadConversionToInteger
+    }
+
+    fn bad_signature() -> Self {
+        Self::BadSignature
+    }
+
+    fn out_of_fuel() -> Self {
+        Self::OutOfFuel
+    }
+
+    fn unknown_external_function() -> Self {
+        Self::UnknownExternalFunction
+    }
+}

--- a/crates/testing/src/evm.rs
+++ b/crates/testing/src/evm.rs
@@ -287,7 +287,7 @@ impl EvmTestingContext {
         &mut self,
         deployer: Address,
         init_bytecode: Bytes,
-    ) -> Result<Address, ExecutionResult> {
+    ) -> Result<Address, ExecutionResult<RwasmHaltReason>> {
         let (contract_address, _) = self.deploy_evm_tx_with_gas_result(deployer, init_bytecode)?;
         Ok(contract_address)
     }
@@ -296,7 +296,7 @@ impl EvmTestingContext {
         &mut self,
         deployer: Address,
         init_bytecode: Bytes,
-    ) -> Result<(Address, u64), ExecutionResult> {
+    ) -> Result<(Address, u64), ExecutionResult<RwasmHaltReason>> {
         let nonce = self.nonce(deployer);
         let result = TxBuilder::create(self, deployer, init_bytecode.clone().into()).exec();
         if !result.is_success() {
@@ -458,7 +458,7 @@ impl<'a> TxBuilder<'a> {
             let result = evm.transact_commit(self.tx.clone()).unwrap();
             let new_db = &mut evm.journaled_state.database;
             self.ctx.db = take(new_db);
-            result
+            result.map_haltreason(RwasmHaltReason::from)
         } else {
             let mut context: RwasmContext<InMemoryDB> = RwasmContext::new(db, PRAGUE);
             context.cfg = self.ctx.cfg.clone();

--- a/e2e/src/deployer.rs
+++ b/e2e/src/deployer.rs
@@ -1,6 +1,7 @@
 use crate::EvmTestingContextWithGenesis;
 use alloy_sol_types::{sol, SolCall, SolValue};
 use fluentbase_contracts::{FLUENTBASE_EXAMPLES_ERC20, FLUENTBASE_EXAMPLES_GREETING};
+use fluentbase_revm::RwasmHaltReason;
 use fluentbase_sdk::{constructor::encode_constructor_params, hex, Address, Bytes};
 use fluentbase_testing::EvmTestingContext;
 use revm::context::result::ExecutionResult;
@@ -108,7 +109,7 @@ fn test_locals_amplification_find_limit() {
     }
 }
 
-fn try_deploy(owner: Address, num_funcs: u32) -> Result<(), ExecutionResult> {
+fn try_deploy(owner: Address, num_funcs: u32) -> Result<(), ExecutionResult<RwasmHaltReason>> {
     let wasm = build_max_locals_module(num_funcs);
     let wasm_len = wasm.len();
 

--- a/e2e/src/oauth2.rs
+++ b/e2e/src/oauth2.rs
@@ -1,7 +1,7 @@
 use crate::EvmTestingContextWithGenesis;
+use fluentbase_revm::RwasmHaltReason;
 use fluentbase_sdk::{Address, Bytes, PRECOMPILE_OAUTH2_VERIFIER};
 use fluentbase_testing::{EvmTestingContext, TxResultExt};
-use revm::context::result::HaltReason;
 
 #[test]
 fn test_oauth2_should_not_panic() {
@@ -16,6 +16,6 @@ fn test_oauth2_should_not_panic() {
     );
     result
         .expect_halt()
-        .expect_reason(HaltReason::UnreachableCodeReached)
+        .expect_reason(RwasmHaltReason::UnreachableCodeReached)
         .expect_gas_used(3_000_000);
 }

--- a/e2e/src/oom.rs
+++ b/e2e/src/oom.rs
@@ -1,8 +1,8 @@
 use crate::EvmTestingContextWithGenesis;
 use fluentbase_contracts::FLUENTBASE_EXAMPLES_MEMORY_OOM;
+use fluentbase_revm::RwasmHaltReason;
 use fluentbase_sdk::{Address, Bytes, ExitCode::MalformedBuiltinParams, U256};
 use fluentbase_testing::{EvmTestingContext, TxBuilder};
-use revm::context::result::HaltReason;
 
 #[test]
 fn test_oom_has_proper_exit_code() {
@@ -20,7 +20,7 @@ fn test_oom_has_proper_exit_code() {
         .input(Bytes::default())
         .execute()
         .expect_halt()
-        .expect_reason(HaltReason::MemoryOutOfBounds)
+        .expect_reason(RwasmHaltReason::MemoryOutOfBounds)
         .expect_gas_used(3_000_000);
 }
 
@@ -48,6 +48,6 @@ fn test_negative_write_output_params_cant_cause_oom() {
     TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module)
         .execute()
         .expect_halt()
-        .expect_reason(HaltReason::MemoryOutOfBounds)
+        .expect_reason(RwasmHaltReason::MemoryOutOfBounds)
         .expect_gas_used(100_000_000);
 }

--- a/e2e/src/wasm.rs
+++ b/e2e/src/wasm.rs
@@ -8,15 +8,13 @@ use fluentbase_contracts::{
     FLUENTBASE_EXAMPLES_SHA256, FLUENTBASE_EXAMPLES_SIMPLE_STORAGE,
     FLUENTBASE_EXAMPLES_TINY_KECCAK, FLUENTBASE_EXAMPLES_UNWIPED_OUTPUT,
 };
+use fluentbase_revm::RwasmHaltReason;
 use fluentbase_sdk::{
     address, bytes, constructor::encode_constructor_params, Address, Bytes, U256,
 };
 use fluentbase_testing::{EvmTestingContext, TxBuilder, TxResultExt};
 use hex_literal::hex;
-use revm::{
-    bytecode::Bytecode,
-    context::result::{ExecutionResult, HaltReason},
-};
+use revm::{bytecode::Bytecode, context::result::ExecutionResult};
 use rwasm::RwasmModule;
 use std::str::from_utf8_unchecked;
 
@@ -444,7 +442,7 @@ fn test_wasm_cant_use_fatal_exit_code() {
     );
     result
         .expect_halt()
-        .expect_reason(HaltReason::UnknownError)
+        .expect_reason(RwasmHaltReason::UnknownError)
         .expect_gas_used(1_000_000);
 }
 
@@ -467,7 +465,7 @@ fn test_wasm_should_not_panic_on_invalid_contract_interface() {
     TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module)
         .execute()
         .expect_halt()
-        .expect_reason(HaltReason::MalformedBuiltinParams)
+        .expect_reason(RwasmHaltReason::MalformedBuiltinParams)
         .expect_gas_used(100_000_000);
 }
 
@@ -499,6 +497,6 @@ fn test_wasm_calling_resume_takes_no_negative_effect() {
     TxBuilder::create(&mut ctx, Address::repeat_byte(0x01), wasm_module)
         .execute()
         .expect_halt()
-        .expect_reason(HaltReason::RootCallOnly)
+        .expect_reason(RwasmHaltReason::RootCallOnly)
         .expect_gas_used(100_000_000);
 }

--- a/evm-e2e/Cargo.lock
+++ b/evm-e2e/Cargo.lock
@@ -3789,7 +3789,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3807,7 +3807,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "bitvec",
  "phf",
@@ -3819,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "either",
@@ -3876,7 +3876,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3894,7 +3894,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "either",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3923,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -3957,7 +3957,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.0",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "revm-statetest-types"
 version = "14.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip7928",
  "k256",
@@ -6121,3 +6121,8 @@ dependencies = [
 name = "rwasm"
 version = "0.3.2"
 source = "git+https://github.com/fluentlabs-xyz/rwasm?tag=v0.4.2#2096fdd4e5d8f244798974b6a9da77d025485099"
+
+[[patch.unused]]
+name = "op-revm"
+version = "15.0.0"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/evm-e2e/Cargo.lock
+++ b/evm-e2e/Cargo.lock
@@ -6116,13 +6116,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "rwasm"
-version = "0.3.2"
-source = "git+https://github.com/fluentlabs-xyz/rwasm?tag=v0.4.2#2096fdd4e5d8f244798974b6a9da77d025485099"
-
-[[patch.unused]]
-name = "op-revm"
-version = "15.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/evm-e2e/Cargo.toml
+++ b/evm-e2e/Cargo.toml
@@ -10,8 +10,8 @@ fluentbase-sdk = { path = "../crates/sdk" }
 fluentbase-genesis = { path = "../crates/genesis", default-features = false }
 fluentbase-revm = { path = "../crates/revm", features = ["eip1559-full-compatibility"] }
 
-revm = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched", default-features = false, features = ["std", "serde-json", "serde"] }
-revm-statetest-types = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v103-patched", default-features = false }
+revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason", default-features = false, features = ["std", "serde-json", "serde"] }
+revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason", default-features = false }
 
 hash-db = "=0.15"
 hex = "0.4"
@@ -53,3 +53,18 @@ wasmtime = [
 
 [patch.crates-io]
 rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm", tag = "v0.4.2" }
+
+[patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
+op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-bytecode = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-inspector = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }

--- a/evm-e2e/Cargo.toml
+++ b/evm-e2e/Cargo.toml
@@ -51,11 +51,7 @@ wasmtime = [
     "fluentbase-runtime/wasmtime",
 ]
 
-[patch.crates-io]
-rwasm = { git = "https://github.com/fluentlabs-xyz/rwasm", tag = "v0.4.2" }
-
 [patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
-op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-bytecode = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-context = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
@@ -67,4 +63,3 @@ revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch 
 revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
-revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }

--- a/evm-e2e/src/merkle_trie.rs
+++ b/evm-e2e/src/merkle_trie.rs
@@ -2,7 +2,7 @@ use alloy_rlp::{RlpEncodable, RlpMaxEncodedLen};
 use hash_db::Hasher;
 use plain_hasher::PlainHasher;
 use revm::{
-    context::result::{EVMError, ExecutionResult, HaltReason, InvalidTransaction},
+    context::result::{EVMError, ExecutionResult, InvalidTransaction},
     database::{bal::EvmDatabaseError, EmptyDB, PlainAccount, State},
     primitives::{keccak256, Address, Log, B256, U256},
 };
@@ -14,9 +14,9 @@ pub struct TestValidationResult {
     pub state_root: B256,
 }
 
-pub fn compute_test_roots(
+pub fn compute_test_roots<HaltReasonT>(
     exec_result: &Result<
-        ExecutionResult<HaltReason>,
+        ExecutionResult<HaltReasonT>,
         EVMError<EvmDatabaseError<Infallible>, InvalidTransaction>,
     >,
     db: &State<EmptyDB>,

--- a/evm-e2e/src/runner.rs
+++ b/evm-e2e/src/runner.rs
@@ -5,7 +5,7 @@ use crate::{
     inspector::TraceInspector,
     state::{evm_cache_state, fill_tx_env, fluent_cache_state, prepare_env, GENESIS_CONTRACTS},
 };
-use fluentbase_revm::{RwasmBuilder, RwasmContext, RwasmEvm};
+use fluentbase_revm::{RwasmBuilder, RwasmContext, RwasmEvm, RwasmHaltReason};
 use fluentbase_sdk::Address;
 use indicatif::{ProgressBar, ProgressDrawTarget};
 use revm::{
@@ -129,8 +129,8 @@ fn check_evm_execution<ERROR: Debug + ToString + Clone + PartialEq, INSP>(
     test: &Test,
     expected_output: Option<&Bytes>,
     test_name: &str,
-    exec_result1: &Result<ExecutionResult, ERROR>,
-    exec_result2: &Result<ExecutionResult, ERROR>,
+    exec_result1: &Result<ExecutionResult<HaltReason>, ERROR>,
+    exec_result2: &Result<ExecutionResult<RwasmHaltReason>, ERROR>,
     evm: &mut MainnetEvm<MainnetContext<State<InMemoryDB>>, INSP>,
     evm2: &mut RwasmEvm<RwasmContext<State<InMemoryDB>>, INSP>,
     print_json_outcome: bool,
@@ -521,7 +521,7 @@ fn check_evm_execution<ERROR: Debug + ToString + Clone + PartialEq, INSP>(
 
 fn format_evm_result(
     exec_result: &Result<
-        ExecutionResult<HaltReason>,
+        ExecutionResult<RwasmHaltReason>,
         EVMError<EvmDatabaseError<Infallible>, InvalidTransaction>,
     >,
 ) -> String {
@@ -539,7 +539,7 @@ fn build_json_output(
     test: &Test,
     test_name: &str,
     exec_result: &Result<
-        ExecutionResult<HaltReason>,
+        ExecutionResult<RwasmHaltReason>,
         EVMError<EvmDatabaseError<Infallible>, InvalidTransaction>,
     >,
     validation: &TestValidationResult,
@@ -566,7 +566,7 @@ fn build_json_output(
 fn validate_exception(
     test: &Test,
     exec_result: &Result<
-        ExecutionResult<HaltReason>,
+        ExecutionResult<RwasmHaltReason>,
         EVMError<EvmDatabaseError<Infallible>, InvalidTransaction>,
     >,
 ) -> Result<bool, TestErrorKind> {
@@ -580,9 +580,9 @@ fn validate_exception(
     }
 }
 
-fn validate_output(
+fn validate_output<HaltReasonT>(
     expected_output: Option<&Bytes>,
-    actual_result: &ExecutionResult<HaltReason>,
+    actual_result: &ExecutionResult<HaltReasonT>,
 ) -> Result<(), TestErrorKind> {
     if let Some((expected, actual)) = expected_output.zip(actual_result.output()) {
         if expected != actual {
@@ -600,7 +600,7 @@ fn check_fluent_execution(
     expected_output: Option<&Bytes>,
     test_name: &str,
     exec_result: &Result<
-        ExecutionResult<HaltReason>,
+        ExecutionResult<RwasmHaltReason>,
         EVMError<EvmDatabaseError<Infallible>, InvalidTransaction>,
     >,
     db: &mut State<EmptyDB>,

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -6006,13 +6006,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "op-revm"
-version = "15.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
-
-[[patch.unused]]
-name = "revm-statetest-types"
-version = "14.0.0"
-source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3776,7 +3776,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 [[package]]
 name = "revm"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3794,7 +3794,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "8.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "bitvec",
  "phf",
@@ -3806,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "13.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "14.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "either",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3881,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "15.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "auto_impl",
  "either",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3910,7 +3910,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "32.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3932,7 +3932,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "22.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "9.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v103-patched#0912c9c885e40be9fc3e289ca666f67c9407c6c4"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -6006,3 +6006,13 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "op-revm"
+version = "15.0.0"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"
+
+[[patch.unused]]
+name = "revm-statetest-types"
+version = "14.0.0"
+source = "git+https://github.com/hedwig0x/revm-rwasm.git?branch=fix%2Fextend-rwasm-halt-reason#2072a2448bfc55c4a2b74a14deb4c3fe83e2e249"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -46,7 +46,6 @@ strip = "symbols"
 tiny-keccak = { git = "https://github.com/fluentlabs-xyz/tiny-keccak.git", branch = "rwasm" }
 
 [patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
-op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-bytecode = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-context = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
@@ -58,4 +57,3 @@ revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch 
 revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
 revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
-revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -44,3 +44,18 @@ strip = "symbols"
 [patch.crates-io]
 # patch tiny-keccak
 tiny-keccak = { git = "https://github.com/fluentlabs-xyz/tiny-keccak.git", branch = "rwasm" }
+
+[patch."https://github.com/fluentlabs-xyz/revm-rwasm.git"]
+op-revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-bytecode = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-context-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-database-interface = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-inspector = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-interpreter = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-precompile = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-primitives = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-state = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }
+revm-statetest-types = { git = "https://github.com/hedwig0x/revm-rwasm.git", branch = "fix/extend-rwasm-halt-reason" }


### PR DESCRIPTION
## Summary
- add Fluentbase-specific RwasmHaltReason enum implementing the new revm-rwasm HaltReasonTr hooks
- preserve rWasm runtime-specific halt reasons without adding them to base EVM HaltReason
- temporarily patch revm-rwasm dependencies to the companion PR branch until that lands

## Companion PR
- https://github.com/fluentlabs-xyz/revm-rwasm/pull/59

## Checks
- cargo check -p fluentbase-revm
- cargo fmt --check -p fluentbase-revm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Redirected multiple workspace and example dependencies to a new upstream branch/source for the revm/rWasm ecosystem.

* **Features**
  * Added richer rWasm-specific halt reasons for clearer execution diagnostics and more precise error reporting; execution results now expose these variants.

* **Tests**
  * Updated tests, examples, and tooling to use the new halt-reason types and adjusted validation flows to align with improved diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluentlabs-xyz/fluentbase/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->