### PR TITLE
feat(runtime-upgrade): support planned bulk upgrades

### DIFF
--- a/contracts/runtime-upgrade/README.md
+++ b/contracts/runtime-upgrade/README.md
@@ -1,2 +1,63 @@
 # Runtime Upgrade
 
+Privileged system contract for replacing Fluent runtime/system contract bytecode.
+Runtime upgrades are consensus-critical, so this contract keeps authorization and audit metadata
+explicit in calldata/events while the host still enforces the native upgrade syscall boundary.
+
+## Entry Points
+
+### `upgradeTo(address target, uint256 genesisHash, string genesisVersion, bytes wasmBytecode)`
+
+Owner-only direct upgrade path.
+
+The contract validates the submitted WASM bytes, compiles them to rWasm for `target`, invokes the
+native runtime-upgrade syscall, then emits `RuntimeUpgraded(target, genesisHash, genesisVersion,
+codeHash)`.
+
+### `recompile(address target)`
+
+Owner-only maintenance path for already deployed WASM bytecode.
+
+The contract reads bytecode from `target` with `code_size`/`code_copy`, requires the loaded length
+to match the reported size, recompiles the bytecode through the same install path as `upgradeTo`,
+and emits `ContractRecompiled(target, codeHash)`.
+
+### `planUpgrade(uint256 genesisHash, string genesisVersion, address[] targets, bytes32[] wasmHashes, address upgrador)`
+
+Owner-only planning path for release upgrades that should be executable by a delegated account.
+
+The plan stores parallel `(target, wasmHash)` pairs plus shared release metadata and a single
+authorized `upgrador`. The contract rejects empty plans, mismatched target/hash array lengths, zero
+targets, zero hashes, duplicate targets, and a zero upgrador.
+
+Target binding is intentional: approving a raw WASM hash alone would let the delegated upgrador
+install approved bytecode at the wrong system address. A planned upgrade is valid only for the exact
+target/hash pair approved by the owner.
+
+Calling `planUpgrade` replaces any previous plan.
+
+### `upgradeToPlanned(address target, bytes wasmBytecode)`
+
+Delegated execution path for planned upgrades.
+
+Only the stored `upgrador` can call this method. The contract hashes `wasmBytecode`, checks that
+`(target, keccak256(wasmBytecode))` exists in the current plan, runs the same compile/install path
+as `upgradeTo`, removes the consumed pair, and emits `RuntimeUpgraded`.
+
+Removing the pair prevents replaying the same planned target/hash entry after it has been installed.
+
+## Trust Model
+
+- `owner` can perform direct upgrades, recompile existing targets, and replace the current plan.
+- `upgrador` can execute only owner-approved target/hash pairs from the current plan.
+- Host-side syscall enforcement remains the final boundary: `SYSCALL_ID_UPGRADE_RUNTIME` must only
+  be reachable through the runtime-upgrade precompile execution path.
+
+## Operational Notes
+
+- Off-chain release tooling must hash the exact raw WASM bytes that will be submitted to
+  `upgradeToPlanned`.
+- Plans are release-scoped: `genesisHash` and `genesisVersion` are emitted audit metadata shared by
+  every planned entry.
+- Very large owner-submitted plans increase linear lookup cost during execution and quadratic
+  duplicate-target validation during planning. Keep plans bounded to the release batch.

--- a/contracts/runtime-upgrade/src/lib.rs
+++ b/contracts/runtime-upgrade/src/lib.rs
@@ -3,14 +3,15 @@
 
 extern crate alloc;
 
