### PR TITLE
fix(ci): fetch tags for release changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -306,6 +306,9 @@ jobs:
       # This is necessary for generating the changelog.
       # It has to come before "Download Artifacts" or else it deletes the artifacts.
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: Download artifacts
         uses: actions/download-artifact@v8
       - name: Generate full changelog


### PR DESCRIPTION
## Summary
- fetch full history and tags in the release draft job before generating changelog
- fixes `git describe ... "^"` failing on shallow tag checkouts

## Verification
- workflow-only change; not run locally