### PR TITLE
test(evm-e2e): reproduce malformed eth_call payload

### DIFF
--- a/evm-e2e/fixtures/testnet_eth_call_b7ab4db5_malformed_builtin_params.json
+++ b/evm-e2e/fixtures/testnet_eth_call_b7ab4db5_malformed_builtin_params.json
@@ -1,0 +1,62 @@
+{
+  "eth_call_b7ab4db5_malformed_builtin_params": {
+    "_info": {
+      "comment": "Reproduces eth_call payload {\"data\":\"0xb7ab4db5\"} against Fluent locally. With no `to`, the call is executed as contract creation; 0xb7 is PUSH24 but only three immediate bytes follow, so Fluent halts with MalformedBuiltinParams.",
+      "sourceRpc": "curl 'https://rpc.fluent.xyz' -H 'content-type: application/json' --data-raw '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_call\",\"params\":[{\"data\":\"0xb7ab4db5\"},\"latest\"]}' | jq"
+    },
+    "config": {
+      "chainid": "0x5202"
+    },
+    "env": {
+      "currentBaseFee": "0x7",
+      "currentCoinbase": "0x0000000000000000000000000000000000520fee",
+      "currentDifficulty": "0x0",
+      "currentGasLimit": "0x2faf080",
+      "currentNumber": "0x172af18",
+      "currentRandom": "0xb026dfda660045d2e5f7fa93ce2b9820403e83582c5d5721514e105ba4411b68",
+      "currentTimestamp": "0x69dfead6"
+    },
+    "pre": {
+      "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+        "balance": "0xde0b6b3a7640000",
+        "nonce": "0x0",
+        "code": "0x",
+        "storage": {}
+      }
+    },
+    "post": {
+      "Prague": [
+        {
+          "hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "indexes": {
+            "data": 0,
+            "gas": 0,
+            "value": 0
+          },
+          "logs": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+          "state": {}
+        }
+      ]
+    },
+    "transaction": {
+      "accessLists": [
+        []
+      ],
+      "data": [
+        "0xb7ab4db5"
+      ],
+      "gasLimit": [
+        "0xf4240"
+      ],
+      "gasPrice": "0x3b9aca07",
+      "maxFeePerGas": "0x3b9aca0e",
+      "maxPriorityFeePerGas": "0x3b9aca00",
+      "nonce": "0x0",
+      "sender": "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+      "value": [
+        "0x0"
+      ],
+      "secretKey": "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
+    }
+  }
+}

--- a/evm-e2e/src/fixtures.rs
+++ b/evm-e2e/src/fixtures.rs
@@ -25,6 +25,7 @@ mod fluent_testnet {
         fn testnet_24363142_bridge_malformed_params_4("fixtures/testnet_24363142_bridge_malformed_params_4.json");
         fn testnet_24456528_bridge_double_mint("fixtures/testnet_24456528_bridge_double_mint.json");
         fn testnet_24457093_bridge_double_mint("fixtures/testnet_24457093_bridge_double_mint.json");
+        fn testnet_eth_call_b7ab4db5_malformed_builtin_params("fixtures/testnet_eth_call_b7ab4db5_malformed_builtin_params.json");
     }
 }
 
@@ -33,4 +34,77 @@ mod fluent_mainnet {
         fn mainnet_2697535_bridge_token_deployment("fixtures/mainnet_2697535_bridge_token_deployment.json");
         fn mainnet_2698630_bridge_token_deployment("fixtures/mainnet_2698630_bridge_token_deployment.json");
     }
