### PR TITLE
fix(webauthn): add strict relying-party policy checks

### DIFF
--- a/contracts/webauthn/README.md
+++ b/contracts/webauthn/README.md
@@ -12,7 +12,7 @@ The implementation follows the cryptographic assertion-verification subset of th
 - [Daimo](https://github.com/daimo-eth/p256-verifier/blob/master/src/WebAuthn.sol)
 - [Coinbase](https://github.com/base-org/webauthn-sol/blob/main/src/WebAuthn.sol)
 
-This contract is not a complete WebAuthn Relying Party implementation by itself. Callers must bind the assertion to their own account, origin/RP policy, challenge lifecycle, and credential state.
+This contract exposes both the original assertion primitive and a stricter selector that enforces caller-controlled RP ID hash and origin policy. Callers must still bind the assertion to their own account, challenge lifecycle, and credential state.
 
 ## Features
 
@@ -26,15 +26,21 @@ This contract is not a complete WebAuthn Relying Party implementation by itself.
 
 ### Function Selector
 
-The contract exposes a single entry point with function selector `0x94516dde`, derived from:
+The contract exposes two entrypoint selectors. The legacy selector is `0x94516dde`, derived from:
 
 ```
 keccak256("verify(bytes,bool,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256,uint256)")
 ```
 
-### Input Parameters
+The strict selector is `0xd6b45308`, derived from:
 
-The function takes the following parameters:
+```
+keccak256("verifyStrict(bytes,bool,bytes32,bytes,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256,uint256)")
+```
+
+### Legacy Input Parameters
+
+The legacy selector takes the following parameters:
 
 1. `challenge` (bytes): The original challenge sent to the authenticator
 2. `require_user_verification` (bool): Whether to require the User Verified (UV) flag
@@ -47,6 +53,19 @@ The function takes the following parameters:
    - `s` (bytes32): The s component of the signature
 4. `x` (uint256): The x coordinate of the public key
 5. `y` (uint256): The y coordinate of the public key
+
+### Strict Input Parameters
+
+The strict selector takes the following parameters:
+
+1. `challenge` (bytes): The original challenge sent to the authenticator
+2. `require_user_verification` (bool): Whether to require the User Verified (UV) flag
+3. `expected_rp_id_hash` (bytes32): SHA-256 hash of the expected RP ID, compared with the first 32 bytes of `authenticator_data`
+4. `expected_origin` (bytes): Expected origin bytes, compared with `client_data_json` at `origin_index`
+5. `origin_index` (uint256): Start index of `"origin":"..."` in `client_data_json`
+6. `auth` (WebAuthnAuth struct): The WebAuthn authentication data
+7. `x` (uint256): The x coordinate of the public key
+8. `y` (uint256): The y coordinate of the public key
 
 ### Return Value
 
@@ -64,9 +83,11 @@ The contract performs the following verification steps:
    - Confirms the challenge matches the expected value
 
 2. **Authenticator Data Validation**:
+   - The strict selector verifies the RP ID hash matches `expected_rp_id_hash`
    - Checks the User Present (UP) flag is set
    - Verifies the User Verified (UV) flag if required
    - Validates backup state consistency
+   - The strict selector verifies the origin matches `expected_origin` at `origin_index`
 
 3. **Signature Verification**:
    - Computes the message hash: SHA-256(authenticator_data || SHA-256(client_data_json))
@@ -83,7 +104,7 @@ The W3C assertion verification procedure includes checks that require Relying Pa
 
 The caller is still responsible for enforcing:
 
-- Expected origin and RP ID policy. In particular, verify the RP ID hash in `authenticator_data` against the caller's expected RP ID hash.
+- Expected origin and RP ID policy when using the legacy selector. The strict selector enforces a single expected origin and RP ID hash supplied by the caller.
 - Credential binding. The supplied public key coordinates must be the registered credential public key for the authenticated account.
 - Challenge freshness and single use. A valid old assertion must not be replayable.
 - Signature counter policy, if the application relies on clone detection.
@@ -94,14 +115,14 @@ The `client_data_json`, `authenticator_data`, indexes, and public key are user-s
 
 ## Security Considerations
 
-This implementation deliberately omits some full Relying Party validations from the current ABI:
+This implementation deliberately omits some full Relying Party validations:
 
-- Origin and RP ID validation (delegated to authenticator)
+- Multiple allowed origins or richer origin parsing
 - Extension outputs
 - Signature counter
 - Attestation objects
 
-These omissions optimize gas usage for the current selector, but they mean the selector should be treated as a cryptographic assertion primitive. A future strict selector should take caller-controlled policy inputs such as expected origin, expected RP ID hash, credential ID/public key binding, and counter policy, then reject mismatches inside the contract.
+The legacy selector should be treated as a cryptographic assertion primitive. Prefer the strict selector when the caller wants the contract to reject RP ID hash or origin mismatches before returning signature success.
 
 ## License
 

--- a/contracts/webauthn/abi.json
+++ b/contracts/webauthn/abi.json
@@ -1,1 +1,159 @@
-[]
+[
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "challenge",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bool",
+        "name": "require_user_verification",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "authenticator_data",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "client_data_json",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint256",
+            "name": "challenge_index",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "type_index",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct WebAuthnAuth",
+        "name": "auth",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "x",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "y",
+        "type": "uint256"
+      }
+    ],
+    "name": "verify",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "is_valid",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "challenge",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bool",
+        "name": "require_user_verification",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "expected_rp_id_hash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "bytes",
+        "name": "expected_origin",
+        "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "origin_index",
+        "type": "uint256"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bytes",
+            "name": "authenticator_data",
+            "type": "bytes"
+          },
+          {
+            "internalType": "bytes",
+            "name": "client_data_json",
+            "type": "bytes"
+          },
+          {
+            "internalType": "uint256",
+            "name": "challenge_index",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "type_index",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "r",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "s",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct WebAuthnAuth",
+        "name": "auth",
+        "type": "tuple"
+      },
+      {
+        "internalType": "uint256",
+        "name": "x",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "y",
+        "type": "uint256"
+      }
+    ],
+    "name": "verifyStrict",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "is_valid",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/contracts/webauthn/src/lib.rs
+++ b/contracts/webauthn/src/lib.rs
@@ -7,12 +7,17 @@ mod webauthn;
 use fluentbase_sdk::{
     codec::SolidityABI, system_entrypoint, Bytes, ContextReader, ExitCode, SystemAPI, B256, U256,
 };
