### PR TITLE
fix(ci): harden release supply chain

### DIFF
--- a/.github/scripts/check-release-supply-chain.sh
+++ b/.github/scripts/check-release-supply-chain.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow=${1:-.github/workflows/release.yml}
+
+fail=0
+
+while IFS=: read -r line_no ref; do
+  if [[ ! "$ref" =~ @[0-9a-f]{40}([[:space:]]|$) ]]; then
+    echo "${workflow}:${line_no}: action is not pinned to a full commit SHA: ${ref}" >&2
+    fail=1
+  fi
+done < <(grep -nE '^[[:space:]]*uses:[[:space:]]*[^[:space:]]+' "$workflow" | sed -E 's/^([0-9]+):[[:space:]]*uses:[[:space:]]*/\1:/')
+
+if grep -nE 'cargo[[:space:]]+(b|build|publish|nextest|test|clippy)([[:space:]]|$)' "$workflow" | grep -v -- '--locked' >&2; then
+  echo "${workflow}: cargo release invocations must use --locked or call a Make target that does" >&2
+  fail=1
+fi
+
+for required in 'release-manifest.sh create' 'release-manifest.sh verify' 'sbom' 'provenance'; do
+  if ! grep -q "$required" "$workflow"; then
+    echo "${workflow}: missing required release supply-chain marker: ${required}" >&2
+    fail=1
+  fi
+done
+
+exit "$fail"

