### PR TITLE
fix(ci): keep rc builder images off latest

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -77,8 +77,18 @@ jobs:
           SDK_VERSION_TAG=""
           fi
           
+          IS_RC=false
+          if [[ "$VERSION" == *-rc* ]]; then
+          IS_RC=true
+          fi
+
+          PUSH_LATEST=false
+          if [[ "$IS_RC" != "true" ]] && { [[ "$EVENT" == "workflow_dispatch" && "${{ inputs.push_latest }}" == "true" ]] || [[ "$REF_TYPE" == "tag" ]]; }; then
+          PUSH_LATEST=true
+          fi
+
           TAGS="${IMAGE}:${VERSION}"
-          if [[ ("$EVENT" == "workflow_dispatch" && "${{ inputs.push_latest }}" == "true") || "$REF_TYPE" == "tag" ]]; then
+          if [[ "$PUSH_LATEST" == "true" ]]; then
           TAGS+=",${IMAGE}:latest"
           fi
           
@@ -91,6 +101,8 @@ jobs:
           
           echo "Resolved metadata:"
           echo "  VERSION=${VERSION}"
+          echo "  IS_RC=${IS_RC}"
+          echo "  PUSH_LATEST=${PUSH_LATEST}"
           echo "  BRANCH=${SDK_VERSION_BRANCH}"
           echo "  TAG=${SDK_VERSION_TAG}"
           echo "  TAGS=${TAGS}"


### PR DESCRIPTION
## Summary
- prevent RC fluentbase-build image publishes from tagging `latest`
- keep versioned RC image tags unchanged
- preserve stable tag and explicit stable workflow_dispatch `push_latest` behavior

## Validation
- `python3` YAML parse for `.github/workflows/build-docker.yml`
- bash simulation for RC tag, stable tag, manual RC, and manual stable tag cases
- `git diff --check`