### PR TITLE
fix(revm): meter metadata storage syscalls

### DIFF
--- a/crates/revm/src/gas.rs
+++ b/crates/revm/src/gas.rs
@@ -1,0 +1,35 @@
+use revm::{
+    context::context_interface::{
+        cfg::GasParams, context::SStoreResult, journaled_state::StateLoad,
+    },
+    interpreter::Gas,
+};
+
+pub(crate) enum SstoreGasError<E> {
+    OutOfFuel,
+    Store(E),
+}
+
+pub(crate) fn sstore_gas<E>(
+    gas: &mut Gas,
+    gas_params: &GasParams,
+    sstore: impl FnOnce(bool) -> Result<StateLoad<SStoreResult>, E>,
+) -> Result<(), SstoreGasError<E>> {
+    if gas.remaining() <= gas_params.call_stipend() {
+        return Err(SstoreGasError::OutOfFuel);
+    }
+    if !gas.record_regular_cost(gas_params.sstore_static_gas()) {
+        return Err(SstoreGasError::OutOfFuel);
+    }
+
+    let skip_cold = gas.remaining() < gas_params.cold_storage_cost();
+    let state_load = sstore(skip_cold).map_err(SstoreGasError::Store)?;
+    let gas_cost = gas_params.sstore_dynamic_gas(true, &state_load.data, state_load.is_cold);
+    if !gas.record_regular_cost(gas_cost) {
+        return Err(SstoreGasError::OutOfFuel);
+    }
+
+    let gas_refund = gas_params.sstore_refund(true, &state_load.data);
+    gas.record_refund(gas_refund);
+    Ok(())
+}

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -10,6 +10,7 @@ mod bridge;
 mod eip2935;
 mod evm;
 mod executor;
+mod gas;
 mod handler;
 mod inspector;
 mod precompiles;

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -8,6 +8,7 @@
 
 use crate::{
     api::RwasmFrame,
+    gas::{sstore_gas, SstoreGasError},
     types::{is_evm_system_precompile, load_account_delegated},
     ExecutionResult, NextAction,
 };
@@ -317,50 +318,26 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                 }};
             }
 
-            if frame.interpreter.gas.remaining() <= ctx.cfg().gas_params().call_stipend() {
-                finish_inspection!();
-                return_halt!(OutOfFuel);
-            }
-
-            if !frame
-                .interpreter
-                .gas
-                .record_regular_cost(ctx.cfg().gas_params().sstore_static_gas())
-            {
-                finish_inspection!();
-                return_halt!(OutOfFuel);
-            }
-
-            let skip_cold =
-                frame.interpreter.gas.remaining() < ctx.cfg().gas_params().cold_storage_cost();
-            let result = ctx.journal_mut().sstore_skip_cold_load(
-                current_target_address,
-                slot,
-                new_value,
-                skip_cold,
-            );
-            let state_load = match result {
-                Ok(v) => v,
-                Err(e) => {
-                    finish_inspection!();
-                    match e {
-                        JournalLoadError::ColdLoadSkipped => return_halt!(OutOfFuel),
-                        JournalLoadError::DBError(e) => return Err(ContextError::Db(e)),
-                    }
-                }
-            };
-            let gas_cost = ctx.cfg().gas_params().sstore_dynamic_gas(
-                true,
-                &state_load.data,
-                state_load.is_cold,
-            );
-            if !frame.interpreter.gas.record_regular_cost(gas_cost) {
-                finish_inspection!();
-                return_halt!(OutOfFuel);
-            }
-            let gas_refund = ctx.cfg().gas_params().sstore_refund(true, &state_load.data);
-            frame.interpreter.gas.record_refund(gas_refund);
+            let gas_params = ctx.cfg().gas_params().clone();
+            let result = sstore_gas(&mut frame.interpreter.gas, &gas_params, |skip_cold| {
+                ctx.journal_mut().sstore_skip_cold_load(
+                    current_target_address,
+                    slot,
+                    new_value,
+                    skip_cold,
+                )
+            });
             finish_inspection!();
