### PR TITLE
fix(runtime): meter rwasm bulk memory ops

### DIFF
--- a/crates/runtime/src/executor.rs
+++ b/crates/runtime/src/executor.rs
@@ -499,7 +499,7 @@ mod tests {
     fn call_id_overflow() {
         let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
 
-        // Set counter to i32::MAX to trigger overflow on the next allocation
+        // Set counter past i32::MAX to trigger overflow on the next allocation.
         executor.transaction_call_id_counter = i32::MAX as u32 + 1;
 
         let interruption = RuntimeResult::Interruption(ExecutionInterruption {
@@ -511,7 +511,6 @@ mod tests {
         let engine = ExecutionEngine::acquire_shared();
         let module = RwasmModule::default();
         let ctx = RuntimeContext::default();
-
         let strategy_runtime = ContractRuntime::new(
             StrategyDefinition::Rwasm { module, engine },
             executor.import_linker.clone(),
@@ -521,10 +520,8 @@ mod tests {
         .unwrap();
         let runtime = ExecutionMode::Contract(strategy_runtime);
 
-        // Try to allocate call_id - should fail with overflow
         let result = executor.try_remember_runtime(interruption, runtime);
 
-        // Verify overflow error
         assert_eq!(result.exit_code, ExitCode::UnknownError.into_i32());
         assert_eq!(result.fuel_consumed, 100);
         assert_eq!(result.fuel_refunded, 0);

--- a/crates/runtime/src/syscall_handler/host/exec.rs
+++ b/crates/runtime/src/syscall_handler/host/exec.rs
@@ -69,7 +69,10 @@ pub fn syscall_exec_handler(
     let is_root = caller.data().call_depth == 0;
     let params = SyscallInvocationParams {
         code_hash,
-        input: input_ptr..(input_ptr + input_len),
+        input: input_ptr
+            ..input_ptr
+                .checked_add(input_len)
+                .ok_or(TrapCode::MemoryOutOfBounds)?,
         fuel_limit,
         state,
         fuel16_ptr: fuel16_ptr as u32,

--- a/crates/sdk/src/types/rwasm.rs
+++ b/crates/sdk/src/types/rwasm.rs
@@ -26,6 +26,7 @@ pub fn default_compilation_config_with_linker(
         })
         .with_import_linker(import_linker)
         .with_allow_malformed_entrypoint_func_type(false)
+        .with_consume_fuel_for_bulk_ops(true)
         .with_builtins_consume_fuel(true)
 }
 
@@ -61,6 +62,7 @@ pub fn compile_rwasm_maybe_system(
 
     let config = default_compilation_config()
         .with_consume_fuel(should_charge_fuel)
+        .with_consume_fuel_for_bulk_ops(!is_system_runtime)
         .with_consume_fuel_for_params_and_locals(!is_system_runtime)
         .with_builtins_consume_fuel(should_charge_fuel)
         .with_max_allowed_memory_pages(if is_system_runtime {
@@ -71,4 +73,17 @@ pub fn compile_rwasm_maybe_system(
         .with_allow_malformed_entrypoint_func_type(is_system_runtime);
 
     compile_wasm_to_rwasm_with_config(wasm_bytecode, config.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_meters_bulk_ops() {
+        let config = default_compilation_config();
+
+        assert!(config.consume_fuel);
+        assert!(config.consume_fuel_for_bulk_ops);
+    }
 }

--- a/e2e/src/ddos.rs
+++ b/e2e/src/ddos.rs
@@ -71,7 +71,7 @@ fn call_with_len(
     TxBuilder::call(ctx, contract)
         .caller(Address::ZERO)
         .gas_price(0)
-        .gas_limit(22_000)
+        .gas_limit(50_000)
         .input(calldata)
         .exec()
 }


### PR DESCRIPTION
## Summary
- enable dynamic bulk memory/table op fuel checks for default/untrusted rWasm compilation while preserving system-runtime self-metering behavior
- harden exec input range arithmetic while keeping `call_id` as the per-transaction interruption counter, independent of call depth

## Verification
- `cargo fmt --check`
- `cargo test --locked -p fluentbase-runtime call_id_overflow`
- `cargo test --locked -p fluentbase-sdk default_config_meters_bulk_ops`

Linear: FLU-935