### PR TITLE
feat: add ethereum replay runner

### DIFF
--- a/evm-e2e/README.md
+++ b/evm-e2e/README.md
@@ -1,1 +1,35 @@
 # evm-e2e
+
+`evm-e2e` runs Ethereum state-test shaped fixtures against Fluent EVM. It can also
+generate and replay single Ethereum transaction fixtures for mainnet compatibility
+checks.
+
+## Generate a replay fixture
+
+Use an RPC endpoint that supports `debug_traceTransaction` with `prestateTracer`:
+
+```sh
+node gen_fixture.mjs \
+  --rpc-url "$RPC_URL" \
+  --tx 0x... \
+  --out fixtures/mainnet/tx-0x....json
+```
+
+Large bytecode values are externalized under `fixtures/reusable-bytecode/` and are
+resolved automatically by the Fluent runner.
+
+## Replay fixtures on Fluent EVM
+
+```sh
+cargo run --bin eth-replay -- fixtures/mainnet
+```
+
+Useful options:
+
+- `--compare-reference` also runs the native EVM path and compares it with Fluent.
+- `--report-jsonl replay.jsonl` writes one JSON record per fixture.
+- `--trace` enables the trace inspector.
+- `--fail-fast` stops after the first failing fixture.
+
+Replay fixtures may include `config.chainid`; when present, Fluent execution uses
+that value instead of the local devnet/testnet path fallback.

