### PR TITLE
ci: use clang for release cross builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/fluent
   DOCKER_IMAGE_NAME_URL: https://ghcr.io/${{ github.repository_owner }}/fluent
   RUSTC_WRAPPER: "sccache"
+  CC: clang
+  CXX: clang++
 
 jobs:
   dry-run:

--- a/Cross.toml
+++ b/Cross.toml
@@ -26,4 +26,4 @@ env.passthrough = [
 ]
 
 [build.env]
-passthrough = ["JEMALLOC_SYS_WITH_LG_PAGE"]
+passthrough = ["JEMALLOC_SYS_WITH_LG_PAGE", "CC", "CXX"]


### PR DESCRIPTION
## Summary
- set `CC=clang` and `CXX=clang++` for the release workflow
- pass those compiler env vars through `cross` so `aws-lc-sys` does not fall back to the unsupported GCC inside the container

## Context
The release dry-run failed in `Build Fluent` for `fluent-rwasm` because `aws-lc-sys v0.41.0` rejected the detected `cc` compiler due to GCC bug 95189.

## Verification
- inspected failed job `79530983951` from run `26955344339`
- checked diff against current `origin/release/v1.3.0`
- full release build not run locally