### PR TITLE
fix(ci): generate cache-warmer lockfile

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -44,7 +44,8 @@ RUN if [ -n "$SDK_VERSION_BRANCH" ]; then \
 # lib.rs
 RUN printf '#![cfg_attr(not(feature = "std"), no_std, no_main)]\n\nextern crate alloc;\nextern crate fluentbase_sdk;\n\nuse fluentbase_sdk::{\n    basic_entrypoint,\n    derive::{router, Contract},\n    SharedAPI,\n    U256,\n};\n\n#[derive(Contract, Default)]\nstruct Warmer<SDK> {\n    sdk: SDK,\n}\n\npub trait WarmerAPI {\n    fn warm(&self) -> U256;\n}\n\n#[router(mode = "solidity")]\nimpl<SDK: SharedAPI> WarmerAPI for Warmer<SDK> {\n    fn warm(&self) -> U256 {\n        U256::from(2)\n    }\n}\n\nimpl<SDK: SharedAPI> Warmer<SDK> {\n    pub fn deploy(&self) {}\n}\n\nbasic_entrypoint!(Warmer);\n' > lib.rs
 
-RUN cargo fetch --locked --target wasm32-unknown-unknown && \
+RUN cargo generate-lockfile && \
+    cargo fetch --locked --target wasm32-unknown-unknown && \
     cargo build --release --locked --target wasm32-unknown-unknown --lib
 
 #######################################


### PR DESCRIPTION
## Summary

- generate the synthetic cache-warmer project's lockfile before using Cargo's locked mode
- retain `--locked` for both dependency fetching and the release WASM build

## Context

The `v1.3.2` release image failed because `/warmup` is generated without a `Cargo.lock`, but the first Cargo invocation was `cargo fetch --locked`:

https://github.com/fluentlabs-xyz/fluentbase/actions/runs/29755299463/job/88395978237

Linear: https://linear.app/fluentlabs-xyz/issue/FLU-977/fix-release-docker-cache-warmer-lockfile-generation

## Verification

- `git diff --check`
- reproduced the generated warmup project locally against SDK tag `v1.3.2` with Cargo/Rust 1.93.1
- `cargo generate-lockfile && cargo fetch --locked --target wasm32-unknown-unknown && cargo build --release --locked --target wasm32-unknown-unknown --lib`

The exact Docker stage could not be run on the development host because Docker is not installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the build process to prepare and cache Rust dependencies more reliably.
  * Maintained locked dependency fetching for consistent release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->