### PR TITLE
fix(sdk): encode wasm panics as evm errors

### DIFF
--- a/crates/sdk/src/panic.rs
+++ b/crates/sdk/src/panic.rs
@@ -1,22 +1,26 @@
 #[cfg(target_arch = "wasm32")]
 #[cfg(not(feature = "fast-panic"))]
 pub unsafe fn handle_panic_info(info: &core::panic::PanicInfo) -> ! {
+    use crate::evm::write_evm_panic_message;
     use fluentbase_types::{ExitCode, NativeAPI, RwasmContext};
+
     let panic_message = alloc::format!("{}", info.message());
     let native_sdk = RwasmContext {};
-    native_sdk.write(panic_message.as_bytes());
+    write_evm_panic_message(&panic_message, |slice| native_sdk.write(slice));
     native_sdk.exit(ExitCode::Panic)
 }
 
 #[cfg(target_arch = "wasm32")]
 #[cfg(feature = "fast-panic")]
 pub unsafe fn handle_panic_info(info: &core::panic::PanicInfo) -> ! {
+    use crate::evm::write_evm_panic_message;
     use fluentbase_types::{ExitCode, NativeAPI, RwasmContext};
+
     let Some(message) = info.message().as_str() else {
         // TODO(dmitry123): "how to support multiline panic messages?"
         unreachable!("multiline or panic with args is not supported with fast-panic feature")
     };
     let native_sdk = RwasmContext {};
-    native_sdk.write(message.as_bytes());
+    write_evm_panic_message(message, |slice| native_sdk.write(slice));
     native_sdk.exit(ExitCode::Panic)
 }

--- a/e2e/src/helpers.rs
+++ b/e2e/src/helpers.rs
@@ -1,3 +1,4 @@
+use fluentbase_codec::SolidityABI;
 use fluentbase_sdk::{Address, Bytes, PRECOMPILE_UNIVERSAL_TOKEN_RUNTIME};
 // use fluentbase_svm::{
 //     account::AccountSharedData,
@@ -9,6 +10,17 @@ use fluentbase_sdk::{Address, Bytes, PRECOMPILE_UNIVERSAL_TOKEN_RUNTIME};
 use fluentbase_testing::{try_print_utf8_error, EvmTestingContext};
 use revm::context::result::ExecutionResult;
 // use solana_program_pack::Pack;
+
+pub fn decode_evm_error_string(output: &[u8]) -> String {
+    const ERROR_STRING_SELECTOR: [u8; 4] = [0x08, 0xc3, 0x79, 0xa0];
+    assert!(
+        output.starts_with(&ERROR_STRING_SELECTOR),
+        "expected Error(string) selector, got: 0x{}",
+        hex::encode(output)
+    );
+    SolidityABI::<String>::decode(&&output[ERROR_STRING_SELECTOR.len()..], 0)
+        .expect("decode Error(string) payload")
+}
 
 pub fn call_with_sig(
     ctx: &mut EvmTestingContext,

--- a/e2e/src/stateless.rs
+++ b/e2e/src/stateless.rs
@@ -1,4 +1,4 @@
-use core::str::from_utf8;
+use crate::helpers::decode_evm_error_string;
 use fluentbase_contracts::{
     FLUENTBASE_EXAMPLES_GREETING, FLUENTBASE_EXAMPLES_PANIC, FLUENTBASE_EXAMPLES_ROUTER_SOLIDITY,
     FLUENTBASE_EXAMPLES_RWASM, FLUENTBASE_EXAMPLES_TINY_KECCAK,
@@ -42,7 +42,7 @@ fn test_example_rwasm() {
 fn test_example_panic() {
     let (output, exit_code) =
         run_with_default_context(FLUENTBASE_EXAMPLES_PANIC.wasm_bytecode.to_vec(), &[]);
-    assert_eq!(from_utf8(&output[..]).unwrap(), "it's panic time",);
+    assert_eq!(decode_evm_error_string(&output), "it's panic time");
     assert_eq!(exit_code, -1);
 }
 

--- a/e2e/src/wasm.rs
+++ b/e2e/src/wasm.rs
@@ -1,4 +1,4 @@
-use crate::EvmTestingContextWithGenesis;
+use crate::{helpers::decode_evm_error_string, EvmTestingContextWithGenesis};
 use core::str::from_utf8;
 use fluentbase_codec::{bytes::BytesMut, SolidityABI};
 use fluentbase_contracts::{
@@ -177,7 +177,7 @@ fn test_wasm_panic() {
     );
     assert!(!result.is_success());
     let bytes = result.output().unwrap_or_default();
-    assert_eq!("it's panic time", from_utf8(&bytes[..]).unwrap());
+    assert_eq!("it's panic time", decode_evm_error_string(&bytes));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- encode SDK panic-handler output with the existing Solidity-compatible Error(string) ABI helper
- keep the existing ExitCode::Panic mapping so EVM callers continue to see a revert while receiving ABI-compatible return data

## Verification
- cargo check -p fluentbase-sdk
- cargo check -p fluentbase-sdk --target wasm32-unknown-unknown --no-default-features

Note: cargo fmt --check -p fluentbase-sdk currently reports an unrelated pre-existing format diff in crates/sdk/src/leb128.rs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved panic message handling by routing through a centralized mechanism for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->