### PR TITLE
ci: use clang for docker cross builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,8 @@ env:
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/fluent
   DOCKER_USERNAME: ${{ github.actor }}
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+  CC: clang
+  CXX: clang++
 
 jobs:
   build-rc:


### PR DESCRIPTION
## Summary
- set `CC=clang` and `CXX=clang++` for the Docker image workflow
- lets the existing `Cross.toml` passthrough carry clang into `cross` builds for Docker RC/latest images

## Context
The `v1.3.0-rc.1` Docker workflow failed in `docker-build-push` because `aws-lc-sys v0.41.0` saw `CC = None`, fell back to `cc`, and rejected it due to GCC bug 95189.

## Verification
- inspected failed job `79547025904` from run `26959881020`
- checked diff against current `origin/release/v1.3.0`
- full Docker image build not rerun