--- a/.github/scripts/release-manifest.sh
+++ b/.github/scripts/release-manifest.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage:
+  release-manifest.sh create <manifest> <sbom> <version> <kind> <artifact-dir> [artifact...]
+  release-manifest.sh verify <manifest>
+
+Creates and verifies release provenance manifests without network access. The
+manifest binds the release commit, lockfile hashes, Rust toolchain, builder
+image identity, build features/configuration, runtime/genesis hashes, artifact
+hashes, and the SBOM hash.
+USAGE
+}
+
+json_escape() {
+  local s=${1-}
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
+sha256_file() {
+  sha256sum "$1" | awk '{print $1}'
+}
+
+image_digest() {
+  local image=${FLUENTBASE_BUILD_DOCKER_IMAGE:-}
+  local tag=${FLUENTBASE_BUILD_DOCKER_TAG:-}
+  local digest=${FLUENTBASE_BUILD_DOCKER_DIGEST:-}
+
+  if [[ -n "$digest" ]]; then
+    printf '%s' "$digest"
+    return
+  fi
+
+  if [[ -n "$image" && -n "$tag" ]] && command -v docker >/dev/null 2>&1; then
+    docker image inspect "${image}:${tag}" \
+      --format '{{range .RepoDigests}}{{println .}}{{end}}{{.Id}}' 2>/dev/null \
+      | sed '/^$/d' \
+      | head -n1
+  fi
+}
+
+write_lockfiles_json() {
+  local first=1 lock
+  while IFS= read -r lock; do
+    [[ $first -eq 0 ]] && printf ',\n'
+    first=0
+    printf '      {"path":"%s","sha256":"%s"}' \
+      "$(json_escape "$lock")" \
+      "$(sha256_file "$lock")"
+  done < <(find . -name Cargo.lock -type f | LC_ALL=C sort)
+}
+
+write_runtime_json() {
+  local first=1 file
+  for file in \
+    ./crates/genesis/genesis-devnet.json \
+    ./crates/genesis/genesis-mainnet.json \
+    ./crates/genesis/evm-runtime-permissive.rwasm
+  do
+    [[ -f "$file" ]] || continue
+    [[ $first -eq 0 ]] && printf ',\n'
+    first=0
+    printf '      {"path":"%s","sha256":"%s"}' \
+      "$(json_escape "$file")" \
+      "$(sha256_file "$file")"
+  done
+}
+
+write_artifacts_json() {
+  local first=1 file
+  for file in "$@"; do
+    [[ -f "$file" ]] || continue
+    [[ $first -eq 0 ]] && printf ',\n'
+    first=0
+    printf '      {"path":"%s","sha256":"%s","bytes":%s}' \
+      "$(json_escape "$file")" \
+      "$(sha256_file "$file")" \
+      "$(wc -c < "$file" | tr -d ' ')"
+  done
+}
+
+create_sbom() {
+  local sbom=$1
+  local generated_at
+  generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  {
+    printf '{\n'
+    printf '  "sbom_format": "fluentbase-cargo-locked-v1",\n'
+    printf '  "generated_at": "%s",\n' "$generated_at"
+    printf '  "source": {"repository":"%s","commit":"%s"},\n' \
+      "$(json_escape "${GITHUB_REPOSITORY:-unknown}")" \
+      "$(json_escape "${GITHUB_SHA:-$(git rev-parse HEAD)}")"
+    printf '  "packages": [\n'
+    cargo metadata --locked --format-version 1 \
+      | python3 -c 'import json,sys
+data=json.load(sys.stdin)
+pkgs=sorted(data["packages"], key=lambda p: (p["name"], p["version"], p["id"]))
+for i,p in enumerate(pkgs):
+    prefix="    " if i == 0 else ",\n    "
+    print(prefix + json.dumps({
+        "name": p["name"],
+        "version": p["version"],
+        "manifest_path": p["manifest_path"],
+        "license": p.get("license"),
+        "source": p.get("source"),
+    }, sort_keys=True, separators=(",", ":")), end="")
+'
+    printf '\n  ]\n'
+    printf '}\n'
+  } > "$sbom"
+}
+
+create_manifest() {
+  local manifest=$1 sbom=$2 version=$3 kind=$4 artifact_dir=$5
+  shift 5
+
+  mkdir -p "$artifact_dir"
+  create_sbom "$sbom"
+
+  local generated_at rustc rustup_toolchain digest cargo_config
+  generated_at=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  rustc=$(rustc -Vv | sed ':a;N;$!ba;s/\n/\\n/g')
+  rustup_toolchain=$(rustup show active-toolchain 2>/dev/null | awk '{print $1}' || true)
+  digest=$(image_digest || true)
+  cargo_config=${BUILD_FEATURES:-${FEATURES:-}}
+
+  {
+    printf '{\n'
+    printf '  "schema": "https://fluent.xyz/schemas/release-provenance-v1.json",\n'
+    printf '  "version": "%s",\n' "$(json_escape "$version")"
+    printf '  "kind": "%s",\n' "$(json_escape "$kind")"
+    printf '  "generated_at": "%s",\n' "$generated_at"
+    printf '  "source": {\n'
+    printf '    "repository": "%s",\n' "$(json_escape "${GITHUB_REPOSITORY:-unknown}")"
+    printf '    "ref": "%s",\n' "$(json_escape "${GITHUB_REF:-unknown}")"
+    printf '    "commit": "%s"\n' "$(json_escape "${GITHUB_SHA:-$(git rev-parse HEAD)}")"
+    printf '  },\n'
+    printf '  "toolchain": {\n'
+    printf '    "rust_toolchain_file": "%s",\n' "$(json_escape "$(tr -d '\n' < rust-toolchain 2>/dev/null || true)")"
+    printf '    "rustup_active_toolchain": "%s",\n' "$(json_escape "$rustup_toolchain")"
+    printf '    "rustc": "%s"\n' "$(json_escape "$rustc")"
+    printf '  },\n'
+    printf '  "builder": {\n'
+    printf '    "image": "%s",\n' "$(json_escape "${FLUENTBASE_BUILD_DOCKER_IMAGE:-}")"
+    printf '    "tag": "%s",\n' "$(json_escape "${FLUENTBASE_BUILD_DOCKER_TAG:-}")"
+    printf '    "digest": "%s"\n' "$(json_escape "$digest")"
+    printf '  },\n'
+    printf '  "build_config": {\n'
+    printf '    "target": "%s",\n' "$(json_escape "${BUILD_TARGET:-}")"
+    printf '    "profile": "%s",\n' "$(json_escape "${BUILD_PROFILE:-}")"
+    printf '    "features": "%s",\n' "$(json_escape "$cargo_config")"
+    printf '    "no_default_features": "%s"\n' "$(json_escape "${NO_DEFAULT_FEATURES:-}")"
+    printf '  },\n'
+    printf '  "lockfiles": [\n'
+    write_lockfiles_json
+    printf '\n  ],\n'
+    printf '  "runtime_and_genesis": [\n'
+    write_runtime_json
+    printf '\n  ],\n'
+    printf '  "artifacts": [\n'
+    write_artifacts_json "$@"
+    printf '\n  ],\n'
+    printf '  "sbom": {"path":"%s","sha256":"%s"}\n' \
+      "$(json_escape "$sbom")" \
+      "$(sha256_file "$sbom")"
+    printf '}\n'
+  } > "$manifest"
+}
+
+verify_manifest() {
+  local manifest=$1
+  python3 - "$manifest" <<'PY'
+import hashlib
+import json
+import pathlib
+import sys
+
+manifest = pathlib.Path(sys.argv[1])
+data = json.loads(manifest.read_text())
+errors = []
+
+def check_file(entry, label):
+    path = pathlib.Path(entry["path"])
+    if not path.exists():
+        errors.append(f"{label} missing: {path}")
+        return
+    actual = hashlib.sha256(path.read_bytes()).hexdigest()
+    if actual != entry["sha256"]:
+        errors.append(f"{label} hash mismatch for {path}: {actual} != {entry['sha256']}")
+
+for entry in data.get("lockfiles", []):
+    check_file(entry, "lockfile")
+for entry in data.get("runtime_and_genesis", []):
+    check_file(entry, "runtime/genesis")
+for entry in data.get("artifacts", []):
+    check_file(entry, "artifact")
+check_file(data["sbom"], "sbom")
+
+if not data.get("source", {}).get("commit"):
+    errors.append("source commit is missing")
+if data.get("builder", {}).get("image") and not data.get("builder", {}).get("digest"):
+    errors.append("builder image is set but digest/id is missing")
+if not data.get("toolchain", {}).get("rustc"):
+    errors.append("rustc version is missing")
+
+if errors:
+    for error in errors:
+        print(error, file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+case "${1-}" in
+  create)
+    [[ $# -ge 6 ]] || { usage; exit 2; }
+    shift
+    create_manifest "$@"
+    ;;
+  verify)
+    [[ $# -eq 2 ]] || { usage; exit 2; }
+    verify_manifest "$2"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,18 +15,18 @@ jobs:
       contents: read
       pull-requests: write  # needed to comment on PRs (won’t work for forks; see note below)
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Install clang and build tools
         run: |
           sudo apt-get update
           sudo apt-get install -y clang libclang-dev pkg-config
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
 
       # Try to fetch the latest successful baseline from devel
       - name: Download baseline from devel
         id: dl
-        uses: dawidd6/action-download-artifact@v21
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         continue-on-error: true            # allow first PRs without a baseline
         with:
           workflow: bench.yml
@@ -46,7 +46,7 @@ jobs:
           cd e2e && cargo bench | grep -v ignored | tee bench_output.txt
 
       - name: Upload full report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: criterion-report-${{ github.sha }}
           path: target/criterion
@@ -63,7 +63,7 @@ jobs:
             echo
             echo "_Heads-up_: runner perf is noisy; treat deltas as a smoke check."
           } > comment.md
-      - uses: marocchino/sticky-pull-request-comment@v3
+      - uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           path: comment.md

--- a/.github/workflows/build-docker-cleanup.yml
+++ b/.github/workflows/build-docker-cleanup.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Delete old package versions
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@25ad4af5be03aef10e0b3376b248688b7a44c40b # v5
         with:
           package-name: ${{ env.PACKAGE_NAME }}
           package-type: "container"
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete old untagged versions
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@25ad4af5be03aef10e0b3376b248688b7a44c40b # v5
         with:
           package-name: ${{ env.PACKAGE_NAME }}
           package-type: "container"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -33,13 +33,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -121,7 +121,7 @@ jobs:
           echo "  TAGS=${TAGS}"
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./
           file: ./docker/Dockerfile.build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ env:
   CXX: clang++
 
 jobs:
+  release-supply-chain:
+    name: Release supply-chain guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Check release workflow hardening
+        run: ./.github/scripts/check-release-supply-chain.sh .github/workflows/release.yml
+
   tests:
     name: Tests (${{ matrix.name }})
     runs-on: self-hosted
@@ -89,7 +97,7 @@ jobs:
             cache-key: fixture-std-wasmtime
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: recursive
           fetch-depth: 1
@@ -103,7 +111,7 @@ jobs:
         run: git config --global net.git-fetch-with-cli true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
 
@@ -111,10 +119,10 @@ jobs:
         run: rustup target list --installed | grep -q '^wasm32-unknown-unknown$' || rustup target add wasm32-unknown-unknown
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
 
       - name: Rust cache (registries + git)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           cache-targets: false
           cache-all-crates: true
@@ -186,7 +194,7 @@ jobs:
     runs-on: self-hosted
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: recursive
           fetch-depth: 1
@@ -200,7 +208,7 @@ jobs:
         run: git config --global net.git-fetch-with-cli true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
 
@@ -208,10 +216,10 @@ jobs:
         run: rustup target list --installed | grep -q '^wasm32-unknown-unknown$' || rustup target add wasm32-unknown-unknown
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
 
       - name: Rust cache (registries + git)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           cache-targets: false
           cache-all-crates: true
@@ -230,13 +238,13 @@ jobs:
           cargo tarpaulin --verbose --timeout 120 --out xml
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v7.0.0
+        uses: codecov/codecov-action@e53489f4d376d79066609109e7a95a29eb3740b1 # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: code-coverage-report
           path: cobertura.xml
@@ -246,7 +254,7 @@ jobs:
     runs-on: self-hosted
     if: github.event_name == 'workflow_dispatch'
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: recursive
           fetch-depth: 1
@@ -255,7 +263,7 @@ jobs:
         run: git config --global net.git-fetch-with-cli true
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -264,10 +272,10 @@ jobs:
         run: rustup target list --installed | grep -q '^wasm32-unknown-unknown$' || rustup target add wasm32-unknown-unknown
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
+        uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
 
       - name: Rust cache (registries + git)
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           cache-targets: false
           cache-all-crates: true

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -30,7 +30,7 @@ jobs:
             command: cargo clippy --manifest-path=./examples/Cargo.toml --workspace --all-targets -- -D warnings
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           submodules: recursive
           fetch-depth: 1
@@ -41,7 +41,7 @@ jobs:
           sudo apt-get install -y clang libclang-dev
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
 
@@ -52,7 +52,7 @@ jobs:
         run: rustup target list --installed | grep -q '^wasm32-unknown-unknown$' || rustup target add wasm32-unknown-unknown
 
       - name: Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           cache-on-failure: true
           shared-key: clippy-${{ matrix.name }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,9 @@ env:
   CARGO_TERM_COLOR: always
   DOCKER_IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/fluent
   DOCKER_USERNAME: ${{ github.actor }}
+  RUST_TOOLCHAIN: "1.93.1"
+  CROSS_REV: "64b5bb4d3d34de062552b9a2093affe77b4ad16a"
+  BINFMT_IMAGE: "tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0"
   CARGO_NET_GIT_FETCH_WITH_CLI: true
   CC: clang
   CXX: clang++
@@ -31,24 +34,25 @@ jobs:
           - name: "Build and push fluent image"
             command: "make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push"
     steps:
-      - uses: actions/checkout@v7
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           cache-on-failure: true
       - name: Install cross main
         id: cross_main
         run: |
-          cargo +1.93.1 install cross --git https://github.com/cross-rs/cross
+          cargo +${RUST_TOOLCHAIN} install cross --git https://github.com/cross-rs/cross --rev ${CROSS_REV} --locked
       - name: Log in to Docker
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
       - name: Set up Docker builder
         run: |
-          docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
+          docker run --privileged --rm "${BINFMT_IMAGE}" --install arm64,amd64
           docker buildx create --use --name cross-builder
       - name: Build and push ${{ matrix.build.name }}
         run: ${{ matrix.build.command }}
@@ -67,24 +71,25 @@ jobs:
           - name: "Build and push fluent image"
             command: "make IMAGE_NAME=$IMAGE_NAME DOCKER_IMAGE_NAME=$DOCKER_IMAGE_NAME PROFILE=maxperf docker-build-push-latest"
     steps:
-      - uses: actions/checkout@v7
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           cache-on-failure: true
       - name: Install cross main
         id: cross_main
         run: |
-          cargo +1.93.1 install cross --git https://github.com/cross-rs/cross
+          cargo +${RUST_TOOLCHAIN} install cross --git https://github.com/cross-rs/cross --rev ${CROSS_REV} --locked
       - name: Log in to Docker
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username ${DOCKER_USERNAME} --password-stdin
       - name: Set up Docker builder
         run: |
-          docker run --privileged --rm tonistiigi/binfmt --install arm64,amd64
+          docker run --privileged --rm "${BINFMT_IMAGE}" --install arm64,amd64
           docker buildx create --use --name cross-builder
       - name: Install clang and build tools
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: "1.93.1"
 
 jobs:
   publish:
@@ -23,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Extract and sanitize version
         id: extract_version
@@ -33,10 +34,12 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
@@ -55,19 +58,19 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          cargo publish -p fluentbase-codec-derive
+          cargo publish --locked -p fluentbase-codec-derive
           cargo search fluentbase-codec-derive | head
-          cargo publish -p fluentbase-codec
+          cargo publish --locked -p fluentbase-codec
           cargo search fluentbase-codec | head
-          cargo publish -p fluentbase-types
+          cargo publish --locked -p fluentbase-types
           cargo search fluentbase-types | head
-          cargo publish -p fluentbase-runtime
+          cargo publish --locked -p fluentbase-runtime
           cargo search fluentbase-runtime | head
-          cargo publish -p fluentbase-crypto
+          cargo publish --locked -p fluentbase-crypto
           cargo search fluentbase-crypto | head
-          cargo publish -p fluentbase-sdk-derive-core
+          cargo publish --locked -p fluentbase-sdk-derive-core
           cargo search fluentbase-sdk-derive-core | head
-          cargo publish -p fluentbase-sdk-derive
+          cargo publish --locked -p fluentbase-sdk-derive
           cargo search fluentbase-sdk-derive | head
-          cargo publish -p fluentbase-sdk
+          cargo publish --locked -p fluentbase-sdk
           cargo search fluentbase-sdk | head

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  RUST_TOOLCHAIN: "1.93.1"
+  CROSS_REV: "64b5bb4d3d34de062552b9a2093affe77b4ad16a"
   REPO_NAME: ${{ github.repository_owner }}/fluent
   IMAGE_NAME: ${{ github.repository_owner }}/fluent
   DOCKER_IMAGE_NAME_URL: https://ghcr.io/${{ github.repository_owner }}/fluent
@@ -51,8 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: extract-version
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Verify crate version matches tag
         # Check that the Cargo version starts with the tag,
         # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
@@ -71,10 +75,12 @@ jobs:
       contents: read
       packages: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.10
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
+      - uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           cache-on-failure: true
 
@@ -100,7 +106,7 @@ jobs:
         run: |
           docker build \
             --file ./docker/Dockerfile.build \
-            --build-arg RUST_TOOLCHAIN=1.93.1 \
+            --build-arg RUST_TOOLCHAIN=${RUST_TOOLCHAIN} \
             --build-arg SDK_VERSION_BRANCH=${{ github.ref_name }} \
             --build-arg SDK_VERSION_TAG= \
             --tag ${{ steps.build_image.outputs.image }}:${{ steps.build_image.outputs.tag }} \
@@ -119,6 +125,8 @@ jobs:
           for i in $(seq 1 40); do
             if docker pull "$IMAGE"; then
               echo "Builder image is available"
+              digest="$(docker image inspect "$IMAGE" --format '{{range .RepoDigests}}{{println .}}{{end}}{{.Id}}' | sed '/^$/d' | head -n1)"
+              echo "digest=$digest" >> "$GITHUB_OUTPUT"
               exit 0
             fi
             echo "[$i/40] image not ready yet, retrying in 30s"
@@ -135,14 +143,15 @@ jobs:
           FLUENTBASE_CONTRACTS_DOCKER: "true"
           FLUENTBASE_BUILD_DOCKER_IMAGE: ${{ steps.build_image.outputs.image }}
           FLUENTBASE_BUILD_DOCKER_TAG: ${{ steps.build_image.outputs.tag }}
+          FLUENTBASE_BUILD_DOCKER_DIGEST: ${{ steps.build_image.outputs.digest }}
         run: |
-          cargo b --release
+          cargo build --release --locked
           sha256sum \
             ./crates/genesis/genesis-devnet.json \
             ./crates/genesis/genesis-mainnet.json \
             ./crates/genesis/evm-runtime-permissive.rwasm \
             > /tmp/fluentbase-genesis.sha256
-          cargo b --release
+          cargo build --release --locked
           sha256sum --check /tmp/fluentbase-genesis.sha256
 
       - name: Package genesis files
@@ -169,6 +178,27 @@ jobs:
               ./artifacts/evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
           } > ./artifacts/genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
 
+      - name: Generate genesis provenance and SBOM
+        env:
+          FLUENTBASE_BUILD_DOCKER_IMAGE: ${{ steps.build_image.outputs.image }}
+          FLUENTBASE_BUILD_DOCKER_TAG: ${{ steps.build_image.outputs.tag }}
+          FLUENTBASE_BUILD_DOCKER_DIGEST: ${{ steps.build_image.outputs.digest }}
+          BUILD_TARGET: "genesis"
+          BUILD_PROFILE: "release"
+        run: |
+          ./.github/scripts/release-manifest.sh create \
+            ./artifacts/genesis-provenance-${{ needs.extract-version.outputs.VERSION }}.json \
+            ./artifacts/genesis-sbom-${{ needs.extract-version.outputs.VERSION }}.json \
+            "${{ needs.extract-version.outputs.VERSION }}" \
+            genesis \
+            ./artifacts \
+            ./artifacts/genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz \
+            ./artifacts/genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz \
+            ./artifacts/evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz \
+            ./artifacts/genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
+          ./.github/scripts/release-manifest.sh verify \
+            ./artifacts/genesis-provenance-${{ needs.extract-version.outputs.VERSION }}.json
+
       - name: Configure GPG and sign genesis artifacts
         if: ${{ github.event.inputs.dry_run != 'true' }}
         env:
@@ -181,7 +211,9 @@ jobs:
           for artifact in \
             genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz \
             genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz \
-            genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
+            genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt \
+            genesis-provenance-${{ needs.extract-version.outputs.VERSION }}.json \
+            genesis-sbom-${{ needs.extract-version.outputs.VERSION }}.json
           do
             echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab "$artifact"
           done
@@ -189,52 +221,80 @@ jobs:
 
       - name: Upload devnet genesis
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz
           path: genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz
 
       - name: Upload mainnet genesis
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz
           path: genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz
 
       - name: Upload permissive EVM runtime
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
           path: evm-runtime-permissive-${{ needs.extract-version.outputs.VERSION }}.rwasm.gz
 
       - name: Upload genesis manifest
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
           path: genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt
 
+      - name: Upload genesis provenance
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: genesis-provenance-${{ needs.extract-version.outputs.VERSION }}.json
+          path: genesis-provenance-${{ needs.extract-version.outputs.VERSION }}.json
+
+      - name: Upload genesis SBOM
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: genesis-sbom-${{ needs.extract-version.outputs.VERSION }}.json
+          path: genesis-sbom-${{ needs.extract-version.outputs.VERSION }}.json
+
       - name: Upload devnet genesis signature
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz.asc
           path: genesis-${{ needs.extract-version.outputs.VERSION }}.json.gz.asc
 
       - name: Upload mainnet genesis signature
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz.asc
           path: genesis-mainnet-${{ needs.extract-version.outputs.VERSION }}.json.gz.asc
 
       - name: Upload genesis manifest signature
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt.asc
           path: genesis-manifest-${{ needs.extract-version.outputs.VERSION }}.txt.asc
+
+      - name: Upload genesis provenance signature
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: genesis-provenance-${{ needs.extract-version.outputs.VERSION }}.json.asc
+          path: genesis-provenance-${{ needs.extract-version.outputs.VERSION }}.json.asc
+
+      - name: Upload genesis SBOM signature
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: genesis-sbom-${{ needs.extract-version.outputs.VERSION }}.json.asc
+          path: genesis-sbom-${{ needs.extract-version.outputs.VERSION }}.json.asc
 
   build:
     name: build release
@@ -279,17 +339,18 @@ jobs:
               jemalloc,otlp,otlp-logs,reth-revm/portable,js-tracer,
               keccak-cache-global,asm-keccak,min-debug-logs
     steps:
-      - uses: actions/checkout@v7
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           target: ${{ matrix.configs.target }}
-      - uses: mozilla-actions/sccache-action@v0.0.10
+      - uses: mozilla-actions/sccache-action@1583d6b38d7be47f593cb472781bbb21cab4321e # v0.0.10
       - name: Install cross main
         id: cross_main
         run: |
-          cargo +1.93.1 install cross --git https://github.com/cross-rs/cross
-      - uses: Swatinem/rust-cache@v2
+          cargo +${RUST_TOOLCHAIN} install cross --git https://github.com/cross-rs/cross --rev ${CROSS_REV} --locked
+      - uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
         with:
           cache-on-failure: true
       - name: Apple M1 setup
@@ -303,6 +364,9 @@ jobs:
       - name: Build Fluent
         env:
           BUILD_FEATURES: ${{ matrix.build.features }}
+          BUILD_TARGET: ${{ matrix.configs.target }}
+          BUILD_PROFILE: ${{ matrix.configs.profile }}
+          NO_DEFAULT_FEATURES: "--no-default-features"
         run: make PROFILE=${{ matrix.configs.profile }} FEATURES="$BUILD_FEATURES" NO_DEFAULT_FEATURES="--no-default-features" ${{ matrix.build.command }}-${{ matrix.configs.target }}
 
       - name: Move binary
@@ -317,24 +381,67 @@ jobs:
         run: |
           export GPG_TTY=$(tty)
           echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import
+          tar -C artifacts -czf artifacts/${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.artifact_binary }}
+          ./.github/scripts/release-manifest.sh create \
+            artifacts/${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-provenance.json \
+            artifacts/${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-sbom.json \
+            "${{ needs.extract-version.outputs.VERSION }}" \
+            "${{ matrix.build.artifact_binary }}" \
+            artifacts \
+            artifacts/${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
+          ./.github/scripts/release-manifest.sh verify \
+            artifacts/${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-provenance.json
           cd artifacts
-          tar -czf ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz ${{ matrix.build.artifact_binary }}
-          echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
-          mv *tar.gz* ..
+          for artifact in \
+            ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz \
+            ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-provenance.json \
+            ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-sbom.json
+          do
+            echo "$GPG_PASSPHRASE" | gpg --passphrase-fd 0 --pinentry-mode loopback --batch -ab "$artifact"
+          done
+          mv * ..
 
       - name: Upload fluent
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
           path: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz
 
       - name: Upload fluent signature
         if: ${{ github.event.inputs.dry_run != 'true' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.asc
           path: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}.tar.gz.asc
+
+      - name: Upload fluent provenance
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-provenance.json
+          path: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-provenance.json
+
+      - name: Upload fluent provenance signature
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-provenance.json.asc
+          path: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-provenance.json.asc
+
+      - name: Upload fluent SBOM
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-sbom.json
+          path: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-sbom.json
+
+      - name: Upload fluent SBOM signature
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-sbom.json.asc
+          path: ${{ matrix.build.artifact_binary }}-${{ needs.extract-version.outputs.VERSION }}-${{ matrix.configs.target }}-sbom.json.asc
 
   draft-release:
     name: draft release
@@ -349,12 +456,12 @@ jobs:
     steps:
       # This is necessary for generating the changelog.
       # It has to come before "Download Artifacts" or else it deletes the artifacts.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
           fetch-tags: true
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
       - name: Generate full changelog
         id: changelog
         # Build release notes by writing git output to a file via redirection.
@@ -400,6 +507,10 @@ jobs:
             assets+=("$d/$(basename "$d")")
           done
           for d in ./*genesis-manifest-*.txt*; do
+            assets+=("$d/$(basename "$d")")
+          done
+          for d in ./*provenance-*.json* ./*-provenance.json* ./*sbom-*.json* ./*-sbom.json*; do
+            [[ -e "$d" ]] || continue
             assets+=("$d/$(basename "$d")")
           done
           gh release create --draft $prerelease_flag -t "Genesis ${VERSION}" -F release-notes.md "${VERSION}" "${assets[@]}"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all: check build
 
+CARGO_LOCKED_FLAGS ?= --locked
+
 .PHONY: check
 check:
 	cargo check --all
@@ -15,7 +17,7 @@ pr: clippy test
 
 .PHONY: build
 build:
-	cargo build --all
+	cargo build $(CARGO_LOCKED_FLAGS) --all
 
 .PHONY: update-deps
 update-deps:
@@ -133,7 +135,7 @@ install: ## Build and install the fluent binary under `$(CARGO_HOME)/bin`.
 
 .PHONY: build-fluent
 build-fluent: ## Build the fluent binary into `target` directory.
-	cargo build --bin fluent --features "$(FEATURES)" --profile "$(PROFILE)"
+	cargo build $(CARGO_LOCKED_FLAGS) --bin fluent --features "$(FEATURES)" --profile "$(PROFILE)"
 
 # Environment variables for reproducible builds
 # Set timestamp from last git commit for reproducible builds
@@ -157,11 +159,11 @@ build-%-reproducible:
 
 .PHONY: build-debug
 build-debug: ## Build the fluent binary into `target/debug` directory.
-	cargo build --bin fluent --features "$(FEATURES)"
+	cargo build $(CARGO_LOCKED_FLAGS) --bin fluent --features "$(FEATURES)"
 
 # Builds the fluent binary natively.
 build-native-%:
-	cargo build --bin fluent --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
+	cargo build $(CARGO_LOCKED_FLAGS) --bin fluent --target $* --features "$(FEATURES)" --profile "$(PROFILE)"
 
 # The following commands use `cross` to build a cross-compile.
 #
@@ -187,7 +189,7 @@ build-x86_64-pc-windows-gnu: FEATURES := $(filter-out jemalloc jemalloc-prof,$(F
 # See: https://github.com/cross-rs/cross/wiki/FAQ#undefined-reference-with-build-std
 build-%:
 	RUSTFLAGS="-C link-arg=-lgcc -Clink-arg=-static-libgcc" \
-		cross build --bin fluent --target $* $(NO_DEFAULT_FEATURES) --features "$(FEATURES)" --profile "$(PROFILE)"
+		cross build $(CARGO_LOCKED_FLAGS) --bin fluent --target $* $(NO_DEFAULT_FEATURES) --features "$(FEATURES)" --profile "$(PROFILE)"
 
 # Unfortunately we can't easily use cross to build for Darwin because of licensing issues.
 # If we wanted to, we would need to build a custom Docker image with the SDK available.
@@ -255,7 +257,7 @@ define docker_build_push
 		--platform linux/amd64,linux/arm64 \
 		--tag $(DOCKER_IMAGE_NAME):$(1) \
 		--tag $(DOCKER_IMAGE_NAME):$(2) \
-		--provenance=false \
+		--provenance=true \
 		--push
 endef
 

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -44,8 +44,8 @@ RUN if [ -n "$SDK_VERSION_BRANCH" ]; then \
 # lib.rs
 RUN printf '#![cfg_attr(not(feature = "std"), no_std, no_main)]\n\nextern crate alloc;\nextern crate fluentbase_sdk;\n\nuse fluentbase_sdk::{\n    basic_entrypoint,\n    derive::{router, Contract},\n    SharedAPI,\n    U256,\n};\n\n#[derive(Contract, Default)]\nstruct Warmer<SDK> {\n    sdk: SDK,\n}\n\npub trait WarmerAPI {\n    fn warm(&self) -> U256;\n}\n\n#[router(mode = "solidity")]\nimpl<SDK: SharedAPI> WarmerAPI for Warmer<SDK> {\n    fn warm(&self) -> U256 {\n        U256::from(2)\n    }\n}\n\nimpl<SDK: SharedAPI> Warmer<SDK> {\n    pub fn deploy(&self) {}\n}\n\nbasic_entrypoint!(Warmer);\n' > lib.rs
 
-RUN cargo fetch --target wasm32-unknown-unknown && \
-    cargo build --release --target wasm32-unknown-unknown --lib
+RUN cargo fetch --locked --target wasm32-unknown-unknown && \
+    cargo build --release --locked --target wasm32-unknown-unknown --lib
 
 #######################################
 # Final SDK


### PR DESCRIPTION
## Summary
- pin GitHub Actions, Rust toolchains, cross install revisions, and binfmt helper image references used by CI/release workflows
- enforce locked Cargo builds/publishes/fetches in release-sensitive paths and the builder image
- add release provenance/SBOM generation, hash verification before signing, signed provenance/SBOM uploads, and a CI guard for release workflow drift

## Verification
- git diff --check
- bash -n .github/scripts/release-manifest.sh .github/scripts/check-release-supply-chain.sh
- .github/scripts/check-release-supply-chain.sh .github/workflows/release.yml
- workflow YAML parse via PyYAML
- local release-manifest.sh create/verify smoke test with a dummy artifact

Linear: FLU-946