### PR TITLE
test(evm): add heavy memory repros

### DIFF
--- a/evm-e2e/README.md
+++ b/evm-e2e/README.md
@@ -1,1 +1,45 @@
 # evm-e2e
+
+## FLU-28 Heavy EVM Memory Repros
+
+The FLU-28 repro tests are ignored and require an explicit environment guard because they can
+consume large amounts of memory. They cover both input families from the issue:
+
+- the pinned upstream Ethereum `GeneralStateTests/stQuadraticComplexityTest` transactions
+- the synthetic `MSTORE8` transaction that forces exactly 2 GiB of active EVM memory
+
+First sync the pinned upstream Ethereum tests:
+
+```bash
+make -C evm-e2e sync_tests
+```
+
+Run the original quadratic-complexity transactions:
+
+```bash
+FLUENTBASE_RUN_HEAVY_EVM_REPRO=1 cargo test \
+  --manifest-path evm-e2e/Cargo.toml \
+  --release \
+  --no-default-features \
+  --features std,wasmtime \
+  --package evm-e2e \
+  heavy_tests::upstream_st_quadratic_complexity \
+  -- --ignored --nocapture
+```
+
+Run the synthetic 2 GiB memory-expansion transaction with RSS reporting:
+
+```bash
+FLUENTBASE_RUN_HEAVY_EVM_REPRO=1 /usr/bin/time -v cargo test \
+  --manifest-path evm-e2e/Cargo.toml \
+  --release \
+  --no-default-features \
+  --features std,wasmtime \
+  --package evm-e2e \
+  heavy_tests::synthetic_memory::mstore8_2gib \
+  -- --ignored --nocapture
+```
+
+For the synthetic fixture, the expected state root is zero so the runner records and compares
+native EVM vs Fluent behavior without requiring a checked-in precomputed root for a machine-sized
+allocation case.

--- a/evm-e2e/fixtures/heavy/evm_memory_2gib_mstore8.json
+++ b/evm-e2e/fixtures/heavy/evm_memory_2gib_mstore8.json
@@ -1,0 +1,70 @@
+{
+  "evm_memory_2gib_mstore8": {
+    "_info": {
+      "comment": "Manual heavy repro for FLU-28. Runtime bytecode writes one byte at offset 2GiB - 1, forcing exactly 2GiB of active EVM memory.",
+      "bytecode": "0x6000637fffffff5300",
+      "envGuard": "FLUENTBASE_RUN_HEAVY_EVM_REPRO=1"
+    },
+    "config": {
+      "chainid": "0x1"
+    },
+    "env": {
+      "currentBaseFee": "0x0",
+      "currentCoinbase": "0x0000000000000000000000000000000000000000",
+      "currentDifficulty": "0x0",
+      "currentGasLimit": "0x82f79cd9000",
+      "currentNumber": "0x1",
+      "currentRandom": "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "currentTimestamp": "0x1"
+    },
+    "pre": {
+      "0x1000000000000000000000000000000000000000": {
+        "balance": "0x0",
+        "nonce": "0x0",
+        "code": "0x6000637fffffff5300",
+        "storage": {}
+      },
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "balance": "0xde0b6b3a7640000",
+        "nonce": "0x0",
+        "code": "0x",
+        "storage": {}
+      }
+    },
+    "post": {
+      "Prague": [
+        {
+          "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "state": {}
+        }
+      ]
+    },
+    "transaction": {
+      "accessLists": [
+        []
+      ],
+      "data": [
+        "0x"
+      ],
+      "gasLimit": [
+        "0x82f79cd9000"
+      ],
+      "gasPrice": "0x0",
+      "maxFeePerGas": "0x0",
+      "maxPriorityFeePerGas": "0x0",
+      "nonce": "0x0",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "to": "0x1000000000000000000000000000000000000000",
+      "value": [
+        "0x0"
+      ],
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    }
+  }
+}