+            match result {
+                Ok(()) => {}
+                Err(SstoreGasError::OutOfFuel)
+                | Err(SstoreGasError::Store(JournalLoadError::ColdLoadSkipped)) => {
+                    return_halt!(OutOfFuel)
+                }
+                Err(SstoreGasError::Store(JournalLoadError::DBError(error))) => {
+                    return Err(ContextError::Db(error))
+                }
+            }
             return_result!(Ok)
         }
 
@@ -1142,13 +1119,19 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                 return_halt!(MalformedBuiltinParams);
             };
             let input = get_input_validated!(== U256::BYTES);
-
-            let Ok(slot): Result<[u8; U256::BYTES], _> = input[..U256::BYTES].try_into() else {
-                return_halt!(MalformedBuiltinParams)
-            };
-            let slot_u256 = U256::from_le_bytes(slot);
-            debug_syscall!("METADATA_STORAGE_READ", "slot={:?}", slot_u256);
-            let value = ctx.journal_mut().sload(account_owner_address, slot_u256)?;
+            let slot = U256::from_le_slice(&input[..U256::BYTES]);
+            debug_syscall!("METADATA_STORAGE_READ", "slot={:?}", slot);
+            let skip_cold =
+                frame.interpreter.gas.remaining() < ctx.cfg().gas_params().cold_storage_cost();
+            let result =
+                ctx.journal_mut()
+                    .sload_skip_cold_load(account_owner_address, slot, skip_cold);
+            let value = unwrap_journal_load_error!(result);
+            charge_regular_gas!(if value.is_cold {
+                ctx.cfg().gas_params().cold_storage_cost()
+            } else {
+                ctx.cfg().gas_params().warm_storage_read_cost()
+            });
             let output: [u8; U256::BYTES] = value.to_le_bytes();
             return_result!(output, Ok);
         }
@@ -1158,28 +1141,36 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                 return_halt!(MalformedBuiltinParams);
             };
             assert_halt!(!is_static, StateChangeDuringStaticCall);
-            // Input: slot + value.
             let input = get_input_validated!(== U256::BYTES + U256::BYTES);
-
-            let Ok(slot): Result<[u8; U256::BYTES], _> = input[..U256::BYTES].try_into() else {
-                return_halt!(MalformedBuiltinParams)
-            };
-            let Ok(value): Result<[u8; U256::BYTES], _> = input[U256::BYTES..].try_into() else {
-                return_halt!(MalformedBuiltinParams)
-            };
-
-            let slot_u256 = U256::from_le_bytes(slot);
-            let value_u256 = U256::from_le_bytes(value);
+            let slot = U256::from_le_slice(&input[..U256::BYTES]);
+            let new_value = U256::from_le_slice(&input[U256::BYTES..]);
             debug_syscall!(
                 "METADATA_STORAGE_WRITE",
                 "slot={:?} value={:?}",
-                slot_u256,
-                value_u256
+                slot,
+                new_value
             );
-            ctx.journal_mut()
-                .sstore(account_owner_address, slot_u256, value_u256)?;
-            ctx.journal_mut().touch_account(account_owner_address);
 
+            let gas_params = ctx.cfg().gas_params().clone();
+            let result = sstore_gas(&mut frame.interpreter.gas, &gas_params, |skip_cold| {
+                ctx.journal_mut().sstore_skip_cold_load(
+                    account_owner_address,
+                    slot,
+                    new_value,
+                    skip_cold,
+                )
+            });
+            match result {
+                Ok(()) => {}
+                Err(SstoreGasError::OutOfFuel)
+                | Err(SstoreGasError::Store(JournalLoadError::ColdLoadSkipped)) => {
+                    return_halt!(OutOfFuel)
+                }
+                Err(SstoreGasError::Store(JournalLoadError::DBError(error))) => {
+                    return Err(ContextError::Db(error))
+                }
+            }
+            ctx.journal_mut().touch_account(account_owner_address);
             return_result!(Bytes::default(), Ok);
         }
 

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -11,8 +11,8 @@ use fluentbase_sdk::{
     calc_create_metadata_address,
     syscall::{
         SYSCALL_ID_BLOCK_HASH, SYSCALL_ID_CODE_COPY, SYSCALL_ID_CODE_HASH,
-        SYSCALL_ID_METADATA_COPY, SYSCALL_ID_METADATA_CREATE, SYSCALL_ID_METADATA_WRITE,
-        SYSCALL_ID_STORAGE_WRITE,
+        SYSCALL_ID_METADATA_COPY, SYSCALL_ID_METADATA_CREATE, SYSCALL_ID_METADATA_STORAGE_READ,
+        SYSCALL_ID_METADATA_STORAGE_WRITE, SYSCALL_ID_METADATA_WRITE, SYSCALL_ID_STORAGE_WRITE,
     },
     Address, Bytes, PRECOMPILE_EVM_RUNTIME, PRECOMPILE_WASM_RUNTIME, STATE_MAIN, U256,
 };
