### PR TITLE
fix(security): harden rwasm deploy and genesis loading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,6 @@ ark-ec = { version = "0.5", default-features = false }
 ark-ff = { version = "0.5", default-features = false }
 ark-serialize = { version = "0.5", default-features = false }
 k256 = { version = "0.13.4", default-features = false }
-libsecp256k1 = { version = "0.7", default-features = false }
 secp256k1 = { version = "0.31.0", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }
 

--- a/crates/node/src/utils.rs
+++ b/crates/node/src/utils.rs
@@ -5,6 +5,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
+const MAX_GENESIS_JSON_BYTES: u64 = 256 * 1024 * 1024;
+
 /// Downloads genesis from GitHub releases into `../genesis/` (sibling to this crate),
 /// caches it, and verifies its detached OpenPGP signature.
 ///
@@ -114,13 +116,20 @@ pub fn download_to(url: &str, path: &Path) -> eyre::Result<()> {
 fn read_genesis_from_gz(path: &Path) -> eyre::Result<Genesis> {
     use eyre::WrapErr as _;
     let gz = fs::read(path).wrap_err_with(|| format!("failed to read {}", path.display()))?;
-    let mut decoder = flate2::read::GzDecoder::new(&gz[..]);
-    let mut json = String::new();
+    let decoder = flate2::read::GzDecoder::new(&gz[..]);
+    let mut json = Vec::new();
     decoder
-        .read_to_string(&mut json)
+        .take(MAX_GENESIS_JSON_BYTES + 1)
+        .read_to_end(&mut json)
         .wrap_err("failed to decompress genesis gz")?;
+    if json.len() as u64 > MAX_GENESIS_JSON_BYTES {
+        eyre::bail!(
+            "genesis JSON exceeds {} byte decompressed limit",
+            MAX_GENESIS_JSON_BYTES
+        );
+    }
     let genesis =
-        serde_json::from_str::<Genesis>(&json).wrap_err("failed to parse genesis JSON")?;
+        serde_json::from_slice::<Genesis>(&json).wrap_err("failed to parse genesis JSON")?;
     Ok(genesis)
 }
 

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -143,7 +143,14 @@ pub(crate) fn run_rwasm_loop<CTX: ContextTr, INSP: Inspector<CTX>>(
         // - the rWasm module (prefix)
         // - constructor parameters (suffix)
         // Check `contracts/wasm/lib.rs` for more
-        let (rwasm_module, bytes_read) = RwasmModule::new(interpreter_result.output.as_ref());
+        let Ok((rwasm_module, bytes_read)) =
+            RwasmModule::new_checked(interpreter_result.output.as_ref())
+        else {
+            return Ok(NextAction::error(
+                ExitCode::MalformedBuiltinParams,
+                interpreter_result.gas,
+            ));
+        };
         let (rwasm_module_raw, constructor_params_raw) = (
             interpreter_result.output.slice(..bytes_read),
             interpreter_result.output.slice(bytes_read..),


### PR DESCRIPTION
## Summary
- Return `MalformedBuiltinParams` instead of panicking when delegated deployment output starts like rWasm but fails `RwasmModule::new_checked`.
- Cap decompressed genesis JSON reads at 256 MiB before parsing to avoid gzip-bomb style startup OOM.
- Remove unused workspace-level `libsecp256k1` dependency declaration.

## Notes
- I intentionally left the `EthVM` `Send`/`Sync` marker impls unchanged in this safe-subset PR. Removing them currently breaks the wasm contract global `Once<Mutex<HashMap<u32, EthVM>>>`; fixing that cleanly needs a separate state-cache redesign.
- I did not add a `cargo-deny` CI gate in this PR because the current tree has known advisory noise through `bins/runtime-upgrade`'s `ethers` stack (`ring 0.16`, `rustls 0.21`, `tungstenite 0.20`, `spin 0.5`). Adding an unverified gate here would likely create a red workflow unrelated to these code fixes.

## Verification
- `cargo fmt --check --package fluentbase-revm --package fluentbase-node --package fluentbase-evm`
- `cargo check -p fluentbase-revm -p fluentbase-node -p fluentbase-evm`

Linear: FLU-856


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cryptography dependencies to improve overall security posture and provide long-term maintenance and compatibility support.
* **Bug Fixes**
  * Added protective decompressed size limit for genesis configuration processing to mitigate potential resource exhaustion vulnerabilities.
  * Enhanced error detection and handling for malformed module parameters to prevent system failures and improve platform reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->