-use webauthn::{verify_webauthn, WebAuthnAuth};
+use webauthn::{verify_webauthn, verify_webauthn_with_policy, WebAuthnAuth, WebAuthnPolicy};
 
 /// Function selector: 0x94516dde
 /// Derived from:
 /// keccak256("verify(bytes,bool,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256,uint256)")
 const VERIFY_SELECTOR: [u8; 4] = [0x94, 0x51, 0x6d, 0xde];
+
+/// Function selector: 0xd6b45308
+/// Derived from:
+/// keccak256("verifyStrict(bytes,bool,bytes32,bytes,uint256,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256,uint256)")
+const VERIFY_STRICT_SELECTOR: [u8; 4] = [0xd6, 0xb4, 0x53, 0x08];
 
 /// Estimated verification cost, in EVM gas units.
 const WEBAUTHN_VERIFY_GAS: u64 = 22_000;
@@ -32,23 +37,53 @@ pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
 
     let input = sdk.bytes_input();
     let (selector, params) = input.split_at(4);
-    if selector != VERIFY_SELECTOR {
-        return Err(ExitCode::MalformedBuiltinParams);
-    }
-
-    let (challenge, require_user_verification, auth, x, y) =
-        SolidityABI::<(Bytes, bool, WebAuthnAuth, U256, U256)>::decode(&params, 0)
-            .map_err(|_| ExitCode::MalformedBuiltinParams)?;
 
     let gas_limit = sdk.context().contract_gas_limit();
