### PR TITLE
fix(evm): use zero blob gas price for evm interpreter

### DIFF
--- a/crates/evm/src/host.rs
+++ b/crates/evm/src/host.rs
@@ -56,10 +56,7 @@ impl<'a, SDK: SystemAPI> Host for HostWrapperImpl<'a, SDK> {
     }
 
     fn blob_gasprice(&self) -> U256 {
-        // TODO(dmitry123): Why block base fee works here and tests pass if blob price equals to base price?
-        //  Check test (cargo:test://evm_e2e::short_tests::good_coverage_tests::opc4_adiff_places)
-        //  P.S: We don't support blobs in Fluent yet, so need to check how it can affect the system.
-        self.sdk.context().block_base_fee()
+        U256::ZERO
     }
 
     fn gas_limit(&self) -> U256 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected blob gas price handling to return a zero value when no blob gas price is available.
  * Removed the previous fallback that incorrectly derived blob gas pricing from the block base fee.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->