--- a/evm-e2e/src/heavy_tests.rs
+++ b/evm-e2e/src/heavy_tests.rs
@@ -1,0 +1,64 @@
+const RUN_HEAVY_EVM_REPRO_ENV: &str = "FLUENTBASE_RUN_HEAVY_EVM_REPRO";
+
+#[test]
+fn synthetic_mstore8_fixture_deserializes() {
+    let fixture = include_str!("../fixtures/heavy/evm_memory_2gib_mstore8.json");
+    let _: revm_statetest_types::TestSuite = serde_json::from_str(fixture).unwrap();
+}
+
+fn run_heavy_evm_e2e_test(test_path: &'static str) {
+    if std::env::var(RUN_HEAVY_EVM_REPRO_ENV).as_deref() != Ok("1") {
+        panic!(
+            "set {RUN_HEAVY_EVM_REPRO_ENV}=1 to run heavy EVM repro test {test_path}; \
+             these tests can allocate large memory and are intentionally opt-in"
+        );
+    }
+
+    crate::utils::run_evm_e2e_test(test_path);
+}
+
+macro_rules! define_heavy_tests {
+    (
+        $( fn $test_name:ident($test_path:literal); )*
+    ) => {
+        $(
+            #[test]
+            #[ignore = "heavy EVM repro; set FLUENTBASE_RUN_HEAVY_EVM_REPRO=1"]
+            fn $test_name() {
+                run_heavy_evm_e2e_test($test_path)
+            }
+        )*
+    };
+}
+
+mod synthetic_memory {
+    use super::*;
+
+    define_heavy_tests! {
+        fn mstore8_2gib("fixtures/heavy/evm_memory_2gib_mstore8.json");
+    }
+}
+
+mod upstream_st_quadratic_complexity {
+    use super::*;
+
+    define_heavy_tests! {
+        fn call1_mb1024_calldepth("tests/GeneralStateTests/stQuadraticComplexityTest/Call1MB1024Calldepth.json");
+        fn call20_kbytes_contract50_1("tests/GeneralStateTests/stQuadraticComplexityTest/Call20KbytesContract50_1.json");
+        fn call20_kbytes_contract50_2("tests/GeneralStateTests/stQuadraticComplexityTest/Call20KbytesContract50_2.json");
+        fn call20_kbytes_contract50_3("tests/GeneralStateTests/stQuadraticComplexityTest/Call20KbytesContract50_3.json");
+        fn call50000("tests/GeneralStateTests/stQuadraticComplexityTest/Call50000.json");
+        fn call50000_ecrec("tests/GeneralStateTests/stQuadraticComplexityTest/Call50000_ecrec.json");
+        fn call50000_identity("tests/GeneralStateTests/stQuadraticComplexityTest/Call50000_identity.json");
+        fn call50000_identity2("tests/GeneralStateTests/stQuadraticComplexityTest/Call50000_identity2.json");
+        fn call50000_rip160("tests/GeneralStateTests/stQuadraticComplexityTest/Call50000_rip160.json");
+        fn call50000_sha256("tests/GeneralStateTests/stQuadraticComplexityTest/Call50000_sha256.json");
+        fn callcode50000("tests/GeneralStateTests/stQuadraticComplexityTest/Callcode50000.json");
+        fn create1000("tests/GeneralStateTests/stQuadraticComplexityTest/Create1000.json");
+        fn create1000_byzantium("tests/GeneralStateTests/stQuadraticComplexityTest/Create1000Byzantium.json");
+        fn create1000_shnghai("tests/GeneralStateTests/stQuadraticComplexityTest/Create1000Shnghai.json");
+        fn quadratic_complexity_solidity_call_data("tests/GeneralStateTests/stQuadraticComplexityTest/QuadraticComplexitySolidity_CallDataCopy.json");
+        fn return50000("tests/GeneralStateTests/stQuadraticComplexityTest/Return50000.json");
+        fn return50000_2("tests/GeneralStateTests/stQuadraticComplexityTest/Return50000_2.json");
+    }
+}

--- a/evm-e2e/src/main.rs
+++ b/evm-e2e/src/main.rs
@@ -1,4 +1,6 @@
 mod fixtures;
+#[cfg(test)]
+mod heavy_tests;
 mod inspector;
 pub mod merkle_trie;
 mod runner;

--- a/evm-e2e/src/runner.rs
+++ b/evm-e2e/src/runner.rs
@@ -270,7 +270,7 @@ fn check_evm_execution<ERROR: Debug + ToString + Clone + PartialEq, INSP>(
         });
     }
 
-    if state_root1 != test.hash {
+    if test.hash != B256::ZERO && state_root1 != test.hash {
         let kind = TestErrorKind::StateRootMismatch {
             expected: test.hash,
             got: state_root1,


### PR DESCRIPTION
## Summary
- add ignored/env-gated FLU-28 heavy tests for the upstream stQuadraticComplexityTest transactions
- add a synthetic MSTORE8 fixture that forces exactly 2 GiB of active EVM memory
- document sync/run commands and allow zero state roots for parity/reporting fixtures

## Validation
- python3 -m json.tool evm-e2e/fixtures/heavy/evm_memory_2gib_mstore8.json
- cargo fmt --manifest-path evm-e2e/Cargo.toml -- --check
- cargo test --manifest-path evm-e2e/Cargo.toml --no-default-features --features std,wasmtime --package evm-e2e --bin evm-e2e --no-run
- cargo test --manifest-path evm-e2e/Cargo.toml --no-default-features --features std,wasmtime --package evm-e2e --bin evm-e2e heavy_tests::synthetic_memory::mstore8_2gib
- cargo test --manifest-path evm-e2e/Cargo.toml --no-default-features --features std,wasmtime --package evm-e2e --bin evm-e2e heavy_tests::synthetic_mstore8_fixture_deserializes

Note: the actual heavy repros remain ignored and require FLUENTBASE_RUN_HEAVY_EVM_REPRO=1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for heavy EVM memory reproduction tests and setup instructions.

* **Tests**
  * Added comprehensive E2E test suite for high-memory EVM scenarios, including a 2 GiB memory expansion test and upstream quadratic complexity tests.
  * Improved state root validation to skip checks when appropriate for certain test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->