### PR TITLE
feat(runtime-upgrade): recompile deployed wasm runtime

### DIFF
--- a/contracts/runtime-upgrade/src/lib.rs
+++ b/contracts/runtime-upgrade/src/lib.rs
@@ -27,6 +27,16 @@ struct RuntimeUpgraded {
 }
 
 #[derive(Event)]
+struct ContractRecompiled {
+    #[indexed]
+    target_address: Address,
+    #[indexed]
+    genesis_hash: B256,
+    genesis_version: String,
+    code_hash: B256,
+}
+
+#[derive(Event)]
 struct OwnerChanged {
     new_owner: Address,
 }
@@ -71,7 +81,15 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
         wasm_bytecode: Bytes,
     ) {
         _ = self.only_owner();
-        self.compile_upgrade_and_emit(target_address, genesis_hash, genesis_version, wasm_bytecode);
+        let code_hash = self.compile_and_install(target_address, wasm_bytecode);
+        RuntimeUpgraded {
+            target_address,
+            genesis_hash,
+            genesis_version,
+            code_hash,
+        }
+        .emit(&mut self.sdk)
+        .unwrap();
     }
 
     #[function_id("recompile(address,uint256,string)")]
@@ -96,7 +114,15 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
             panic!("runtime-upgrade: incomplete target bytecode");
         }
 
-        self.compile_upgrade_and_emit(target_address, genesis_hash, genesis_version, wasm_bytecode);
+        let code_hash = self.compile_and_install(target_address, wasm_bytecode);
+        ContractRecompiled {
+            target_address,
+            genesis_hash,
+            genesis_version,
+            code_hash,
+        }
+        .emit(&mut self.sdk)
+        .unwrap();
     }
 
     #[function_id("changeOwner(address)")]