-    let is_valid = verify_webauthn(
-        &challenge,
-        require_user_verification,
-        &auth,
-        x,
-        y,
-        gas_limit,
-    )?;
+    let is_valid = if selector == VERIFY_SELECTOR {
+        let (challenge, require_user_verification, auth, x, y) =
+            SolidityABI::<(Bytes, bool, WebAuthnAuth, U256, U256)>::decode(&params, 0)
+                .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+
+        verify_webauthn(
+            &challenge,
+            require_user_verification,
+            &auth,
+            x,
+            y,
+            gas_limit,
+        )?
+    } else if selector == VERIFY_STRICT_SELECTOR {
+        let (
+            challenge,
+            require_user_verification,
+            expected_rp_id_hash,
+            expected_origin,
+            origin_index,
+            auth,
+            x,
+            y,
+        ) = SolidityABI::<(Bytes, bool, B256, Bytes, U256, WebAuthnAuth, U256, U256)>::decode(
+            &params, 0,
+        )
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+
+        verify_webauthn_with_policy(
+            &challenge,
+            require_user_verification,
+            &WebAuthnPolicy {
+                expected_rp_id_hash,
+                expected_origin,
+                origin_index,
+            },
+            &auth,
+            x,
+            y,
+            gas_limit,
+        )?
+    } else {
+        return Err(ExitCode::MalformedBuiltinParams);
+    };
+
     let result = B256::with_last_byte(if is_valid { 0x01 } else { 0x00 });
     sdk.write(&result[..]);
 
@@ -68,6 +103,8 @@ mod tests {
         ecdsa::{signature::SignerMut, SigningKey, VerifyingKey},
         elliptic_curve::rand_core::OsRng,
     };