-use alloc::{borrow::Cow, string::String, vec};
+use alloc::{borrow::Cow, string::String, vec, vec::Vec};
 use fluentbase_sdk::{
     basic_entrypoint,
     codec::Codec,
     compile_rwasm_maybe_system,
+    crypto::crypto_keccak256,
     derive::{function_id, router, Contract, Event},
     hex,
-    storage::StorageAddress,
+    storage::{StorageAddress, StorageBytes32, StorageString, StorageVec},
     syscall::{encode, SYSCALL_ID_UPGRADE_RUNTIME},
     Address, Bytes, ContextReader, ExitCode, RwasmCompilationResult, SharedAPI, B256,
     DEFAULT_UPDATE_GENESIS_AUTH, STATE_MAIN, SYSTEM_ADDRESS, WASM_MAGIC_BYTES,
@@ -34,6 +35,16 @@ struct ContractRecompiled {
 }
 
 #[derive(Event)]
+struct UpgradePlanned {
+    #[indexed]
+    genesis_hash: B256,
+    genesis_version: String,
+    target_addresses: Vec<Address>,
+    wasm_code_hashes: Vec<B256>,
+    upgrador: Address,
+}
+
+#[derive(Event)]
 struct OwnerChanged {
     new_owner: Address,
 }
@@ -42,6 +53,11 @@ struct OwnerChanged {
 struct App<SDK> {
     sdk: SDK,
     owner: StorageAddress,
+    planned_genesis_hash: StorageBytes32,
+    planned_genesis_version: StorageString,
+    planned_upgrador: StorageAddress,
+    planned_target_addresses: StorageVec<StorageAddress>,
+    planned_wasm_hashes: StorageVec<StorageBytes32>,
 }
 
 trait RuntimeUpgradeTr {
@@ -56,6 +72,19 @@ trait RuntimeUpgradeTr {
 
     /// Recompile already deployed WASM runtime smart contract
     fn recompile(&mut self, target_address: Address);
+
+    /// Plan a bulk runtime upgrade.
+    fn plan_upgrade(
+        &mut self,
+        genesis_hash: B256,
+        genesis_version: String,
+        target_addresses: Vec<Address>,
+        wasm_code_hashes: Vec<B256>,
+        upgrador: Address,
+    );
+
+    /// Upgrade WASM runtime smart contract using a previously planned target/hash pair.
+    fn upgrade_to_planned(&mut self, target_address: Address, wasm_bytecode: Bytes);
 
     /// Change contract owner
     fn change_owner(&mut self, new_owner: Address);
@@ -114,6 +143,104 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
         let code_hash = self.compile_and_install(target_address, wasm_bytecode);
         ContractRecompiled {
             target_address,
+            code_hash,
+        }
+        .emit(&mut self.sdk)
+        .unwrap();
+    }
+
+    #[function_id("planUpgrade(uint256,string,address[],bytes32[],address)")]
+    fn plan_upgrade(
+        &mut self,
+        genesis_hash: B256,
+        genesis_version: String,
+        target_addresses: Vec<Address>,
+        wasm_code_hashes: Vec<B256>,
+        upgrador: Address,
+    ) {
+        _ = self.only_owner();
+        if wasm_code_hashes.is_empty() {
+            panic!("runtime-upgrade: empty upgrade plan");
+        }
+        if target_addresses.len() != wasm_code_hashes.len() {
+            panic!("runtime-upgrade: mismatched upgrade plan");
+        }
+        if upgrador == Address::ZERO {
+            panic!("runtime-upgrade: planned upgrador is zero address");
+        }
+
+        for (index, (target_address, wasm_code_hash)) in target_addresses
+            .iter()
+            .copied()
+            .zip(wasm_code_hashes.iter().copied())
+            .enumerate()
+        {
+            if target_address == Address::ZERO {
+                panic!("runtime-upgrade: planned target is zero address");
+            }
+            if wasm_code_hash == B256::ZERO {
+                panic!("runtime-upgrade: planned hash is zero");
+            }
+            if target_addresses[..index].contains(&target_address) {
+                panic!("runtime-upgrade: duplicate planned target");
+            }
+        }
+
+        self.clear_planned_hashes();
+        self.planned_genesis_hash_accessor()
+            .set(&mut self.sdk, genesis_hash);
+        self.planned_genesis_version_accessor()
+            .set(&mut self.sdk, &genesis_version);
+        self.planned_upgrador_accessor()
+            .set(&mut self.sdk, upgrador);
+
+        for (target_address, wasm_code_hash) in target_addresses
+            .iter()
+            .copied()
+            .zip(wasm_code_hashes.iter().copied())
+        {
+            self.planned_target_addresses_accessor()
+                .push(&mut self.sdk, target_address);
+            self.planned_wasm_hashes_accessor()
+                .push(&mut self.sdk, wasm_code_hash);
+        }
+
+        UpgradePlanned {
+            genesis_hash,
+            genesis_version,
+            target_addresses,
+            wasm_code_hashes,
+            upgrador,
+        }
+        .emit(&mut self.sdk)
+        .unwrap();
+    }
+
+    #[function_id("upgradeToPlanned(address,bytes)")]
+    fn upgrade_to_planned(&mut self, target_address: Address, wasm_bytecode: Bytes) {
+        let upgrador = self.planned_upgrador_accessor().get(&self.sdk);
+        if upgrador == Address::ZERO {
+            panic!("runtime-upgrade: no planned upgrade");
+        }
+        let caller = self.sdk.context().contract_caller();
+        if caller != upgrador {
+            panic!("runtime-upgrade: incorrect planned upgrador");
+        }
+
+        let wasm_code_hash = crypto_keccak256(wasm_bytecode.as_ref());
+        if !self.has_planned_upgrade(target_address, wasm_code_hash) {
+            panic!("runtime-upgrade: unplanned wasm hash");
+        }
+
+        let genesis_hash = self.planned_genesis_hash_accessor().get(&self.sdk);
+        let genesis_version = self.planned_genesis_version_accessor().get(&self.sdk);
+        let code_hash = self.compile_and_install(target_address, wasm_bytecode);
+        self.remove_planned_upgrade(target_address, wasm_code_hash);
+
+        RuntimeUpgraded {
+            target_address,
+            genesis_hash,
+            genesis_version,
             code_hash,
         }
         .emit(&mut self.sdk)
@@ -184,6 +311,52 @@ impl<SDK: SharedAPI> App<SDK> {
         code_hash
     }
 
+    fn clear_planned_hashes(&mut self) {
+        self.planned_target_addresses_accessor()
+            .clear(&mut self.sdk);
+        self.planned_wasm_hashes_accessor().clear(&mut self.sdk);
+    }
+
+    fn has_planned_upgrade(&self, target_address: Address, wasm_code_hash: B256) -> bool {
+        let planned_target_addresses = self.planned_target_addresses_accessor();
+        let planned_wasm_hashes = self.planned_wasm_hashes_accessor();
+        let hashes_len = planned_wasm_hashes.len(&self.sdk);
+        for index in 0..hashes_len {
+            if planned_target_addresses.at(index).get(&self.sdk) == target_address
+                && planned_wasm_hashes.at(index).get(&self.sdk) == wasm_code_hash
+            {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn remove_planned_upgrade(&mut self, target_address: Address, wasm_code_hash: B256) {
+        let planned_target_addresses = self.planned_target_addresses_accessor();
+        let planned_wasm_hashes = self.planned_wasm_hashes_accessor();
+        let hashes_len = planned_wasm_hashes.len(&self.sdk);
+        for index in 0..hashes_len {
+            if planned_target_addresses.at(index).get(&self.sdk) != target_address
+                || planned_wasm_hashes.at(index).get(&self.sdk) != wasm_code_hash
+            {
+                continue;
+            }
+
+            let last_index = hashes_len - 1;
+            if index != last_index {
+                let last_target = planned_target_addresses.at(last_index).get(&self.sdk);
+                let last_hash = planned_wasm_hashes.at(last_index).get(&self.sdk);
+                planned_target_addresses
+                    .at(index)
+                    .set(&mut self.sdk, last_target);
+                planned_wasm_hashes.at(index).set(&mut self.sdk, last_hash);
+            }
+            _ = planned_target_addresses.pop(&mut self.sdk);
+            _ = planned_wasm_hashes.pop(&mut self.sdk);
+            break;
+        }
+    }
+
     fn only_owner(&self) -> Address {
         let mut owner = self.owner_accessor().get(&self.sdk);
         if owner == Address::ZERO {
@@ -206,8 +379,44 @@ basic_entrypoint!(App);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fluentbase_sdk::{address, bytes, ContractContextV1, B256};
+    use fluentbase_sdk::{address, bytes, ContractContextV1, ExitCode, B256};
     use fluentbase_testing::TestingContextImpl;
+
+    struct Harness {
+        sdk: TestingContextImpl,
+    }
+
+    impl Harness {
+        fn new() -> Self {
+            Self {
+                sdk: TestingContextImpl::default().with_contract_context(ContractContextV1 {
+                    gas_limit: 120_000,
+                    ..Default::default()
+                }),
+            }
+        }
+
+        fn set_caller(&mut self, caller: Address) {
+            self.sdk.context_mut().caller = caller;
+        }
+
+        fn call<I: Into<Bytes>>(&mut self, input: I) -> ExitCode {
+            self.sdk = core::mem::take(&mut self.sdk).with_input(input.into());
+            let storage_before_call = self.sdk.dump_storage();
+            let mut app = App::new(core::mem::take(&mut self.sdk));
+            let exit_code =
+                match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| app.main())) {
+                    Ok(_) => ExitCode::Ok,
+                    Err(_) => ExitCode::Panic,
+                };
+            self.sdk = app.sdk;
+            if !exit_code.is_ok() {
+                self.sdk.restore_storage(storage_before_call);
+            }
+            _ = self.sdk.take_output();
+            exit_code
+        }
+    }
 
     #[test]
     fn test_upgrade_to_encoding() {
@@ -252,6 +461,49 @@ mod tests {
     }
 
     #[test]
+    fn test_plan_upgrade_encoding() {
+        let genesis_hash = B256::from([0xab; 32]);
+        let genesis_version = "v1.0.0".to_string();
+        let target_addresses = vec![
+            address!("2222222222222222222222222222222222222222"),
+            address!("3333333333333333333333333333333333333333"),
+        ];
+        let wasm_code_hashes = vec![B256::from([0x11; 32]), B256::from([0x22; 32])];
+        let upgrador = address!("1111111111111111111111111111111111111111");
+
+        let call = PlanUpgradeCall::new((
+            genesis_hash,
+            genesis_version.clone(),
+            target_addresses.clone(),
+            wasm_code_hashes.clone(),
+            upgrador,
+        ));
+        let encoded = call.encode();
+
+        assert!(encoded.len() >= 4);
+        let decoded = PlanUpgradeCall::decode(&&encoded[4..]).expect("failed to decode");
+        assert_eq!(decoded.0 .0, genesis_hash, "genesis_hash mismatch");
+        assert_eq!(decoded.0 .1, genesis_version, "genesis_version mismatch");
+        assert_eq!(decoded.0 .2, target_addresses, "target_addresses mismatch");
+        assert_eq!(decoded.0 .3, wasm_code_hashes, "wasm_code_hashes mismatch");
+        assert_eq!(decoded.0 .4, upgrador, "upgrador mismatch");
+    }
+
+    #[test]
+    fn test_upgrade_to_planned_encoding() {
+        let target = address!("2222222222222222222222222222222222222222");
+        let wasm_bytecode = Bytes::from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00].as_ref());
+
+        let call = UpgradeToPlannedCall::new((target, wasm_bytecode.clone()));
+        let encoded = call.encode();
+
+        assert!(encoded.len() >= 4);
+        let decoded = UpgradeToPlannedCall::decode(&&encoded[4..]).expect("failed to decode");
+        assert_eq!(decoded.0 .0, target, "target_address mismatch");
+        assert_eq!(decoded.0 .1, wasm_bytecode, "wasm_bytecode mismatch");
+    }
+
+    #[test]
     fn test_upgrade_and_recompile_event_signatures_are_distinct() {
         assert_eq!(
             RuntimeUpgraded::SIGNATURE,
@@ -262,5 +514,29 @@ mod tests {
             "ContractRecompiled(address,bytes32)"
         );
         assert_ne!(RuntimeUpgraded::SELECTOR, ContractRecompiled::SELECTOR);
+    }
+
+    #[test]
+    fn test_planned_upgrade_rejects_same_hash_for_wrong_target() {
+        let planned_target = address!("2222222222222222222222222222222222222222");
+        let wrong_target = address!("3333333333333333333333333333333333333333");
+        let upgrador = address!("1111111111111111111111111111111111111111");
+        let wasm_bytecode = Bytes::from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00].as_ref());
+        let wasm_code_hash = crypto_keccak256(wasm_bytecode.as_ref());
+
+        let mut h = Harness::new();
+        h.set_caller(DEFAULT_UPDATE_GENESIS_AUTH);
+        let plan_call = PlanUpgradeCall::new((
+            B256::from([0xab; 32]),
+            "v1.0.0".to_string(),
+            vec![planned_target],
+            vec![wasm_code_hash],
+            upgrador,
+        ));
+        assert_eq!(h.call(plan_call.encode()), ExitCode::Ok);
+
+        h.set_caller(upgrador);
+        let upgrade_call = UpgradeToPlannedCall::new((wrong_target, wasm_bytecode));
+        assert_ne!(h.call(upgrade_call.encode()), ExitCode::Ok);
     }
 }

--- a/contracts/runtime-upgrade/src/lib.rs
+++ b/contracts/runtime-upgrade/src/lib.rs
@@ -73,7 +73,10 @@ trait RuntimeUpgradeTr {
     /// Recompile already deployed WASM runtime smart contract
     fn recompile(&mut self, target_address: Address);
 
-    /// Plan a bulk runtime upgrade.
+    /// Plan a bulk runtime upgrade as exact target/hash pairs.
+    ///
+    /// The target address is part of the authorization boundary: approving only a WASM hash would
+    /// let the delegated upgrader install approved bytecode at the wrong system address.
     fn plan_upgrade(
         &mut self,
         genesis_hash: B256,
@@ -169,6 +172,8 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
             panic!("runtime-upgrade: planned upgrador is zero address");
         }
 
+        // Validate the whole replacement plan before clearing the previous one. The runtime should
+        // never persist a partial plan if one entry is malformed.
         for (index, (target_address, wasm_code_hash)) in target_addresses
             .iter()
             .copied()
@@ -235,6 +240,7 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
         let genesis_hash = self.planned_genesis_hash_accessor().get(&self.sdk);
         let genesis_version = self.planned_genesis_version_accessor().get(&self.sdk);
         let code_hash = self.compile_and_install(target_address, wasm_bytecode);
+        // Consume the exact target/hash pair so a planned upgrade cannot be replayed.
         self.remove_planned_upgrade(target_address, wasm_code_hash);
 
         RuntimeUpgraded {

--- a/docs/06-runtime-upgrade.md
+++ b/docs/06-runtime-upgrade.md
@@ -19,6 +19,8 @@ Upgrade contract exposes:
 
 - `upgradeTo(...)`
 - `recompile(...)`
+- `planUpgrade(...)`
+- `upgradeToPlanned(...)`
 - `changeOwner(...)`
 - `owner()`
 - `renounceOwnership()`
@@ -29,6 +31,12 @@ Key behavior:
   original WASM bytes, recompiles it to rWasm, and then uses the same upgrade syscall path as
   `upgradeTo(...)`,
 - `upgradeTo(...)` emits `RuntimeUpgraded`, while `recompile(...)` emits `ContractRecompiled`,
+- `planUpgrade(...)` lets the owner pre-authorize a release batch as exact `(target, raw WASM
+  hash)` pairs plus release metadata and an authorized upgrador,
+- `upgradeToPlanned(...)` can be called only by that upgrador and only for a stored target/hash
+  pair; the pair is removed after successful installation to prevent replay,
+- planned upgrades bind hashes to target addresses so a delegated upgrader cannot reuse approved
+  bytecode against the wrong system contract,
 - zero owner assignment is rejected by `changeOwner`,
 - renounce sets owner to system address,
 - default owner fallback is defined for unset state.
@@ -63,6 +71,7 @@ Treat it as compatibility debt, not target architecture.
 For real upgrades:
 
 - produce deterministic build artifacts,
+- publish target-address-to-WASM-hash pairs for planned releases,
 - use multisig/operator quorum controls,
 - roll out to all nodes coherently,
 - verify post-upgrade code hash and runtime behavior,


### PR DESCRIPTION
## Summary
- add a planned bulk runtime-upgrade flow with `planUpgrade(uint256,string,bytes32[],address)` and `UpgradePlanned`
- add `upgradeToPlanned(address,bytes)` with planned raw WASM hash checks, upgrador authorization, and remove-after-use behavior
- keep the existing direct `upgradeTo(...)` path and share its install/event logic

## Tests
- `cargo fmt --check --manifest-path contracts/Cargo.toml --package fluentbase-contracts-runtime-upgrade`
- `cargo test --manifest-path contracts/Cargo.toml --package fluentbase-contracts-runtime-upgrade`

Linear: FLU-873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a two-step planned runtime upgrade flow enabling batch approval and staged deployment of WASM code.
  * Introduced new upgrade execution capability that validates pre-approved code and upgrader authorization before deploying.

* **Tests**
  * Added encoding round-trip tests for upgrade planning and execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->