### PR TITLE
fix(ci): keep rc builder images off latest

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -144,22 +144,31 @@ jobs:
           no-cache: true
 
       - name: Inspect image
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          REGISTRY: ${{ env.REGISTRY }}
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect "${REGISTRY}/${IMAGE_NAME}:${VERSION}"
 
       - name: Print summary
+        env:
+          GH_SHA: ${{ github.sha }}
+          RUST_TOOLCHAIN: ${{ env.RUST_TOOLCHAIN }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
           echo "### 🚀 Docker Image Published" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "| Property | Value |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| **Platform** | \`linux/amd64\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Rust** | \`${{ env.RUST_TOOLCHAIN }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **SDK Version** | \`${{ steps.meta.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **Commit** | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Rust** | \`${RUST_TOOLCHAIN}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **SDK Version** | \`${VERSION}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **Commit** | \`${GH_SHA}\` |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Available tags:**" >> $GITHUB_STEP_SUMMARY
-          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.meta.outputs.tags }}"
+          IFS=',' read -ra TAG_ARRAY <<< "${TAGS}"
           for tag in "${TAG_ARRAY[@]}"; do
             echo "- \`docker pull ${tag}\`" >> $GITHUB_STEP_SUMMARY
           done

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -97,11 +97,11 @@ jobs:
           fi
 
           PUSH_LATEST=false
-          if [[ "$IS_RC" != "true" ]] && { [[ "$EVENT" == "workflow_dispatch" && "${{ inputs.push_latest }}" == "true" ]] || [[ "$REF_TYPE" == "tag" ]]; }; then
+          if [[ "$IS_RC" != "true" ]] && { [[ "$EVENT" == "workflow_dispatch" && "${INPUT_PUSH_LATEST}" == "true" ]] || [[ "$REF_TYPE" == "tag" ]]; }; then
           PUSH_LATEST=true
           fi
           TAGS="${IMAGE}:${VERSION}"
-          if [[ ("$EVENT" == "workflow_dispatch" && "${INPUT_PUSH_LATEST}" == "true") || "$REF_TYPE" == "tag" ]]; then
+          if [[ "$PUSH_LATEST" == "true" ]]; then
           TAGS+=",${IMAGE}:latest"
           fi
           
@@ -130,12 +130,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.version=${{ steps.meta.outputs.sdk_version }}
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
             org.opencontainers.image.title=Fluent Reproducible Build Environment
             org.opencontainers.image.description=Pre-warmed Docker image for reproducible cross-platform builds of Fluent smart contracts
-            xyz.fluent.sdk.version=${{ steps.meta.outputs.sdk_version }}
+            xyz.fluent.sdk.version=${{ steps.meta.outputs.version }}
             xyz.fluent.rust.toolchain=${{ env.RUST_TOOLCHAIN }}
           build-args: |
             RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN }}
@@ -155,7 +155,7 @@ jobs:
           echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
           echo "| **Platform** | \`linux/amd64\` |" >> $GITHUB_STEP_SUMMARY
           echo "| **Rust** | \`${{ env.RUST_TOOLCHAIN }}\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| **SDK Version** | \`v${{ steps.meta.outputs.sdk_version }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| **SDK Version** | \`${{ steps.meta.outputs.version }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "| **Commit** | \`${{ github.sha }}\` |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Available tags:**" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- reuse the computed `PUSH_LATEST` guard when building fluentbase-build image tags
- keep release-candidate tags from publishing or manually pushing `latest`
- use the existing `version` output for OCI labels and the workflow summary instead of the unset `sdk_version` output

## Validation
- `git diff --check`
- parsed `.github/workflows/build-docker.yml` with Ruby YAML
- local bash simulation for RC tag, stable tag, manual RC, and manual stable `push_latest=true` cases

## Notes
This keeps the versioned RC image tag behavior unchanged; it only prevents `latest` from being appended when `IS_RC=true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented release-candidate Docker images from being published with the `latest` tag.
  * Standardized the version shown in container metadata and build summaries.
  * Removed inconsistent version formatting from Docker build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->