@@ -38,6 +38,196 @@ impl MemoryReaderTr for ForwardInputMemoryReader {
             .ok_or(TrapCode::MemoryOutOfBounds)?
             .copy_to_slice(buffer);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod metadata_storage_gas_tests {
+    use super::*;
+    use revm::{
+        context::Cfg, handler::system_interruption::SystemInterruptionInputs, state::Account,
+    };
+
+    fn new_context(owner: Address, storage: Option<(U256, U256)>) -> RwasmContext<InMemoryDB> {
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(owner, AccountInfo::default());
+        if let Some((slot, value)) = storage {
+            db.insert_account_storage(owner, slot, value).unwrap();
+        }
+        let mut ctx = RwasmContext::new(db, RwasmSpecId::PRAGUE);
+        ctx.cfg = CfgEnv::new_with_spec(RwasmSpecId::PRAGUE);
+        ctx.block = BlockEnv::default();
+        ctx.tx = TxEnv::default();
+        let transaction_id = ctx.journaled_state.inner.transaction_id;
+        ctx.journaled_state.inner.state.insert(
+            owner,
+            Account {
+                info: AccountInfo::default(),
+                original_info: Box::<AccountInfo>::default(),
+                transaction_id,
+                storage: Default::default(),
+                status: Default::default(),
+            },
+        );
+        ctx
+    }
+
+    fn execute_metadata_storage(
+        ctx: &mut RwasmContext<InMemoryDB>,
+        owner: Address,
+        code_hash: B256,
+        input: Vec<u8>,
+        gas_limit: u64,
+        is_static: bool,
+    ) -> (InstructionResult, Bytes, Gas, i64) {
+        let mut frame = RwasmFrame::default();
+        frame.interpreter.input.account_owner = Some(owner);
+        frame.interpreter.runtime_flag.is_static = is_static;
+        frame.interpreter.gas = Gas::new(gas_limit);
+        let mr = ForwardInputMemoryReader(input.into());
+
+        let interruption_inputs = SystemInterruptionInputs {
+            call_id: 0,
+            code_hash,
+            input: 0..mr.0.len(),
+            fuel_limit: 0,
+            state: STATE_MAIN,
+            fuel16_ptr: 0,
+            gas: Gas::new(gas_limit),
+            preloaded_slot_costs: None,
+        };
+
+        let result = execute_rwasm_interruption::<_, NoOpInspector>(
+            &mut frame,
+            None,
+            ctx,
+            interruption_inputs,
+            mr,
+        )
+        .unwrap();
+
+        let refunded = frame.interpreter.gas.refunded();
+        match frame.interrupted_outcome {
+            Some(outcome) => {
+                let result = outcome.result.expect("metadata storage returns an outcome");
+                (result.result, result.output, result.gas, refunded)
+            }
+            None => {
+                let result = result.into_interpreter_action();
+                (
+                    result.instruction_result().unwrap(),
+                    Bytes::new(),
+                    Gas::new(0),
+                    refunded,
+                )
+            }
+        }
+    }
+
+    fn slot_input(slot: U256) -> Vec<u8> {
+        slot.to_le_bytes::<32>().to_vec()
+    }
+
+    fn write_input(slot: U256, value: U256) -> Vec<u8> {
+        let mut input = vec![0u8; 64];
+        input[0..32].copy_from_slice(&slot.to_le_bytes::<32>());
+        input[32..64].copy_from_slice(&value.to_le_bytes::<32>());
+        input
+    }
+
+    #[test]
+    fn metadata_storage_read_charges_cold_then_warm_storage_cost() {
+        let owner = address!("1111111111111111111111111111111111111111");
+        let slot = U256::from(7);
+        let value = U256::from(0xbeefu64);
+        let mut ctx = new_context(owner, Some((slot, value)));
+
+        let (cold_result, cold_output, cold_gas, _) = execute_metadata_storage(
+            &mut ctx,
+            owner,
+            SYSCALL_ID_METADATA_STORAGE_READ,
+            slot_input(slot),
+            10_000_000,
+            false,
+        );
+        let (warm_result, warm_output, warm_gas, _) = execute_metadata_storage(
+            &mut ctx,
+            owner,
+            SYSCALL_ID_METADATA_STORAGE_READ,
+            slot_input(slot),
+            10_000_000,
+            false,
+        );
+
+        assert_eq!(cold_result, InstructionResult::Return);
+        assert_eq!(warm_result, InstructionResult::Return);
+        assert_eq!(cold_output.as_ref(), value.to_le_bytes::<32>().as_slice());
+        assert_eq!(warm_output, cold_output);
+        assert_eq!(
+            cold_gas.total_gas_spent(),
+            ctx.cfg().gas_params().cold_storage_cost()
+        );
+        assert_eq!(
+            warm_gas.total_gas_spent(),
+            ctx.cfg().gas_params().warm_storage_read_cost()
+        );
+    }
+
+    #[test]
+    fn metadata_storage_write_charges_sstore_cost_and_records_refund() {
+        let owner = address!("1111111111111111111111111111111111111111");
+        let slot = U256::from(7);
+        let old_value = U256::from(0xbeefu64);
+        let mut ctx = new_context(owner, Some((slot, old_value)));
+
+        let (result, _, gas, refunded) = execute_metadata_storage(
+            &mut ctx,
+            owner,
+            SYSCALL_ID_METADATA_STORAGE_WRITE,
+            write_input(slot, U256::ZERO),
+            10_000_000,
+            false,
+        );
+
+        assert_eq!(result, InstructionResult::Stop);
+        assert_eq!(
+            gas.total_gas_spent(),
+            ctx.cfg().gas_params().sstore_static_gas()
+                + ctx.cfg().gas_params().cold_storage_cost()
+                + ctx.cfg().gas_params().sstore_reset_without_cold_load_cost()
+        );
+        assert_eq!(
+            refunded,
+            ctx.cfg().gas_params().sstore_clearing_slot_refund() as i64
+        );
+        assert_eq!(
+            ctx.journal_mut().sload(owner, slot).unwrap().data,
+            StorageValue::ZERO
+        );
+    }
+
+    #[test]
+    fn metadata_storage_write_oog_before_sstore_leaves_slot_unchanged() {
+        let owner = address!("1111111111111111111111111111111111111111");
+        let slot = U256::from(7);
+        let old_value = U256::from(0xbeefu64);
+        let mut ctx = new_context(owner, Some((slot, old_value)));
+        let gas_limit = ctx.cfg().gas_params().call_stipend();
+
+        let (result, _, _, _) = execute_metadata_storage(
+            &mut ctx,
+            owner,
+            SYSCALL_ID_METADATA_STORAGE_WRITE,
+            write_input(slot, U256::ZERO),
+            gas_limit,
+            false,
+        );
+
+        assert_eq!(result, InstructionResult::OutOfFuel);
+        assert_eq!(
+            ctx.journal_mut().sload(owner, slot).unwrap().data,
+            old_value
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- apply cold/warm SLOAD gas accounting to metadata storage reads
- apply SSTORE stipend, static cost, cold-load, dynamic cost, and refund accounting to metadata storage writes
- add metadata storage syscall tests for cold/warm reads, write gas/refund, and low-gas no-mutation behavior

## Verification
- cargo fmt --check
- cargo test -p fluentbase-revm metadata_storage
- cargo clippy -p fluentbase-revm --all-targets -- -D warnings
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of metadata storage read/write syscall behavior.
  * Corrected gas charging for cold vs warm metadata storage access.
  * Applied proper account touch/refund handling on metadata storage writes.
  * Ensured metadata storage is not modified when a write runs out of gas.

* **Tests**
  * Added new tests validating metadata storage read/write results, gas costs, and refunds.
  * Added an out-of-gas test to confirm storage remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->