### PR TITLE
feat(runtime-upgrade): emit Safe transaction bundles

### DIFF
--- a/bins/runtime-upgrade/main.rs
+++ b/bins/runtime-upgrade/main.rs
@@ -79,14 +79,6 @@ struct Args {
     /// If set: write Safe Transaction Builder JSON and DO NOT sign or broadcast.
     #[arg(long, value_name = "PATH", conflicts_with = "print_raw_tx")]
     safe_bundle: Option<PathBuf>,
-
-    /// Use legacy upgrade mode
-    #[arg(long, default_value_t = false)]
-    force_legacy: bool,
-
-    /// Use legacy upgrade mode
-    #[arg(long, default_value_t = false)]
-    legacy_prefix: bool,
 }
 
 struct PreparedUpgradeTx {
@@ -95,7 +87,6 @@ struct PreparedUpgradeTx {
     to: Address,
     data: Vec<u8>,
     gas_limit: Option<u64>,
-    legacy: bool,
 }
 
 #[derive(Serialize)]
@@ -286,15 +277,14 @@ fn write_safe_bundle(
         .iter()
         .map(|tx| {
             format!(
-                "{}: contract={}, to={}, data_bytes={}, gas_limit={}, legacy={}",
+                "{}: contract={}, to={}, data_bytes={}, gas_limit={}",
                 tx.contract_key,
                 address_hex(tx.contract),
                 address_hex(tx.to),
                 tx.data.len(),
                 tx.gas_limit
                     .map(|gas| gas.to_string())
-                    .unwrap_or_else(|| "unset".to_string()),
-                tx.legacy
+                    .unwrap_or_else(|| "unset".to_string())
             )
         })
         .collect::<Vec<_>>()
@@ -463,17 +453,6 @@ async fn main() -> Result<()> {
         )))
     };
 
