### PR TITLE
fix(runtime): gate root interruption continuation

### DIFF
--- a/crates/runtime/src/context.rs
+++ b/crates/runtime/src/context.rs
@@ -1,5 +1,5 @@
 use crate::{executor::ExecutionResult, syscall_handler::InterruptionHolder};
-use fluentbase_types::{Bytes, CALL_DEPTH_ROOT, STATE_MAIN};
+use fluentbase_types::{Bytes, ExitCode, CALL_DEPTH_ROOT, STATE_MAIN};
 
 /// Per-invocation execution context carried inside the VM store.
 #[derive(Debug, Clone)]
@@ -57,22 +57,76 @@ impl RuntimeContext {
     }
 
     /// Extract serialized resumable context
-    pub fn take_resumable_context_serialized(&mut self) -> Option<Vec<u8>> {
+    pub fn take_resumable_context_serialized(&mut self) -> Result<Option<Vec<u8>>, ExitCode> {
         // Take resumable context from execution context
-        let resumable_context = self.resumable_context.take()?;
+        let Some(resumable_context) = self.resumable_context.take() else {
+            return Ok(None);
+        };
         if resumable_context.is_root {
-            unimplemented!("validate this logic, might not be ok in STF mode");
+            return Err(ExitCode::UnexpectedFatalExecutionFailure);
         }
         // serialize the delegated execution state,
         // but we don't serialize registers and stack state,
         // instead we remember it inside the internal structure
         // and assign a special identifier for recovery
         let result = resumable_context.params.encode();
-        Some(result)
+        Ok(Some(result))
     }
 
     /// Clears the accumulated output buffer.
     pub fn clear_output(&mut self) {
         self.execution_result.output.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluentbase_types::{SyscallInvocationParams, B256};
+
+    fn resumable_context(is_root: bool) -> InterruptionHolder {
+        InterruptionHolder {
+            params: SyscallInvocationParams {
+                code_hash: B256::default(),
+                input: 4..8,
+                fuel_limit: 13,
+                state: 2,
+                fuel16_ptr: 16,
+            },
+            is_root,
+        }
+    }
+
+    #[test]
+    fn root_resumable_context_returns_fatal_error_without_panicking() {
+        let mut ctx = RuntimeContext {
+            resumable_context: Some(resumable_context(true)),
+            ..Default::default()
+        };
+
+        let err = ctx.take_resumable_context_serialized().unwrap_err();
+
+        assert_eq!(err, ExitCode::UnexpectedFatalExecutionFailure);
+        assert!(ctx.resumable_context.is_none());
+    }
+
+    #[test]
+    fn child_resumable_context_still_serializes() {
+        let params = resumable_context(false).params;
+        let mut ctx = RuntimeContext {
+            resumable_context: Some(InterruptionHolder {
+                params: params.clone(),
+                is_root: false,
+            }),
+            ..Default::default()
+        };
+
+        let encoded = ctx
+            .take_resumable_context_serialized()
+            .unwrap()
+            .expect("child interruption should serialize");
+
+        assert_eq!(SyscallInvocationParams::decode(&encoded), Some(params));
+        assert!(ctx.resumable_context.is_none());
     }
 }

--- a/crates/runtime/src/executor.rs
+++ b/crates/runtime/src/executor.rs
@@ -296,8 +296,20 @@ impl RuntimeFactoryExecutor {
             // handler to pass into parent runtime.
             //
             // Safety: For system runtimes we don't save this
-            if let Some(resumable_return_data) = ctx.take_resumable_context_serialized() {
-                return_data = resumable_return_data;
+            match ctx.take_resumable_context_serialized() {
+                Ok(Some(resumable_return_data)) => {
+                    return_data = resumable_return_data;
+                }
+                Ok(None) => {}
+                Err(exit_code) => {
+                    return RuntimeResult::Result(ExecutionResult {
+                        exit_code: exit_code.into_i32(),
+                        fuel_consumed,
+                        fuel_refunded,
+                        output: vec![],
+                        return_data: vec![],
+                    });
+                }
             }
             return RuntimeResult::Interruption(ExecutionInterruption {
                 fuel_consumed,

--- a/crates/runtime/src/syscall_handler/host/exec.rs
+++ b/crates/runtime/src/syscall_handler/host/exec.rs
@@ -85,9 +85,15 @@ pub fn syscall_exec_handler(
 /// Continues an exec after an interruption, executing the delegated call.
 pub fn syscall_exec_continue(
     _caller: &mut impl StoreTr<RuntimeContext>,
-    _context: &InterruptionHolder,
+    context: &InterruptionHolder,
 ) -> (u64, i64, i32) {
-    unimplemented!("runtime: not supported until we finish zkVM");
+    // Continuation is gated until the root/STF resume ABI is fully defined.
+    // Fail deterministically instead of panicking in enabled runtimes.
+    (
+        context.params.fuel_limit,
+        0,
+        ExitCode::UnexpectedFatalExecutionFailure.into_i32(),
+    )
     // let fuel_limit = context.params.fuel_limit;
     // let (fuel_consumed, fuel_refunded, exit_code) = caller.context_mut(|ctx| {
     //     syscall_exec_impl(


### PR DESCRIPTION
## Summary
- replace root interruption serialization panic with a deterministic fatal execution result
- make the exec continuation stub fail closed instead of using `unimplemented!`
- add coverage for root failure and child interruption serialization

## Verification
- cargo fmt --check
- cargo test -p fluentbase-runtime
- cargo clippy -p fluentbase-runtime --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of interrupted executions so unsupported resume scenarios now fail with a clear execution status instead of causing a runtime panic.
  - Preserved resumable execution data when continuation is supported.
  - Ensured missing resume data is handled safely without altering existing results.
  - Added coverage for root and child resume scenarios, including successful serialization and graceful failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->