+}
+
+#[test]
+fn eth_call_b7ab4db5_halts_with_malformed_builtin_params() {
+    use crate::{
+        runner::resolve_externalized_bytecodes,
+        state::{evm_cache_state, fill_tx_env, prepare_env},
+    };
+    use fluentbase_revm::{RwasmBuilder, RwasmContext};
+    use revm::{
+        context::result::ExecutionResult,
+        database::{EmptyDB, StateBuilder},
+        interpreter::InstructionResult,
+        ExecuteCommitEvm,
+    };
+    use revm_statetest_types::{SpecName, TestSuite};
+    use std::{fs, path::Path};
+
+    let path = Path::new("./fixtures/testnet_eth_call_b7ab4db5_malformed_builtin_params.json");
+    let mut fixture: serde_json::Value = serde_json::from_str(&fs::read_to_string(path).unwrap())
+        .expect("fixture should deserialize as json");
+    resolve_externalized_bytecodes(&mut fixture, path.parent().unwrap());
+    let suite: TestSuite = serde_json::from_value(fixture).expect("fixture should parse");
+    let (name, unit) = suite
+        .0
+        .into_iter()
+        .next()
+        .expect("fixture should contain one test");
+
+    let cache_state = evm_cache_state(&unit);
+    let (mut cfg_env, block_env, mut tx_env) = prepare_env(&unit, &name).unwrap();
+    cfg_env.chain_id = 20994;
+
+    let tests = unit
+        .post
+        .into_iter()
+        .find_map(|(spec_name, tests)| (spec_name == SpecName::Prague).then_some(tests))
+        .expect("fixture should define Prague expectations");
+    let test = tests
+        .into_iter()
+        .next()
+        .expect("fixture should contain one post");
+
+    cfg_env.spec = SpecName::Prague.to_spec_id();
+    fill_tx_env(&mut tx_env, &unit.transaction, &test);
+    tx_env.chain_id = Some(cfg_env.chain_id);
+
+    let mut cache = cache_state.clone();
+    cache.set_state_clear_flag(
+        cfg_env
+            .spec
+            .is_enabled_in(revm::primitives::hardfork::SpecId::SPURIOUS_DRAGON),
+    );
+    let state: revm::database::State<EmptyDB> = StateBuilder::default()
+        .with_cached_prestate(cache)
+        .with_bundle_update()
+        .build();
+    let mut evm = RwasmContext::new(state, cfg_env.spec)
+        .with_cfg(cfg_env)
+        .with_block(block_env)
+        .build_rwasm();
+    evm.0.cfg.legacy_bytecode_enabled = false;
+
+    let result = evm.transact_commit(tx_env);
+    let Ok(ExecutionResult::Halt { reason, .. }) = result else {
+        panic!("expected MalformedBuiltinParams halt, got {result:?}");
+    };
+    let instruction_result: InstructionResult = reason.into();
+    assert_eq!(
+        instruction_result,
+        InstructionResult::MalformedBuiltinParams,
+        "0xb7 is PUSH24 and the payload only supplies three immediate bytes"
+    );
 }

--- a/evm-e2e/src/fixtures.rs
+++ b/evm-e2e/src/fixtures.rs
@@ -52,10 +52,15 @@ fn eth_call_b7ab4db5_halts_with_malformed_builtin_params() {
     use revm_statetest_types::{SpecName, TestSuite};
     use std::{fs, path::Path};
 
-    let path = Path::new("./fixtures/testnet_eth_call_b7ab4db5_malformed_builtin_params.json");
-    let mut fixture: serde_json::Value = serde_json::from_str(&fs::read_to_string(path).unwrap())
-        .expect("fixture should deserialize as json");
-    resolve_externalized_bytecodes(&mut fixture, path.parent().unwrap());
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("fixtures/testnet_eth_call_b7ab4db5_malformed_builtin_params.json");
+    let mut fixture: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&path).expect("fixture should be readable"))
+            .expect("fixture should deserialize as json");
+    resolve_externalized_bytecodes(
+        &mut fixture,
+        path.parent().expect("fixture path should have a parent"),
+    );
     let suite: TestSuite = serde_json::from_value(fixture).expect("fixture should parse");
     let (name, unit) = suite
         .0


### PR DESCRIPTION
## Summary
- add a focused Fluent e2e fixture for the reported eth_call payload with data 0xb7ab4db5 and no to address
- register the fixture and add an explicit assertion that the local Fluent execution halts with MalformedBuiltinParams
- document in the fixture why the payload maps to create-style execution and fails: 0xb7 is PUSH24 with only three immediate bytes

## Tests
- cargo fmt --manifest-path ./evm-e2e/Cargo.toml --check
- cargo test --manifest-path ./evm-e2e/Cargo.toml testnet_eth_call_b7ab4db5_malformed_builtin_params --no-default-features --features std,wasmtime
- cargo test --manifest-path ./evm-e2e/Cargo.toml eth_call_b7ab4db5_halts_with_malformed_builtin_params --no-default-features --features std,wasmtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage for EVM call handling to ensure proper validation and error handling in the Prague fork.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->