@@ -132,13 +158,7 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
 }
 
 impl<SDK: SharedAPI> App<SDK> {
-    fn compile_upgrade_and_emit(
-        &mut self,
-        target_address: Address,
-        genesis_hash: B256,
-        genesis_version: String,
-        wasm_bytecode: Bytes,
-    ) {
+    fn compile_and_install(&mut self, target_address: Address, wasm_bytecode: Bytes) -> B256 {
         if !wasm_bytecode.starts_with(&WASM_MAGIC_BYTES) {
             panic!("runtime-upgrade: malformed wasm bytecode");
         }
@@ -166,14 +186,7 @@ impl<SDK: SharedAPI> App<SDK> {
             panic!("runtime-upgrade: can't obtain code hash");
         };
 
-        RuntimeUpgraded {
-            target_address,
-            genesis_hash,
-            genesis_version,
-            code_hash,
-        }
-        .emit(&mut self.sdk)
-        .unwrap();
+        code_hash
     }
 
     fn only_owner(&self) -> Address {
@@ -245,5 +258,18 @@ mod tests {
         assert_eq!(decoded.0 .0, target, "target_address mismatch");
         assert_eq!(decoded.0 .1, genesis_hash, "genesis_hash mismatch");
         assert_eq!(decoded.0 .2, genesis_version, "genesis_version mismatch");
+    }
+
+    #[test]
+    fn test_upgrade_and_recompile_event_signatures_are_distinct() {
+        assert_eq!(
+            RuntimeUpgraded::SIGNATURE,
+            "RuntimeUpgraded(address,bytes32,string,bytes32)"
+        );
+        assert_eq!(
+            ContractRecompiled::SIGNATURE,
+            "ContractRecompiled(address,bytes32,string,bytes32)"
+        );
+        assert_ne!(RuntimeUpgraded::SELECTOR, ContractRecompiled::SELECTOR);
     }
 }

--- a/contracts/runtime-upgrade/src/lib.rs
+++ b/contracts/runtime-upgrade/src/lib.rs
@@ -30,9 +30,6 @@ struct RuntimeUpgraded {
 struct ContractRecompiled {
     #[indexed]
     target_address: Address,
-    #[indexed]
-    genesis_hash: B256,
-    genesis_version: String,
     code_hash: B256,
 }
 
@@ -58,7 +55,7 @@ trait RuntimeUpgradeTr {
     );
 
     /// Recompile already deployed WASM runtime smart contract
-    fn recompile(&mut self, target_address: Address, genesis_hash: B256, genesis_version: String);
+    fn recompile(&mut self, target_address: Address);
 
     /// Change contract owner
     fn change_owner(&mut self, new_owner: Address);
@@ -92,8 +89,8 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
         .unwrap();
     }
 
-    #[function_id("recompile(address,uint256,string)")]
-    fn recompile(&mut self, target_address: Address, genesis_hash: B256, genesis_version: String) {
+    #[function_id("recompile(address)")]
+    fn recompile(&mut self, target_address: Address) {
         _ = self.only_owner();
 
         let Ok(code_size) = self.sdk.code_size(&target_address).ok() else {
@@ -117,8 +114,6 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
         let code_hash = self.compile_and_install(target_address, wasm_bytecode);
         ContractRecompiled {
             target_address,
-            genesis_hash,
-            genesis_version,
             code_hash,
         }
         .emit(&mut self.sdk)
@@ -245,10 +240,8 @@ mod tests {
     #[test]
     fn test_recompile_encoding() {
         let target = address!("2222222222222222222222222222222222222222");
-        let genesis_hash = B256::from([0xab; 32]);
-        let genesis_version = "v1.0.0".to_string();
 
-        let call = RecompileCall::new((target, genesis_hash, genesis_version.clone()));
+        let call = RecompileCall::new((target,));
         let encoded = call.encode();
 
         assert!(encoded.len() >= 4);
@@ -256,8 +249,6 @@ mod tests {
 
         let decoded = RecompileCall::decode(&&encoded[4..]).expect("failed to decode");
         assert_eq!(decoded.0 .0, target, "target_address mismatch");
-        assert_eq!(decoded.0 .1, genesis_hash, "genesis_hash mismatch");
-        assert_eq!(decoded.0 .2, genesis_version, "genesis_version mismatch");
     }
 
     #[test]
@@ -268,7 +259,7 @@ mod tests {
         );
         assert_eq!(
             ContractRecompiled::SIGNATURE,
-            "ContractRecompiled(address,bytes32,string,bytes32)"
+            "ContractRecompiled(address,bytes32)"
         );
         assert_ne!(RuntimeUpgraded::SELECTOR, ContractRecompiled::SELECTOR);
     }

--- a/contracts/runtime-upgrade/src/lib.rs
+++ b/contracts/runtime-upgrade/src/lib.rs
@@ -47,6 +47,9 @@ trait RuntimeUpgradeTr {
         wasm_bytecode: Bytes,
     );
 
+    /// Recompile already deployed WASM runtime smart contract
+    fn recompile(&mut self, target_address: Address, genesis_hash: B256, genesis_version: String);
+
     /// Change contract owner
     fn change_owner(&mut self, new_owner: Address);
 
@@ -68,6 +71,74 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
         wasm_bytecode: Bytes,
     ) {
         _ = self.only_owner();
+        self.compile_upgrade_and_emit(target_address, genesis_hash, genesis_version, wasm_bytecode);
+    }
+
+    #[function_id("recompile(address,uint256,string)")]
+    fn recompile(&mut self, target_address: Address, genesis_hash: B256, genesis_version: String) {
+        _ = self.only_owner();
+
+        let Ok(code_size) = self.sdk.code_size(&target_address).ok() else {
+            panic!("runtime-upgrade: can't obtain code size");
+        };
+        if code_size == 0 {
+            panic!("runtime-upgrade: empty target bytecode");
+        }
+
+        let Ok(wasm_bytecode) = self
+            .sdk
+            .code_copy(&target_address, 0, code_size as u64)
+            .ok()
+        else {
+            panic!("runtime-upgrade: can't load target bytecode");
+        };
+        if wasm_bytecode.len() != code_size as usize {
+            panic!("runtime-upgrade: incomplete target bytecode");
+        }
+
+        self.compile_upgrade_and_emit(target_address, genesis_hash, genesis_version, wasm_bytecode);
+    }
+
+    #[function_id("changeOwner(address)")]
+    fn change_owner(&mut self, new_owner: Address) {
+        _ = self.only_owner();
+        if new_owner == Address::ZERO {
+            panic!("runtime-upgrade: can't set owner to zero address");
+        }
+        self.owner_accessor().set(&mut self.sdk, new_owner);
+        OwnerChanged { new_owner }.emit(&mut self.sdk).unwrap();
+    }
+
+    #[function_id("owner()")]
+    fn owner(&mut self) -> Address {
+        let mut owner = self.owner_accessor().get(&self.sdk);
+        if owner.is_zero() {
+            owner = DEFAULT_UPDATE_GENESIS_AUTH;
+        }
+        owner
+    }
+
+    #[function_id("renounceOwnership()")]
+    fn renounce_ownership(&mut self) {
+        _ = self.only_owner();
+        // We set to `SYSTEM_ADDRESS` to make a system fully maintained by forks (if it's required)
+        self.owner_accessor().set(&mut self.sdk, SYSTEM_ADDRESS);
+        OwnerChanged {
+            new_owner: SYSTEM_ADDRESS,
+        }
+        .emit(&mut self.sdk)
+        .unwrap();
+    }
+}
+
+impl<SDK: SharedAPI> App<SDK> {
+    fn compile_upgrade_and_emit(
+        &mut self,
+        target_address: Address,
+        genesis_hash: B256,
+        genesis_version: String,
+        wasm_bytecode: Bytes,
+    ) {
         if !wasm_bytecode.starts_with(&WASM_MAGIC_BYTES) {
             panic!("runtime-upgrade: malformed wasm bytecode");
         }
@@ -105,39 +176,6 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
         .unwrap();
     }
 
-    #[function_id("changeOwner(address)")]
-    fn change_owner(&mut self, new_owner: Address) {
-        _ = self.only_owner();
-        if new_owner == Address::ZERO {
-            panic!("runtime-upgrade: can't set owner to zero address");
-        }
-        self.owner_accessor().set(&mut self.sdk, new_owner);
-        OwnerChanged { new_owner }.emit(&mut self.sdk).unwrap();
-    }
-
-    #[function_id("owner()")]
-    fn owner(&mut self) -> Address {
-        let mut owner = self.owner_accessor().get(&self.sdk);
-        if owner.is_zero() {
-            owner = DEFAULT_UPDATE_GENESIS_AUTH;
-        }
-        owner
-    }
-
-    #[function_id("renounceOwnership()")]
-    fn renounce_ownership(&mut self) {
-        _ = self.only_owner();
-        // We set to `SYSTEM_ADDRESS` to make a system fully maintained by forks (if it's required)
-        self.owner_accessor().set(&mut self.sdk, SYSTEM_ADDRESS);
-        OwnerChanged {
-            new_owner: SYSTEM_ADDRESS,
-        }
-        .emit(&mut self.sdk)
-        .unwrap();
-    }
-}
-
-impl<SDK: SharedAPI> App<SDK> {
     fn only_owner(&self) -> Address {
         let mut owner = self.owner_accessor().get(&self.sdk);
         if owner == Address::ZERO {
@@ -189,5 +227,23 @@ mod tests {
         assert_eq!(decoded.0 .1, genesis_hash, "genesis_hash mismatch");
         assert_eq!(decoded.0 .2, genesis_version, "genesis_version mismatch");
         assert_eq!(decoded.0 .3, wasm_bytecode, "wasm_bytecode mismatch");
+    }
+
+    #[test]
+    fn test_recompile_encoding() {
+        let target = address!("2222222222222222222222222222222222222222");
+        let genesis_hash = B256::from([0xab; 32]);
+        let genesis_version = "v1.0.0".to_string();
+
+        let call = RecompileCall::new((target, genesis_hash, genesis_version.clone()));
+        let encoded = call.encode();
+
+        assert!(encoded.len() >= 4);
+        println!("Encoded call data: {}", hex::encode(&encoded));
+
+        let decoded = RecompileCall::decode(&&encoded[4..]).expect("failed to decode");
+        assert_eq!(decoded.0 .0, target, "target_address mismatch");
+        assert_eq!(decoded.0 .1, genesis_hash, "genesis_hash mismatch");
+        assert_eq!(decoded.0 .2, genesis_version, "genesis_version mismatch");
     }
 }

--- a/docs/06-runtime-upgrade.md
+++ b/docs/06-runtime-upgrade.md
@@ -18,12 +18,16 @@ It exists so chain operators can replace system runtime bytecode, but it must st
 Upgrade contract exposes:
 
 - `upgradeTo(...)`
+- `recompile(...)`
 - `changeOwner(...)`
 - `owner()`
 - `renounceOwnership()`
 
 Key behavior:
 - only owner can upgrade,
+- `recompile(...)` loads the target account bytecode with `code_size`/`code_copy`, requires it to be
+  original WASM bytes, recompiles it to rWasm, and then uses the same upgrade syscall path as
+  `upgradeTo(...)`,
 - zero owner assignment is rejected by `changeOwner`,
 - renounce sets owner to system address,
 - default owner fallback is defined for unset state.

--- a/docs/06-runtime-upgrade.md
+++ b/docs/06-runtime-upgrade.md
@@ -9,7 +9,7 @@ It exists so chain operators can replace system runtime bytecode, but it must st
 2. Input wasm is validated and compiled to rWasm.
 3. Contract invokes native upgrade syscall with target address + serialized rWasm module.
 4. Host side verifies caller path and installs new code at target.
-5. Upgrade event is emitted with metadata (target/genesis refs/code hash).
+5. Upgrade or recompile event is emitted with metadata (target/genesis refs/code hash).
 
 ---
 
@@ -28,6 +28,7 @@ Key behavior:
 - `recompile(...)` loads the target account bytecode with `code_size`/`code_copy`, requires it to be
   original WASM bytes, recompiles it to rWasm, and then uses the same upgrade syscall path as
   `upgradeTo(...)`,
+- `upgradeTo(...)` emits `RuntimeUpgraded`, while `recompile(...)` emits `ContractRecompiled`,
 - zero owner assignment is rejected by `changeOwner`,
 - renounce sets owner to system address,
 - default owner fallback is defined for unset state.

--- a/docs/06-runtime-upgrade.md
+++ b/docs/06-runtime-upgrade.md
@@ -9,7 +9,7 @@ It exists so chain operators can replace system runtime bytecode, but it must st
 2. Input wasm is validated and compiled to rWasm.
 3. Contract invokes native upgrade syscall with target address + serialized rWasm module.
 4. Host side verifies caller path and installs new code at target.
-5. Upgrade or recompile event is emitted with metadata (target/genesis refs/code hash).
+5. Upgrade emits target/genesis refs/code hash; recompile emits target/code hash.
 
 ---
 
@@ -25,7 +25,7 @@ Upgrade contract exposes:
 
 Key behavior:
 - only owner can upgrade,
-- `recompile(...)` loads the target account bytecode with `code_size`/`code_copy`, requires it to be
+- `recompile(address)` loads the target account bytecode with `code_size`/`code_copy`, requires it to be
   original WASM bytes, recompiles it to rWasm, and then uses the same upgrade syscall path as
   `upgradeTo(...)`,
 - `upgradeTo(...)` emits `RuntimeUpgraded`, while `recompile(...)` emits `ContractRecompiled`,


### PR DESCRIPTION
## Summary
- add owner-gated `recompile(address,uint256,string)` to runtime-upgrade
- load target account bytecode via `code_size`/`code_copy` and reuse the existing WASM compile + upgrade syscall path
- document the operational constraint that the target code must still be original WASM bytes

## Tests
- `cargo fmt --package fluentbase-contracts-runtime-upgrade --check` from `contracts/`
- `cargo test -p fluentbase-contracts-runtime-upgrade` from `contracts/`

Linear: FLU-850