+
+    type StrictCallParams = (Bytes, bool, B256, Bytes, U256, WebAuthnAuth, U256, U256);
 
     fn valid_call_params(
         require_user_verification: bool,
@@ -133,6 +170,45 @@ mod tests {
         input
     }
 
+    fn encode_strict_call(params_tuple: &StrictCallParams) -> Vec<u8> {
+        let mut params = BytesMut::new();
+        SolidityABI::<(Bytes, bool, B256, Bytes, U256, WebAuthnAuth, U256, U256)>::encode(
+            params_tuple,
+            &mut params,
+            0,
+        )
+        .unwrap();
+
+        let mut input = VERIFY_STRICT_SELECTOR.to_vec();
+        input.extend_from_slice(&params);
+        input
+    }
+
+    fn valid_strict_call_input(require_user_verification: bool) -> (Vec<u8>, StrictCallParams) {
+        let (challenge, require_user_verification, auth, x, y) =
+            valid_call_params(require_user_verification);
+        let expected_rp_id_hash = B256::from_slice(&auth.authenticator_data[..32]);
+        let expected_origin = Bytes::copy_from_slice(b"http://localhost:3005");
+        let origin_index = U256::from(
+            auth.client_data_json
+                .windows(b"\"origin\"".len())
+                .position(|window| window == b"\"origin\"")
+                .unwrap(),
+        );
+        let params = (
+            challenge,
+            require_user_verification,
+            expected_rp_id_hash,
+            expected_origin,
+            origin_index,
+            auth,
+            x,
+            y,
+        );
+
+        (encode_strict_call(&params), params)
+    }
+
     fn valid_call_input(require_user_verification: bool) -> Vec<u8> {
         encode_call(&valid_call_params(require_user_verification))
     }
@@ -153,6 +229,34 @@ mod tests {
     fn valid_signature_returns_true_and_charges_fuel() {
         let (output, fuel) = exec(&valid_call_input(true), WEBAUTHN_VERIFY_GAS).unwrap();
         assert_eq!(output, B256::with_last_byte(1)[..]);
+        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+    }
+
+    #[test]
+    fn strict_valid_signature_returns_true_and_charges_fuel() {
+        let (input, _) = valid_strict_call_input(true);
+        let (output, fuel) = exec(&input, WEBAUTHN_VERIFY_GAS).unwrap();
+        assert_eq!(output, B256::with_last_byte(1)[..]);
+        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+    }
+
+    #[test]
+    fn strict_mismatched_rp_id_hash_returns_false() {
+        let (_, mut params) = valid_strict_call_input(true);
+        params.2 = B256::with_last_byte(1);
+
+        let (output, fuel) = exec(&encode_strict_call(&params), WEBAUTHN_VERIFY_GAS).unwrap();
+        assert_eq!(output, B256::default()[..]);
+        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+    }
+
+    #[test]
+    fn strict_disallowed_origin_returns_false() {
+        let (_, mut params) = valid_strict_call_input(true);
+        params.3 = Bytes::copy_from_slice(b"https://example.com");
+
+        let (output, fuel) = exec(&encode_strict_call(&params), WEBAUTHN_VERIFY_GAS).unwrap();
+        assert_eq!(output, B256::default()[..]);
         assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
     }
 

--- a/contracts/webauthn/src/webauthn.rs
+++ b/contracts/webauthn/src/webauthn.rs
@@ -1,4 +1,4 @@
-use alloc::{format, vec::Vec};
+use alloc::{format, string::String, vec::Vec};
 use fluentbase_sdk::{codec::Codec, crypto::crypto_sha256, Bytes, ExitCode, B256, U256};
 
 /// WebAuthn authenticator data flag bits

--- a/contracts/webauthn/src/webauthn.rs
+++ b/contracts/webauthn/src/webauthn.rs
@@ -1,5 +1,5 @@
-use alloc::{format, string::String, vec::Vec};
-use fluentbase_sdk::{codec::Codec, crypto::crypto_sha256, Bytes, ExitCode, U256};
+use alloc::{format, vec::Vec};
+use fluentbase_sdk::{codec::Codec, crypto::crypto_sha256, Bytes, ExitCode, B256, U256};
 
 /// WebAuthn authenticator data flag bits
 pub const AUTH_DATA_FLAGS_UP: u8 = 0x01; // User Present bit
@@ -40,6 +40,13 @@ pub struct WebAuthnAuth {
     /// Signature components (r, s) of the WebAuthn authentication assertion.
     pub r: U256,
     pub s: U256,
+}
+
+/// Caller-controlled relying-party policy for strict WebAuthn assertion checks.
+pub struct WebAuthnPolicy {
+    pub expected_rp_id_hash: B256,
+    pub expected_origin: Bytes,
+    pub origin_index: U256,
 }
 
 /// Verifies a WebAuthn Authentication Assertion
@@ -86,6 +93,60 @@ pub fn verify_webauthn(
 
     // Step 4: Verify signature
     verify_signature(message_hash, auth.r, auth.s, x, y, gas_limit)
+}
+
+/// Verifies a WebAuthn assertion and caller-controlled relying-party policy.
+pub fn verify_webauthn_with_policy(
+    challenge: &Bytes,
+    require_user_verification: bool,
+    policy: &WebAuthnPolicy,
+    auth: &WebAuthnAuth,
+    x: U256,
+    y: U256,
+    gas_limit: u64,
+) -> Result<bool, ExitCode> {
+    if !verify_rp_id_hash(&auth.authenticator_data, &policy.expected_rp_id_hash) {
+        return Ok(false);
+    }
+
+    if !verify_client_data_json_origin(
+        &auth.client_data_json,
+        &policy.expected_origin,
+        policy.origin_index,
+    ) {
+        return Ok(false);
+    }
+
+    verify_webauthn(challenge, require_user_verification, auth, x, y, gas_limit)
+}
+
+fn verify_rp_id_hash(authenticator_data: &Bytes, expected_rp_id_hash: &B256) -> bool {
+    if authenticator_data.len() < 32 {
+        return false;
+    }
+
+    &authenticator_data[..32] == expected_rp_id_hash.as_slice()
+}
+
+fn verify_client_data_json_origin(
+    client_data_json: &Bytes,
+    expected_origin: &Bytes,
+    origin_index: U256,
+) -> bool {
+    let origin_idx = match u32::try_from(origin_index) {
+        Ok(idx) => idx as usize,
+        Err(_) => return false,
+    };
+
+    if origin_idx >= client_data_json.len() {
+        return false;
+    }
+
+    let mut origin_str = Vec::with_capacity(b"\"origin\":\"\"".len() + expected_origin.len());
+    origin_str.extend_from_slice(b"\"origin\":\"");
+    origin_str.extend_from_slice(expected_origin.as_ref());
+    origin_str.extend_from_slice(b"\"");
+    contains_at(origin_str.as_slice(), client_data_json, origin_idx)
 }
 
 /// Verifies the client data JSON type and challenge
@@ -203,11 +264,16 @@ fn verify_signature(
 fn contains_at(substr: &[u8], full_str: &[u8], location: usize) -> bool {
     let substr_len = substr.len();
 
-    if location + substr_len > full_str.len() {
+    let end = match location.checked_add(substr_len) {
+        Some(end) => end,
+        None => return false,
+    };
+
+    if end > full_str.len() {
         return false;
     }
 
-    let slice = &full_str[location..location + substr_len];
+    let slice = &full_str[location..end];
     slice == substr
 }
 
@@ -388,6 +454,108 @@ mod tests {
             !result,
             "verify_client_data_json should return false for invalid data"
         );
+    }
+
+    #[test]
+    fn test_verify_client_data_json_origin() {
+        let (client_data_json, _, _, _) = create_valid_client_data_json_test_data();
+        let origin = Bytes::copy_from_slice(b"http://localhost:3005");
+        let origin_index = U256::from(
+            client_data_json
+                .windows(b"\"origin\"".len())
+                .position(|window| window == b"\"origin\"")
+                .unwrap(),
+        );
+
+        assert!(verify_client_data_json_origin(
+            &client_data_json,
+            &origin,
+            origin_index,
+        ));
+        assert!(!verify_client_data_json_origin(
+            &client_data_json,
+            &Bytes::copy_from_slice(b"https://example.com"),
+            origin_index,
+        ));
+        assert!(!verify_client_data_json_origin(
+            &client_data_json,
+            &origin,
+            U256::from(client_data_json.len()),
+        ));
+    }
+
+    #[test]
+    fn test_verify_rp_id_hash() {
+        let challenge = create_valid_challenge();
+        let (auth, _, _) = create_valid_webauthn(&challenge);
+        let expected = B256::from_slice(&auth.authenticator_data[..32]);
+        let wrong = B256::with_last_byte(1);
+
+        assert!(verify_rp_id_hash(&auth.authenticator_data, &expected));
+        assert!(!verify_rp_id_hash(&auth.authenticator_data, &wrong));
+        assert!(!verify_rp_id_hash(
+            &Bytes::copy_from_slice(&auth.authenticator_data[..31]),
+            &expected,
+        ));
+    }
+
+    #[test]
+    fn test_valid_signature_with_policy() {
+        let challenge = create_valid_challenge();
+        let (auth, x, y) = create_valid_webauthn(&challenge);
+        let expected_rp_id_hash = B256::from_slice(&auth.authenticator_data[..32]);
+        let expected_origin = Bytes::copy_from_slice(b"http://localhost:3005");
+        let origin_index = U256::from(
+            auth.client_data_json
+                .windows(b"\"origin\"".len())
+                .position(|window| window == b"\"origin\"")
+                .unwrap(),
+        );
+
+        assert!(verify_webauthn_with_policy(
+            &challenge,
+            true,
+            &WebAuthnPolicy {
+                expected_rp_id_hash,
+                expected_origin: expected_origin.clone(),
+                origin_index,
+            },
+            &auth,
+            x,
+            y,
+            100000,
+        )
+        .unwrap());
+
+        assert!(!verify_webauthn_with_policy(
+            &challenge,
+            true,
+            &WebAuthnPolicy {
+                expected_rp_id_hash: B256::with_last_byte(1),
+                expected_origin: expected_origin.clone(),
+                origin_index,
+            },
+            &auth,
+            x,
+            y,
+            100000,
+        )
+        .unwrap());
+
+        assert!(!verify_webauthn_with_policy(
+            &challenge,
+            true,
+            &WebAuthnPolicy {
+                expected_rp_id_hash,
+                expected_origin: Bytes::copy_from_slice(b"https://example.com"),
+                origin_index,
+            },
+            &auth,
+            x,
+            y,
+            100000,
+        )
+        .unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep the existing WebAuthn verify selector as a compatibility assertion primitive
- add a strict selector that checks caller-supplied RP ID hash and origin before signature success
- add focused helper and entrypoint tests for strict success, RP mismatch, and origin mismatch
- document the legacy and strict selector ABI expectations

## Verification
- cargo fmt --manifest-path contracts/Cargo.toml --package fluentbase-contracts-webauthn
- cargo test --manifest-path contracts/Cargo.toml -p fluentbase-contracts-webauthn
- cargo clippy --manifest-path contracts/Cargo.toml -p fluentbase-contracts-webauthn --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strict WebAuthn verification with caller-supplied RP ID hash and origin validation.
  * Added an ABI artifact documenting both standard and strict verification entrypoints.
  * Strict verification now rejects mismatched relying-party identifiers or disallowed origins.

* **Bug Fixes**
  * Improved bounds handling for origin matching to safely reject invalid positions.

* **Documentation**
  * Updated WebAuthn contract documentation with strict verification behavior, parameters, selectors, and security guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->