### PR TITLE
fix(genesis): make release artifacts reproducible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,19 +130,44 @@ jobs:
       - name: Install wasm32 target
         run: rustup target add wasm32-unknown-unknown
 
-      - name: Build Genesis
+      - name: Build and verify genesis reproducibility
         env:
           FLUENTBASE_CONTRACTS_DOCKER: "true"
           FLUENTBASE_BUILD_DOCKER_IMAGE: ${{ steps.build_image.outputs.image }}
           FLUENTBASE_BUILD_DOCKER_TAG: ${{ steps.build_image.outputs.tag }}
-        run: cargo b --release
+        run: |
+          cargo b --release
+          sha256sum \
+            ./crates/genesis/genesis-devnet.json \
+            ./crates/genesis/genesis-mainnet.json \
+            ./crates/genesis/evm-runtime-permissive.rwasm \
+            > /tmp/fluentbase-genesis.sha256
+          cargo b --release
+          sha256sum --check /tmp/fluentbase-genesis.sha256
 
       - name: Package genesis files
         run: |
           mkdir -p artifacts
-          gzip -c ./crates/genesis/genesis-devnet.json > ./artifacts/genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz
-          gzip -c ./crates/genesis/genesis-mainnet.json > ./artifacts/genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz
-          gzip -c ./crates/genesis/evm-runtime-permissive.rwasm > ./artifacts/evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
+          gzip -n -c ./crates/genesis/genesis-devnet.json > ./artifacts/genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz
+          gzip -n -c ./crates/genesis/genesis-mainnet.json > ./artifacts/genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz
+          gzip -n -c ./crates/genesis/evm-runtime-permissive.rwasm > ./artifacts/evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
+
+          {
+            echo "version=${{ needs.extract-version.outputs.VERSION }}"
+            echo "commit=${GITHUB_SHA}"
+            echo
+            echo "[raw]"
+            sha256sum \
+              ./crates/genesis/genesis-devnet.json \
+              ./crates/genesis/genesis-mainnet.json \
+              ./crates/genesis/evm-runtime-permissive.rwasm
+            echo
+            echo "[compressed]"
+            sha256sum \
+              ./artifacts/genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz \
+              ./artifacts/genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz \
+              ./artifacts/evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
+          } > ./artifacts/genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
 
       - name: Configure GPG and sign genesis artifacts
         if: ${{ github.event.inputs.dry_run != 'true' }}
@@ -153,8 +178,13 @@ jobs:
           export GPG_TTY=$(tty)
           echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
           cd artifacts
-          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz
-          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz
+          for artifact in \
+            genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz \
+            genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz \
+            genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
+          do
+            echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab "$artifact"
+          done
           mv * ..
 
       - name: Upload devnet genesis
@@ -178,6 +208,13 @@ jobs:
           name: evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
           path: evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
 
+      - name: Upload genesis manifest
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
+          path: genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
+
       - name: Upload devnet genesis signature
         if: ${{ github.event.inputs.dry_run != 'true' }}
         uses: actions/upload-artifact@v7
@@ -191,6 +228,13 @@ jobs:
         with:
           name: genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz.asc
           path: genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz.asc
+
+      - name: Upload genesis manifest signature
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt.asc
+          path: genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt.asc
 
   build:
     name: build release
@@ -353,6 +397,9 @@ jobs:
             assets+=("$d/$(basename "$d")")
           done
           for d in ./*evm-runtime-permissive-*.rwasm.gz*; do
+            assets+=("$d/$(basename "$d")")
+          done
+          for d in ./*genesis-manifest-*.txt*; do
             assets+=("$d/$(basename "$d")")
           done
           gh release create --draft $prerelease_flag -t "Genesis ${VERSION}" -F release-notes.md "${VERSION}" "${assets[@]}"

--- a/crates/genesis/build.rs
+++ b/crates/genesis/build.rs
@@ -17,7 +17,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     env, fs,
     path::PathBuf,
-    time::{Instant, SystemTime},
+    time::Instant,
 };
 
 #[rustfmt::skip]
@@ -52,6 +52,9 @@ const GENESIS_CONTRACTS: &[(Address, fluentbase_contracts::BuildOutput)] = &[
     (fluentbase_sdk::PRECOMPILE_SHA256, fluentbase_contracts::FLUENTBASE_CONTRACTS_SHA256),
     (fluentbase_sdk::PRECOMPILE_WEBAUTHN_VERIFIER, fluentbase_contracts::FLUENTBASE_CONTRACTS_WEBAUTHN),
 ];
+
+const DEVNET_GENESIS_TIMESTAMP: u64 = 0x69b8194c;
+const MAINNET_GENESIS_TIMESTAMP: u64 = 0x69b8194c;
 
 fn default_chain_config(chain_id: u64) -> ChainConfig {
     ChainConfig {
@@ -247,11 +250,6 @@ fn main() {
     code.push("];".to_string());
     let code = code.join("\n");
 
-    let timestamp = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-
     // devnet/testnet genesis
     {
         let mut alloc = alloc.clone();
@@ -277,7 +275,7 @@ fn main() {
         let genesis = Genesis {
             config: default_chain_config(1337),
             nonce: 0,
-            timestamp,
+            timestamp: DEVNET_GENESIS_TIMESTAMP,
             extra_data: Bytes::new(),
             // Default gas limit is 100mil
             gas_limit: 0x5f5e100,
@@ -302,7 +300,7 @@ fn main() {
             config: default_chain_config(25363),
             nonce: 0,
             // A timestamp for first Fluent mainnet genesis creation
-            timestamp: 0x69b8194c,
+            timestamp: MAINNET_GENESIS_TIMESTAMP,
             extra_data: Bytes::new(),
             // Default gas limit is 100mil
             gas_limit: 0x5f5e100,


### PR DESCRIPTION
## Summary
- Replace wall-clock devnet genesis timestamps with explicit fixed genesis timestamp constants.
- Add a release reproducibility check that rebuilds genesis artifacts and verifies raw hashes before packaging.
- Package genesis/runtime artifacts with deterministic `gzip -n` and publish a signed manifest binding version, commit, raw hashes, and compressed hashes.

## Tests
- cargo fmt --check -p fluentbase-genesis
- cargo check -p fluentbase-genesis --locked

Linear: FLU-937