### PR TITLE
docs: document Linear task decomposition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,13 @@ from the author in Linear comments before implementation. When a task is in `Bac
 agent must refine the task, label and estimate it where possible, move it to `Todo`, and unassign it
 before implementation.
 
+If a Linear issue is estimated greater than 5 story points, decompose it before implementation.
+Do this during Backlog intake or Research, before any `In Progress` implementation work begins.
+Each child issue should include concrete context, expected outcome, acceptance criteria, relevant
+links, labels, and an estimate no greater than 5 where possible. Link the child issues from the
+parent, summarize the split in a Linear comment, and leave the parent in the appropriate planning or
+review status until the manager moves the approved implementation work to `In Progress`.
+
 ## Branch and Git Standards
 
 - Default remote base branch is `origin/devel` in this repo. Rebase/start branch work from the latest


### PR DESCRIPTION
## Summary
- Add a Linear workflow rule requiring issues estimated above 5 story points to be decomposed before implementation.
- Document when decomposition happens, what child issues need, and how to handle the parent issue.

## Checks
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linear issue management guidelines introducing a task decomposition rule for large items. Issues estimated above 5 story points must now be broken down into smaller child issues with comprehensive context, acceptance criteria, relevant links, labels, and individual estimates (ideally under 5 points). Parent issues remain in planning status until manager approval for implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fluentlabs-xyz/fluentbase/pull/424?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->