### PR TITLE
chore(deps): bump rwasm to 0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12324,13 +12324,12 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ca3389842e77886fbea818729e0b19fdf5bfa2fe83f8847ba529c0f00817e8"
+checksum = "44e76cddefd31473f933059faa2b11efca2489337b2b785c2e2b7110fac45e1f"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",
- "bytes",
  "downcast-rs",
  "hashbrown 0.17.1",
  "libm",
@@ -12341,7 +12340,7 @@ dependencies = [
  "rwasm-fuel-policy",
  "serde",
  "smallvec",
- "spin 0.10.0",
+ "spin 0.12.2",
  "tiny-keccak",
  "wasmparser-nostd",
  "wasmtime-rwasm",
@@ -13140,6 +13139,12 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spin"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ fluentbase-types = { path = "./crates/types", default-features = false, version 
 #solana_rbpf = { path = "../rbpf", default-features = false }
 
 # rwasm
-rwasm = { version = "0.4.4", default-features = false }
+rwasm = { version = "0.4.5", default-features = false }
 
 # alloy
 alloy-primitives = { version = "1.5.6", default-features = false, features = ["map-foldhash", "sha3-keccak", "rlp"] }
@@ -147,7 +147,7 @@ serde = { version = "1.0.203", default-features = false, features = ["derive", "
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_bytes = { version = "0.11.15", default-features = false }
 serde_with = { version = "3.11.0", default-features = false }
-spin = { version = "0.10.0", default-features = false, features = ["mutex"] }
+spin = { version = "0.10.0", default-features = false, features = ["mutex", "once", "spin_mutex"] }
 static_assertions = { version = "1.1.0", default-features = false }
 memoffset = { version = "0.9.1", default-features = false }
 paste = { version = "1.0", default-features = false }

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
  "fluentbase-evm",
  "fluentbase-sdk",
  "fluentbase-testing",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2212,7 +2212,7 @@ dependencies = [
  "fluentbase-types",
  "hashbrown 0.16.1",
  "rwasm",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -4187,13 +4187,12 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ca3389842e77886fbea818729e0b19fdf5bfa2fe83f8847ba529c0f00817e8"
+checksum = "44e76cddefd31473f933059faa2b11efca2489337b2b785c2e2b7110fac45e1f"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",
- "bytes",
  "downcast-rs",
  "hashbrown 0.17.1",
  "libm",
@@ -4204,7 +4203,7 @@ dependencies = [
  "rwasm-fuel-policy",
  "serde",
  "smallvec",
- "spin",
+ "spin 0.12.2",
  "tiny-keccak",
  "wasmparser-nostd",
  "wasmtime-rwasm",
@@ -4620,6 +4619,12 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spin"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 dependencies = [
  "lock_api",
 ]

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -33,7 +33,7 @@ hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 ecdsa = { git = "https://github.com/rwasm-patches/signatures.git", default-features = false, features = ["hazmat", "verifying"] }
 k256 = { version = "0.13.4", default-features = false }
 hashbrown = { version = "0.16.0", default-features = false, features = ["default-hasher", "inline-more"] }
-spin = { version = "0.10.0", default-features = false, features = ["mutex"] }
+spin = { version = "0.10.0", default-features = false, features = ["mutex", "once", "spin_mutex"] }
 
 [profile.release]
 panic = "abort"

--- a/crates/runtime/src/runtime/system_runtime.rs
+++ b/crates/runtime/src/runtime/system_runtime.rs
@@ -379,6 +379,8 @@ fn system_runtime_compilation_config(
         .with_import_linker(import_linker)
         .with_allow_malformed_entrypoint_func_type(true)
         .with_consume_fuel(consume_fuel)
+        // Wasmtime meters bulk operations itself; rWasm instrumentation would diverge.
+        .with_consume_fuel_for_bulk_ops(false)
         .with_consume_fuel_for_params_and_locals(false)
         .with_builtins_consume_fuel(false)
         .with_max_allowed_memory_pages(N_MAX_ALLOWED_MEMORY_PAGES)
@@ -408,6 +410,14 @@ mod tests {
     fn cache_contains(cache_key: CompiledModuleCacheKey) -> bool {
         COMPILED_RUNTIMES
             .with_borrow(|compiled_runtimes| compiled_runtimes.contains_key(&cache_key))
+    }
+
+    #[test]
+    fn system_runtime_config_disables_rwasm_bulk_op_metering() {
+        let config = system_runtime_compilation_config(import_linker_v1_preview(), true);
+
+        assert!(config.consume_fuel);
+        assert!(!config.consume_fuel_for_bulk_ops);
     }
 
     #[test]

--- a/evm-e2e/Cargo.lock
+++ b/evm-e2e/Cargo.lock
@@ -4173,13 +4173,12 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ca3389842e77886fbea818729e0b19fdf5bfa2fe83f8847ba529c0f00817e8"
+checksum = "44e76cddefd31473f933059faa2b11efca2489337b2b785c2e2b7110fac45e1f"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",
- "bytes",
  "downcast-rs",
  "hashbrown 0.17.1",
  "libm",
@@ -4190,7 +4189,7 @@ dependencies = [
  "rwasm-fuel-policy",
  "serde",
  "smallvec",
- "spin 0.10.0",
+ "spin 0.12.2",
  "tiny-keccak",
  "wasmparser-nostd",
  "wasmtime-rwasm",
@@ -4621,6 +4620,12 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spin"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 dependencies = [
  "lock_api",
 ]

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -2010,7 +2010,7 @@ dependencies = [
  "fluentbase-types",
  "hashbrown 0.16.1",
  "rwasm",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -4067,13 +4067,12 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ca3389842e77886fbea818729e0b19fdf5bfa2fe83f8847ba529c0f00817e8"
+checksum = "44e76cddefd31473f933059faa2b11efca2489337b2b785c2e2b7110fac45e1f"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",
- "bytes",
  "downcast-rs",
  "hashbrown 0.17.1",
  "libm",
@@ -4083,7 +4082,7 @@ dependencies = [
  "rwasm-fuel-policy",
  "serde",
  "smallvec",
- "spin",
+ "spin 0.12.2",
  "tiny-keccak",
  "wasmparser-nostd",
  "wasmtime-rwasm",
@@ -4580,6 +4579,12 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spin"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
## Summary

- bump the workspace `rwasm` dependency and all four lockfiles from 0.4.4 to 0.4.5
- make Wasmtime system-runtime bulk-op metering policy explicit and cover it with a regression test
- explicitly enable the `spin` 0.10 mutex/once implementations that were previously inherited through rWasm feature unification

## Testing

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p fluentbase-sdk default_config_meters_bulk_ops --locked`
- `cargo test -p fluentbase-runtime --features wasmtime --locked`
- `cargo check --workspace --all-targets --locked`
- `cargo check --manifest-path=./contracts/Cargo.toml --workspace --all-targets --locked`
- `cargo check --manifest-path=./examples/Cargo.toml --workspace --all-targets --locked`
- `cargo check --manifest-path=./evm-e2e/Cargo.toml --all-targets --locked`
- root, contracts, and examples workspace clippy with `--all-targets --locked -- -D warnings`

Linear: https://linear.app/fluentlabs-xyz/issue/FLU-971/bump-fluentbases-rwasm-version-to-v045


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime execution reliability for bulk operations.
  * Updated runtime configuration to apply fuel metering consistently, helping prevent unexpected execution behavior.

* **Chores**
  * Updated internal runtime support components and enabled required execution capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->