-    let runtime_upgrade_bytecode = provider
-        .get_code(
-            NameOrAddress::Address((*PRECOMPILE_RUNTIME_UPGRADE.0).into()),
-            None,
-        )
-        .await?;
-    let mut is_legacy_upgrade_scheme = runtime_upgrade_bytecode.is_empty();
-    if args.force_legacy {
-        is_legacy_upgrade_scheme = true;
-    }
-
     let mut prepared_txs = Vec::new();
     for contract in upgrade_list {
         print!("Upgrading contract {}... ", contract);
@@ -499,62 +478,37 @@ async fn main() -> Result<()> {
             continue;
         }
 
-        let mut data = vec![];
-        if is_legacy_upgrade_scheme {
-            data.extend_from_slice(&[0x69, 0xbc, 0x6f, 0x65]);
-            data.extend_from_slice(&new_rwasm.hint_section);
-        } else {
-            data.extend_from_slice(&UPDATE_GENESIS_PREFIX);
-            let mut buffer = BytesMut::new();
-            if args.legacy_prefix {
-                SolidityABI::<(Address, B256, String, Bytes)>::encode(
-                    &(
-                        contract,
-                        genesis_hash,
-                        args.genesis.clone(),
-                        Bytes::copy_from_slice(&new_rwasm.hint_section),
-                    ),
-                    &mut buffer,
-                    0,
-                )
-                .unwrap();
-            } else {
-                SolidityABI::<(Address, B256, String, Bytes)>::encode_function_args(
-                    &(
-                        contract,
-                        genesis_hash,
-                        args.genesis.clone(),
-                        Bytes::copy_from_slice(&new_rwasm.hint_section),
-                    ),
-                    &mut buffer,
-                )
-                .unwrap();
-            }
-            let buffer = buffer.freeze();
-            data.extend_from_slice(buffer.as_ref());
-        }
-
-        let send_to = if is_legacy_upgrade_scheme {
-            contract
-        } else {
-            PRECOMPILE_RUNTIME_UPGRADE
-        };
+        let mut data = Vec::from(UPDATE_GENESIS_PREFIX);
+        let mut buffer = BytesMut::new();
+        SolidityABI::<(Address, B256, String, Bytes)>::encode_function_args(
+            &(
+                contract,
+                genesis_hash,
+                args.genesis.clone(),
+                Bytes::copy_from_slice(&new_rwasm.hint_section),
+            ),
+            &mut buffer,
+        )
+        .unwrap();
+        let buffer = buffer.freeze();
+        data.extend_from_slice(buffer.as_ref());
 
         if args.safe_bundle.is_some() {
             prepared_txs.push(PreparedUpgradeTx {
                 contract_key: contract_key_for(&contracts, contract).to_string(),
                 contract,
-                to: send_to,
+                to: PRECOMPILE_RUNTIME_UPGRADE,
                 data,
                 gas_limit: args.gas_limit,
-                legacy: is_legacy_upgrade_scheme,
             });
             println!("SAFE_BUNDLE_QUEUED");
             continue;
         }
 
         let mut tx = TransactionRequest::new()
-            .to(NameOrAddress::Address((*send_to.0).into()))
+            .to(NameOrAddress::Address(
+                (*PRECOMPILE_RUNTIME_UPGRADE.0).into(),
+            ))
             .data(data);
         if let Some(gas_limit) = args.gas_limit {
             tx = tx.gas(gas_limit);

--- a/bins/runtime-upgrade/main.rs
+++ b/bins/runtime-upgrade/main.rs
@@ -46,7 +46,7 @@ struct Args {
     #[arg(long)]
     gas_limit: Option<u64>,
 
-    /// Contract key name (e.g. EVM_RUNTIME) from CONTRACTS_TO_UPGRADE.
+    /// Contract key name (e.g. PRECOMPILE_EVM_RUNTIME) from CONTRACTS_TO_UPGRADE.
     /// If omitted, upgrades all known contracts (with a prompt).
     #[arg(long)]
     contract: Option<String>,

--- a/bins/runtime-upgrade/main.rs
+++ b/bins/runtime-upgrade/main.rs
@@ -25,12 +25,14 @@ use reth_chainspec::{
 };
 use rpassword::read_password;
 use rwasm::RwasmModule;
+use serde::Serialize;
 use std::{
     collections::HashMap,
     fs,
     io::{Read, Write},
-    path::Path,
+    path::{Path, PathBuf},
     sync::LazyLock,
+    time::{SystemTime, UNIX_EPOCH},
 };
 
 #[derive(Parser, Debug)]
@@ -74,6 +76,10 @@ struct Args {
     #[arg(long)]
     print_raw_tx: bool,
 
+    /// If set: write Safe Transaction Builder JSON and DO NOT sign or broadcast.
+    #[arg(long, value_name = "PATH", conflicts_with = "print_raw_tx")]
+    safe_bundle: Option<PathBuf>,
+
     /// Use legacy upgrade mode
     #[arg(long, default_value_t = false)]
     force_legacy: bool,
@@ -81,6 +87,50 @@ struct Args {
     /// Use legacy upgrade mode
     #[arg(long, default_value_t = false)]
     legacy_prefix: bool,
+}
+
+struct PreparedUpgradeTx {
+    contract_key: String,
+    contract: Address,
+    to: Address,
+    data: Vec<u8>,
+    gas_limit: Option<u64>,
+    legacy: bool,
+}
+
+#[derive(Serialize)]
+struct SafeBundle {
+    version: &'static str,
+    #[serde(rename = "chainId")]
+    chain_id: String,
+    #[serde(rename = "createdAt")]
+    created_at: u128,
+    meta: SafeBundleMeta,
+    transactions: Vec<SafeBundleTransaction>,
+}
+
+#[derive(Serialize)]
+struct SafeBundleMeta {
+    name: String,
+    description: String,
+    #[serde(rename = "txBuilderVersion")]
+    tx_builder_version: String,
+    #[serde(rename = "createdFromSafeAddress")]
+    created_from_safe_address: String,
+    #[serde(rename = "createdFromOwnerAddress")]
+    created_from_owner_address: String,
+    checksum: String,
+}
+
+#[derive(Serialize)]
+struct SafeBundleTransaction {
+    to: String,
+    value: &'static str,
+    data: String,
+    #[serde(rename = "contractMethod")]
+    contract_method: Option<serde_json::Value>,
+    #[serde(rename = "contractInputsValues")]
+    contract_inputs_values: Option<serde_json::Value>,
 }
 
 fn contracts_to_upgrade() -> HashMap<&'static str, Address> {
@@ -206,6 +256,88 @@ fn strip_0x(s: &str) -> &str {
     s.strip_prefix("0x").unwrap_or(s)
 }
 
+fn ethers_address(address: Address) -> ethers::types::Address {
+    (*address.0).into()
+}
+
+fn address_hex(address: Address) -> String {
+    format!("{:#x}", ethers_address(address))
+}
+
+fn contract_key_for(contracts: &HashMap<&'static str, Address>, contract: Address) -> &'static str {
+    contracts
+        .iter()
+        .find_map(|(key, address)| (*address == contract).then_some(*key))
+        .unwrap_or("UNKNOWN")
+}
+
+fn write_safe_bundle(
+    path: &Path,
+    genesis_version: &str,
+    genesis_hash: B256,
+    chain_id: u64,
+    prepared_txs: &[PreparedUpgradeTx],
+) -> Result<()> {
+    let created_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock before UNIX_EPOCH")?
+        .as_millis();
+    let metadata = prepared_txs
+        .iter()
+        .map(|tx| {
+            format!(
+                "{}: contract={}, to={}, data_bytes={}, gas_limit={}, legacy={}",
+                tx.contract_key,
+                address_hex(tx.contract),
+                address_hex(tx.to),
+                tx.data.len(),
+                tx.gas_limit
+                    .map(|gas| gas.to_string())
+                    .unwrap_or_else(|| "unset".to_string()),
+                tx.legacy
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let description = format!(
+        "Fluent runtime upgrade bundle\nGenesis version: {}\nGenesis hash: {}\nTransactions:\n{}",
+        genesis_version, genesis_hash, metadata
+    );
+    let transactions = prepared_txs
+        .iter()
+        .map(|tx| SafeBundleTransaction {
+            to: address_hex(tx.to),
+            value: "0",
+            data: format!("0x{}", hex::encode(&tx.data)),
+            contract_method: None,
+            contract_inputs_values: None,
+        })
+        .collect();
+    let bundle = SafeBundle {
+        version: "1.0",
+        chain_id: chain_id.to_string(),
+        created_at,
+        meta: SafeBundleMeta {
+            name: format!("Fluent runtime upgrade {}", genesis_version),
+            description,
+            tx_builder_version: "1.18.0".to_string(),
+            created_from_safe_address: String::new(),
+            created_from_owner_address: String::new(),
+            checksum: String::new(),
+        },
+        transactions,
+    };
+    let json = serde_json::to_string_pretty(&bundle).context("serializing Safe bundle")?;
+    if path == Path::new("-") {
+        println!("{}", json);
+    } else {
+        fs::write(path, format!("{}\n", json))
+            .with_context(|| format!("writing Safe bundle {}", path.display()))?;
+        println!("SAFE_BUNDLE={}", path.display());
+    }
+    Ok(())
+}
+
 fn load_wallet(args: &Args) -> Result<LocalWallet> {
     // Priority: CLI flag -> env -> prompt (hidden)
     let pk = if let Some(pk) = args.private_key.as_deref() {
@@ -310,10 +442,6 @@ async fn main() -> Result<()> {
         }
     };
 
-    // Wallet from a private key
-    let wallet = load_wallet(&args)?;
-    println!("Wallet loaded ({})", wallet.address());
-
     let rpc = pick_rpc(&args)?;
     let provider = Provider::<Http>::try_from(rpc).context("creating provider")?;
 
@@ -323,9 +451,17 @@ async fn main() -> Result<()> {
         .context("get_chainid")?
         .as_u64();
 
-    let wallet = wallet.with_chain_id(chain_id);
-    let signer = SignerMiddleware::new(provider.clone(), wallet);
-    let signer = std::sync::Arc::new(signer);
+    let signer = if args.safe_bundle.is_some() {
+        None
+    } else {
+        let wallet = load_wallet(&args)?;
+        println!("Wallet loaded ({})", wallet.address());
+        let wallet = wallet.with_chain_id(chain_id);
+        Some(std::sync::Arc::new(SignerMiddleware::new(
+            provider.clone(),
+            wallet,
+        )))
+    };
 
     let runtime_upgrade_bytecode = provider
         .get_code(
@@ -338,6 +474,7 @@ async fn main() -> Result<()> {
         is_legacy_upgrade_scheme = true;
     }
 
+    let mut prepared_txs = Vec::new();
     for contract in upgrade_list {
         print!("Upgrading contract {}... ", contract);
         std::io::stdout().flush().ok();
@@ -402,6 +539,20 @@ async fn main() -> Result<()> {
         } else {
             PRECOMPILE_RUNTIME_UPGRADE
         };
+
+        if args.safe_bundle.is_some() {
+            prepared_txs.push(PreparedUpgradeTx {
+                contract_key: contract_key_for(&contracts, contract).to_string(),
+                contract,
+                to: send_to,
+                data,
+                gas_limit: args.gas_limit,
+                legacy: is_legacy_upgrade_scheme,
+            });
+            println!("SAFE_BUNDLE_QUEUED");
+            continue;
+        }
+
         let mut tx = TransactionRequest::new()
             .to(NameOrAddress::Address((*send_to.0).into()))
             .data(data);
@@ -411,6 +562,9 @@ async fn main() -> Result<()> {
 
         if args.print_raw_tx {
             let mut typed: TypedTransaction = tx.into();
+            let signer = signer
+                .as_ref()
+                .expect("signer must exist outside Safe mode");
             signer
                 .fill_transaction(&mut typed, None)
                 .await
@@ -426,6 +580,9 @@ async fn main() -> Result<()> {
         }
 
         // Normal path: broadcast
+        let signer = signer
+            .as_ref()
+            .expect("signer must exist outside Safe mode");
         match signer.send_transaction(tx, None).await {
             Ok(pending) => {
                 let tx_hash = *pending;
@@ -467,6 +624,10 @@ async fn main() -> Result<()> {
                 new_rwasm.hint_section.len()
             );
         }
+    }
+
+    if let Some(path) = args.safe_bundle.as_deref() {
+        write_safe_bundle(path, &args.genesis, genesis_hash, chain_id, &prepared_txs)?;
     }
 
     Ok(())

--- a/docs/06-runtime-upgrade.md
+++ b/docs/06-runtime-upgrade.md
@@ -66,6 +66,72 @@ Treat it as compatibility debt, not target architecture.
 
 ---
 
+## Runtime-upgrade CLI
+
+The `runtime-upgrade` CLI prepares upgrade transactions from a Fluentbase release genesis file.
+It downloads `genesis-<release-tag>.json.gz`, extracts the target WASM bytecode, compares it with
+the current chain state, and builds calls to the runtime-upgrade precompile.
+
+The CLI always uses the runtime-upgrade precompile path:
+
+- transaction `to` is `PRECOMPILE_RUNTIME_UPGRADE`,
+- calldata is `UPDATE_GENESIS_PREFIX` followed by ABI-encoded
+  `(target, genesisHash, genesisVersion, wasmBytecode)`,
+- legacy direct-to-target upgrade calldata is not supported.
+
+Build the CLI before use:
+
+```bash
+cargo build -p fluentbase-runtime-upgrade --bin runtime-upgrade
+```
+
+Generate a Safe Transaction Builder bundle without signing or broadcasting:
+
+```bash
+cargo run -p fluentbase-runtime-upgrade --bin runtime-upgrade -- \
+  --genesis <release-tag> \
+  --test \
+  --contract PRECOMPILE_EVM_RUNTIME \
+  --safe-bundle /tmp/runtime-upgrade.json
+```
+
+Use `--dev` for devnet, `--test` for testnet, `--local` for `http://localhost:8545`, or
+`--rpc <url>` for a custom endpoint. To prepare every known contract, omit `--contract` and confirm
+the prompt:
+
+```bash
+cargo run -p fluentbase-runtime-upgrade --bin runtime-upgrade -- \
+  --genesis <release-tag> \
+  --test \
+  --safe-bundle /tmp/runtime-upgrade-all.json
+```
+
+Print a signed raw transaction instead of broadcasting. The signer comes from `--private-key`,
+`PRIVATE_KEY`, or an interactive hidden prompt:
+
+```bash
+PRIVATE_KEY=<hex-private-key> \
+cargo run -p fluentbase-runtime-upgrade --bin runtime-upgrade -- \
+  --genesis <release-tag> \
+  --test \
+  --contract PRECOMPILE_EVM_RUNTIME \
+  --print-raw-tx
+```
+
+Broadcast directly only after validating the generated transaction data and signer:
+
+```bash
+PRIVATE_KEY=<hex-private-key> \
+cargo run -p fluentbase-runtime-upgrade --bin runtime-upgrade -- \
+  --genesis <release-tag> \
+  --test \
+  --contract PRECOMPILE_EVM_RUNTIME
+```
+
+Use `--gas-limit <gas>` when the target network requires an explicit gas limit.
+
+---
+
 ## Operational expectations
 
 For real upgrades:


### PR DESCRIPTION
## Summary
- add a `--safe-bundle <PATH>` mode for `runtime-upgrade` that writes Safe Transaction Builder JSON instead of loading a private key
- split changed-contract transaction preparation from signing/broadcasting for Safe output, while preserving raw tx and broadcast flows
- include chain ID, genesis version/hash, contract metadata, calldata, gas-limit metadata, and legacy-mode metadata in the generated bundle

## Verification
- `cargo fmt --check --package fluentbase-runtime-upgrade` passed (rustfmt emitted existing stable-channel warnings for unstable rustfmt settings)
- `cargo check -p fluentbase-runtime-upgrade` passed
- `cargo run -p fluentbase-runtime-upgrade -- --help | rg -n "safe-bundle|print-raw|private-key"` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Safe Transaction Builder JSON export mode for runtime-upgrade transactions.
  * When enabled, the CLI prepares upgrade transactions and writes a Safe-compatible bundle to a file or stdout (no signing/broadcasting).
  * Included per-contract details in the exported bundle, including optional gas limits.
* **Bug Fixes**
  * Improved signer initialization so it is only created for non-Safe execution paths.
* **Documentation**
  * Added a “Runtime-upgrade CLI” guide covering genesis-based upgrades, supported calldata approach, and relevant flags/options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->