### PR TITLE
fix(ci): skip crates publish for prerelease tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   publish:
     name: Publish to crates.io
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) || (github.ref_type == 'tag' && !contains(github.ref_name, '-')) }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- skip the crates.io publish workflow for prerelease tags such as v1.3.0-rc.2
- keep manual dry-run validation available for prerelease refs

## Verification
- not run; workflow-only guard change