--- a/evm-e2e/src/bin/eth-replay.rs
+++ b/evm-e2e/src/bin/eth-replay.rs
@@ -1,0 +1,186 @@
+#![allow(dead_code)]
+
+#[path = "../inspector.rs"]
+mod inspector;
+#[path = "../merkle_trie.rs"]
+pub mod merkle_trie;
+#[path = "../runner.rs"]
+mod runner;
+#[path = "../state.rs"]
+mod state;
+#[path = "../utils.rs"]
+pub mod utils;
+
+use runner::{execute_evm_test_suite, execute_fluent_test_suite, find_all_json_tests};
+use serde_json::json;
+use std::{
+    fs::{File, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+    process::ExitCode,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "eth-replay",
+    about = "Replay Ethereum transaction fixtures against Fluent EVM"
+)]
+struct Cmd {
+    /// Path to a replay fixture JSON file or a directory containing fixture JSON files.
+    #[structopt(required = true)]
+    path: Vec<PathBuf>,
+
+    /// Run Fluent with the trace inspector.
+    #[structopt(long)]
+    trace: bool,
+
+    /// Emit per-test JSON outcome records from the underlying runner.
+    #[structopt(short = "o", long)]
+    json_outcome: bool,
+
+    /// Also run the reference EVM path and compare it against Fluent.
+    #[structopt(long)]
+    compare_reference: bool,
+
+    /// Stop after the first failed fixture.
+    #[structopt(long)]
+    fail_fast: bool,
+
+    /// Write one JSON object per replayed fixture.
+    #[structopt(long, parse(from_os_str))]
+    report_jsonl: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+struct ReplayResult {
+    path: PathBuf,
+    ok: bool,
+    elapsed: Duration,
+    error: Option<String>,
+}
+
+impl Cmd {
+    fn run(&self) -> io::Result<bool> {
+        let files = self.fixture_files();
+        let started = Instant::now();
+        let mut report = self.open_report()?;
+        let mut results = Vec::with_capacity(files.len());
+        let elapsed = Arc::new(Mutex::new(Duration::ZERO));
+
+        for path in files {
+            let result = self.run_fixture(&path, &elapsed);
+            self.write_report(&mut report, &result)?;
+            let failed = !result.ok;
+            results.push(result);
+
+            if failed && self.fail_fast {
+                break;
+            }
+        }
+
+        self.print_summary(&results, started.elapsed(), *elapsed.lock().unwrap());
+        Ok(results.iter().all(|result| result.ok))
+    }
+
+    fn fixture_files(&self) -> Vec<PathBuf> {
+        let mut files = self
+            .path
+            .iter()
+            .flat_map(|path| find_all_json_tests(path))
+            .collect::<Vec<_>>();
+        files.sort();
+        files
+    }
+
+    fn run_fixture(&self, path: &Path, elapsed: &Arc<Mutex<Duration>>) -> ReplayResult {
+        let started = Instant::now();
+        let outcome = if self.compare_reference {
+            execute_evm_test_suite(path, elapsed, self.trace, self.json_outcome)
+        } else {
+            execute_fluent_test_suite(path, elapsed, self.trace, self.json_outcome)
+        };
+
+        match outcome {
+            Ok(()) => ReplayResult {
+                path: path.to_path_buf(),
+                ok: true,
+                elapsed: started.elapsed(),
+                error: None,
+            },
+            Err(error) => ReplayResult {
+                path: path.to_path_buf(),
+                ok: false,
+                elapsed: started.elapsed(),
+                error: Some(error.to_string()),
+            },
+        }
+    }
+
+    fn open_report(&self) -> io::Result<Option<File>> {
+        self.report_jsonl
+            .as_ref()
+            .map(|path| {
+                OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(path)
+            })
+            .transpose()
+    }
+
+    fn write_report(&self, report: &mut Option<File>, result: &ReplayResult) -> io::Result<()> {
+        let Some(report) = report else {
+            return Ok(());
+        };
+
+        let record = json!({
+            "path": result.path,
+            "engine": if self.compare_reference { "compare" } else { "fluent" },
+            "ok": result.ok,
+            "elapsedMillis": result.elapsed.as_millis(),
+            "error": result.error,
+        });
+        writeln!(report, "{record}")
+    }
+
+    fn print_summary(&self, results: &[ReplayResult], wall_time: Duration, cpu_time: Duration) {
+        let passed = results.iter().filter(|result| result.ok).count();
+        let failed = results.len() - passed;
+        let engine = if self.compare_reference {
+            "compare"
+        } else {
+            "fluent"
+        };
+
+        println!(
+            "Replay summary: {} files, {passed} passed, {failed} failed, engine={engine}",
+            results.len()
+        );
+        println!("Wall time: {:.6}s", wall_time.as_secs_f64());
+        println!("Total CPU time: {:.6}s", cpu_time.as_secs_f64());
+
+        for result in results.iter().filter(|result| !result.ok) {
+            println!(
+                "FAILED {}: {}",
+                result.path.display(),
+                result.error.as_deref().unwrap_or("unknown error")
+            );
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let cmd = Cmd::from_args();
+    match cmd.run() {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::from(1),
+        Err(error) => {
+            eprintln!("eth-replay failed: {error}");
+            ExitCode::from(1)
+        }
+    }
+}

--- a/evm-e2e/src/runner.rs
+++ b/evm-e2e/src/runner.rs
@@ -916,6 +916,30 @@ pub fn resolve_externalized_bytecodes(v: &mut Value, base_dir: &Path) {
     }
 }
 
+fn parse_u64_json(value: &Value) -> Option<u64> {
+    match value {
+        Value::Number(number) => number.as_u64(),
+        Value::String(value) => {
+            if let Some(hex_value) = value.strip_prefix("0x") {
+                u64::from_str_radix(hex_value, 16).ok()
+            } else {
+                value.parse().ok()
+            }
+        }
+        _ => None,
+    }
+}
+
+fn fixture_chain_id(fixture: &Value) -> Option<u64> {
+    fixture.as_object()?.values().find_map(|unit| {
+        let config = unit.get("config")?;
+        config
+            .get("chainid")
+            .or_else(|| config.get("chainId"))
+            .and_then(parse_u64_json)
+    })
+}
+
 pub fn execute_fluent_test_suite(
     path: &Path,
     elapsed: &Arc<Mutex<Duration>>,
@@ -932,6 +956,7 @@ pub fn execute_fluent_test_suite(
 
     let mut fixture: Value = serde_json::from_str(&fs::read_to_string(path).unwrap()).unwrap();
     resolve_externalized_bytecodes(&mut fixture, path.parent().unwrap());
+    let fixture_chain_id = fixture_chain_id(&fixture);
 
     let suite: TestSuite = serde_json::from_value(fixture).map_err(|e| TestError {
         name: path.to_string_lossy().into_owned(),
@@ -946,8 +971,9 @@ pub fn execute_fluent_test_suite(
         let cache_state = evm_cache_state(&unit);
         let (mut cfg_env, block_env, mut tx_env) = prepare_env(&unit, &name)?;
 
-        // TODO(dmitry123): Once revm testing unit has config use it instead of path check
-        if path.to_str().unwrap().contains("testnet") {
+        if let Some(chain_id) = fixture_chain_id {
+            cfg_env.chain_id = chain_id;
+        } else if path.to_str().unwrap().contains("testnet") {
             cfg_env.chain_id = 20994;
         } else if path.to_str().unwrap().contains("devnet") {
             cfg_env.chain_id = 20993;


### PR DESCRIPTION
## Summary
- Add a new `eth-replay` binary under `evm-e2e` for replaying Ethereum transaction fixtures against Fluent EVM.
- Add optional reference comparison and JSONL per-fixture reporting for divergence triage.
- Respect fixture-level `config.chainid` for Fluent execution, with existing path-based devnet/testnet fallback preserved.

## Verification
- `cargo fmt --manifest-path evm-e2e/Cargo.toml --check`
- `cargo check --manifest-path evm-e2e/Cargo.toml --bin eth-replay`
- `cargo check --manifest-path evm-e2e/Cargo.toml --bin evm-e2e` (passes with existing dead-code warnings in runner helpers)

Linear: FLU-29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `eth-replay` CLI tool to replay Ethereum test fixtures against Fluent EVM with optional tracing and reference comparison capabilities.
  * Added documentation for running state-test fixtures, generating single-transaction replay fixtures via RPC, and available CLI options.

* **Improvements**
  * Enhanced chain ID extraction from fixture files with robust fallback logic for improved mainnet compatibility testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->