### PR TITLE
feat(staking): add staking contract

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2106,6 +2106,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluentbase-contracts-staking"
+version = "0.1.0"
+dependencies = [
+ "fluentbase-sdk",
+ "fluentbase-testing",
+]
+
+[[package]]
 name = "fluentbase-contracts-universal-token"
 version = "0.1.0"
 dependencies = [

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -24,6 +24,7 @@ Each subfolder is an individual crate. Notable crates include:
 - ripemd160 — RIPEMD-160 precompile.
 - secp256r1 — secp256r1 (P-256) signature verification precompile (EIP-7212).
 - sha256 — SHA-256 hashing precompile.
+- staking — Genesis validator staking, delegation, rewards, committees, and slashing.
 - svm — Solana VM (SVM) integration contracts.
 - wasm — A compiler form Wasm into rWasm (devnet & testnet only).
 - webauthn — WebAuthn verification helpers and tests.

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "fluentbase-contracts-staking"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fluentbase-sdk = { workspace = true }
+
+[dev-dependencies]
+fluentbase-testing = { workspace = true }
+
+[lib]
+crate-type = ["cdylib"]
+path = "src/lib.rs"
+
+[features]
+default = ["std"]
+std = ["fluentbase-sdk/std", "fluentbase-testing/std"]
+debug-print = ["fluentbase-sdk/debug-print", "fluentbase-testing/debug-print"]

--- a/contracts/staking/README.md
+++ b/contracts/staking/README.md
@@ -1,0 +1,51 @@
+# Staking
+
+The core validator staking contract implemented as a normal rWasm contract and deployed at
+`GENESIS_STAKING`. It uses `SharedAPI` for storage, BLEND transfers, logs, and calls to protocol
+dependencies.
+
+## Scope
+
+- Implements validator lifecycle, delegation, rewards, committees, liveness jail, and equivocation
+  slashing.
+- Owns the chain configuration previously read from `ChainConfig`.
+- Keeps `StakingPool` external and unchanged; this crate does not deploy or replace it.
+- Calls configured BLS verifier, evidence decoder, liveness, and BLEND reserve contracts.
+
+## Lifecycle
+
+1. Genesis governance calls `configure` and `initialize` once each; non-zero initial stake requires
+   configuration first.
+2. Governance configures external dependencies and manages validator status.
+3. Validators register consensus keys; delegators approve and deposit BLEND.
+4. The system caller commits epoch committees and settles finalized epoch stipends.
+5. Liveness and equivocation paths jail or permanently tombstone validators.
+
+## Accounting Invariants
+
+- Stake and commission changes take effect through epoch snapshots; selection changes become visible
+  in the following epoch.
+- Delegation amounts must use `BALANCE_COMPACT_PRECISION`.
+- Undelegated principal is released only after its maturity epoch and is claimed through the reward
+  path.
+- Claims, stipend catch-up, committee pruning, and jail scans are bounded per call.
+- BLEND transfers accept ERC-20 tokens that return `true` or no data; explicit `false` reverts.
+- Reserve settlement credits rewards only after the exact assigned amount is disbursed.
+- Equivocation tombstones are permanent and prevent key reuse or jail release.
+
+## Source Layout
+
+- `handlers.rs`: initialization, compatibility getters, and validator administration.
+- `economics.rs`: registration, delegation, and undelegation.
+- `rewards.rs`: reward claims, redelegation, and stipend settlement.
+- `consensus.rs`: consensus keys and epoch committees.
+- `liveness.rs` / `equivocation.rs`: jail and slashing paths.
+- `storage.rs`: ERC-7201 layout and epoch snapshots.
+- `config.rs`: governance-controlled parameters and dependencies.
+
+## Verification
+
+```bash
+cargo test --manifest-path contracts/Cargo.toml -p fluentbase-contracts-staking
+cargo test -p fluentbase-e2e staking
+```

--- a/contracts/staking/src/config.rs
+++ b/contracts/staking/src/config.rs
@@ -1,0 +1,552 @@
+use alloc::string::String;
+
+use fluentbase_sdk::{ContextReader, ExitCode, SharedAPI, U256};
+
+use crate::{
+    consts::*,
+    events,
+    storage::staking_storage,
+    types::{
+        AddressCommand, BoolCommand, ConfigureDependenciesCommand, U256Command, U32Command,
+        U64Command,
+    },
+    util::{
+        decode, ensure_governance, ensure_initialized, ensure_mutable, ensure_non_payable, revert,
+        revert_with, write_abi,
+    },
+};
+
+fn ensure_governance_mutation<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)
+}
+
+pub fn default_participation_floor_bps<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &DEFAULT_PARTICIPATION_FLOOR_BPS)
+}
+
+pub fn default_slash_reporter_bps<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &DEFAULT_SLASH_REPORTER_REWARD_BPS)
+}
+
+pub fn max_active_validators<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &(MAX_ACTIVE_VALIDATORS_LENGTH as u32))
+}
+
+pub fn max_blend_stipend_per_epoch<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &MAX_BLEND_STIPEND_PER_EPOCH)
+}
+
+pub fn max_participation_floor_bps<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &MAX_PARTICIPATION_FLOOR_BPS)
+}
+
+pub fn max_slash_reporter_bps<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &MAX_SLASH_REPORTER_REWARD_BPS)
+}
+
+fn require_nonzero<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    value: U256,
+    field: &str,
+) -> Result<(), ExitCode> {
+    if value.is_zero() {
+        return revert_with(sdk, ERR_ZERO_VALUE, &String::from(field));
+    }
+    Ok(())
+}
+
+fn zero_value<SDK: SharedAPI>(sdk: &mut SDK, field: &str) -> Result<(), ExitCode> {
+    revert_with(sdk, ERR_ZERO_VALUE, &String::from(field))
+}
+
+fn require_undelegate_window<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    period: u64,
+    interval: u64,
+) -> Result<(), ExitCode> {
+    let window = U256::from(period)
+        .checked_mul(U256::from(interval))
+        .ok_or(ExitCode::IntegerOverflow)?;
+    let minimum = staking_storage()
+        .config_accessor()
+        .min_undelegate_blocks_accessor()
+        .get_checked(sdk)?;
+    if window < minimum {
+        return revert_with(sdk, ERR_UNDELEGATE_WINDOW_TOO_SHORT, &(window, minimum));
+    }
+    Ok(())
+}
+
+pub fn configure_dependencies<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let storage = staking_storage();
+    let caller = sdk.context().contract_caller();
+    if caller != storage.owner_accessor().get_checked(sdk)? {
+        return revert_with(sdk, ERR_ONLY_OWNER, &caller);
+    }
+    let command: ConfigureDependenciesCommand = decode(input)?;
+    if command.liveness_slashing.is_zero() {
+        return zero_value(sdk, "livenessSlashing");
+    }
+    if command.blend_reserve.is_zero() {
+        return zero_value(sdk, "blendReserve");
+    }
+    let config = storage.config_accessor();
+    config
+        .liveness_slashing_accessor()
+        .set_checked(sdk, command.liveness_slashing)?;
+    config
+        .blend_reserve_accessor()
+        .set_checked(sdk, command.blend_reserve)
+}
+
+pub fn get_felony_threshold<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .config_accessor()
+            .felony_threshold_accessor()
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn set_felony_threshold<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U32Command>(input)?.value;
+    if value == 0 {
+        return zero_value(sdk, "felonyThreshold");
+    }
+    let field = staking_storage()
+        .config_accessor()
+        .felony_threshold_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::FelonyThresholdChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn get_validator_jail_epoch_length<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .config_accessor()
+            .validator_jail_epoch_length_accessor()
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn set_validator_jail_epoch_length<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U32Command>(input)?.value;
+    if value == 0 {
+        return zero_value(sdk, "validatorJailEpochLength");
+    }
+    let field = staking_storage()
+        .config_accessor()
+        .validator_jail_epoch_length_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::ValidatorJailEpochLengthChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn get_slash_reporter_reward_bps<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let stored = staking_storage()
+        .config_accessor()
+        .slash_reporter_reward_bps_accessor()
+        .get_checked(sdk)?;
+    write_abi(
+        sdk,
+        &(if stored == 0 {
+            DEFAULT_SLASH_REPORTER_REWARD_BPS
+        } else {
+            stored
+        }),
+    )
+}
+
+pub fn set_slash_reporter_reward_bps<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U32Command>(input)?.value;
+    if value == 0 {
+        return zero_value(sdk, "slashReporterRewardBps");
+    }
+    if value > MAX_SLASH_REPORTER_REWARD_BPS {
+        return revert_with(
+            sdk,
+            ERR_SLASH_REPORTER_REWARD_BPS_TOO_HIGH,
+            &(value, MAX_SLASH_REPORTER_REWARD_BPS),
+        );
+    }
+    let field = staking_storage()
+        .config_accessor()
+        .slash_reporter_reward_bps_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::SlashReporterRewardBpsChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn get_slash_fund_address<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .config_accessor()
+            .slash_fund_address_accessor()
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn set_slash_fund_address<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<AddressCommand>(input)?.value;
+    if value.is_zero() {
+        return zero_value(sdk, "slashFundAddress");
+    }
+    let field = staking_storage()
+        .config_accessor()
+        .slash_fund_address_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::SlashFundAddressChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn get_participation_floor_bps<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let stored = staking_storage()
+        .config_accessor()
+        .participation_floor_bps_accessor()
+        .get_checked(sdk)?;
+    write_abi(
+        sdk,
+        &(if stored == 0 {
+            DEFAULT_PARTICIPATION_FLOOR_BPS
+        } else {
+            stored
+        }),
+    )
+}
+
+pub fn set_participation_floor_bps<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U32Command>(input)?.value;
+    if value == 0 {
+        return zero_value(sdk, "participationFloorBps");
+    }
+    if value > MAX_PARTICIPATION_FLOOR_BPS {
+        return revert_with(
+            sdk,
+            ERR_PARTICIPATION_FLOOR_BPS_TOO_HIGH,
+            &(value, MAX_PARTICIPATION_FLOOR_BPS),
+        );
+    }
+    let field = staking_storage()
+        .config_accessor()
+        .participation_floor_bps_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::ParticipationFloorBpsChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn get_participation_jail_disabled<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .config_accessor()
+            .participation_jail_disabled_accessor()
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn set_participation_jail_disabled<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<BoolCommand>(input)?.value;
+    let field = staking_storage()
+        .config_accessor()
+        .participation_jail_disabled_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::ParticipationJailDisabledChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn get_blend_stipend_per_epoch<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .config_accessor()
+            .blend_stipend_per_epoch_accessor()
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn set_blend_stipend_per_epoch<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U256Command>(input)?.value;
+    if value > MAX_BLEND_STIPEND_PER_EPOCH {
+        return revert_with(
+            sdk,
+            ERR_BLEND_STIPEND_PER_EPOCH_TOO_HIGH,
+            &(value, MAX_BLEND_STIPEND_PER_EPOCH),
+        );
+    }
+    let field = staking_storage()
+        .config_accessor()
+        .blend_stipend_per_epoch_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::BlendStipendPerEpochChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn set_active_validators_length<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U32Command>(input)?.value;
+    if value == 0 {
+        return zero_value(sdk, "activeValidatorsLength");
+    }
+    if value as u64 > MAX_ACTIVE_VALIDATORS_LENGTH {
+        return revert_with(
+            sdk,
+            ERR_MAX_ACTIVE_VALIDATORS_EXCEEDED,
+            &(value, MAX_ACTIVE_VALIDATORS_LENGTH as u32),
+        );
+    }
+    let field = staking_storage()
+        .config_accessor()
+        .active_validators_length_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value as u64)?;
+    events::ActiveValidatorsLengthChanged {
+        prev_value: previous as u32,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn set_epoch_block_interval<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U32Command>(input)?.value;
+    if value == 0 {
+        return zero_value(sdk, "epochBlockInterval");
+    }
+    let config = staking_storage().config_accessor();
+    let activation = config.dpos_activation_block_accessor().get_checked(sdk)?;
+    if activation != 0 && sdk.context().block_number() >= activation {
+        return revert(sdk, ERR_DPOS_ALREADY_ACTIVE);
+    }
+    if activation != 0 && activation % value as u64 != 0 {
+        return revert(sdk, ERR_UNALIGNED_ACTIVATION_BLOCK);
+    }
+    let undelegate = config.undelegate_period_accessor().get_checked(sdk)?;
+    require_undelegate_window(sdk, undelegate, value as u64)?;
+    let field = config.epoch_block_interval_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value as u64)?;
+    events::EpochBlockIntervalChanged {
+        prev_value: previous as u32,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn set_dpos_activation_block<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U64Command>(input)?.value;
+    let config = staking_storage().config_accessor();
+    let previous = config.dpos_activation_block_accessor().get_checked(sdk)?;
+    if previous != 0 && sdk.context().block_number() >= previous {
+        return revert(sdk, ERR_DPOS_ALREADY_ACTIVE);
+    }
+    let interval = config.epoch_block_interval_accessor().get_checked(sdk)?;
+    if interval == 0 || value % interval != 0 {
+        return revert(sdk, ERR_UNALIGNED_ACTIVATION_BLOCK);
+    }
+    if value < sdk.context().block_number() {
+        return revert(sdk, ERR_ACTIVATION_BLOCK_IN_PAST);
+    }
+    config
+        .dpos_activation_block_accessor()
+        .set_checked(sdk, value)?;
+    events::DposActivationBlockChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn set_undelegate_period<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U32Command>(input)?.value;
+    if value == 0 {
+        return zero_value(sdk, "undelegatePeriod");
+    }
+    let config = staking_storage().config_accessor();
+    require_undelegate_window(
+        sdk,
+        value as u64,
+        config.epoch_block_interval_accessor().get_checked(sdk)?,
+    )?;
+    let field = config.undelegate_period_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value as u64)?;
+    events::UndelegatePeriodChanged {
+        prev_value: previous as u32,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn set_min_validator_stake_amount<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U256Command>(input)?.value;
+    require_nonzero(sdk, value, "minValidatorStakeAmount")?;
+    let field = staking_storage()
+        .config_accessor()
+        .min_validator_stake_amount_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::MinValidatorStakeAmountChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn set_min_staking_amount<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<U256Command>(input)?.value;
+    require_nonzero(sdk, value, "minStakingAmount")?;
+    let field = staking_storage()
+        .config_accessor()
+        .min_staking_amount_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::MinStakingAmountChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn get_bls_verifier<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .config_accessor()
+            .bls_verifier_accessor()
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn set_bls_verifier<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<AddressCommand>(input)?.value;
+    if value.is_zero() {
+        return zero_value(sdk, "blsVerifier");
+    }
+    let field = staking_storage().config_accessor().bls_verifier_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::BlsVerifierChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}
+
+pub fn get_evidence_decoder<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .config_accessor()
+            .evidence_decoder_accessor()
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn set_evidence_decoder<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_governance_mutation(sdk)?;
+    let value = decode::<AddressCommand>(input)?.value;
+    if value.is_zero() {
+        return zero_value(sdk, "evidenceDecoder");
+    }
+    let field = staking_storage()
+        .config_accessor()
+        .evidence_decoder_accessor();
+    let previous = field.get_checked(sdk)?;
+    field.set_checked(sdk, value)?;
+    events::EvidenceDecoderChanged {
+        prev_value: previous,
+        new_value: value,
+    }
+    .emit(sdk)
+}

--- a/contracts/staking/src/config.rs
+++ b/contracts/staking/src/config.rs
@@ -1,3 +1,7 @@
+//! Governance-controlled staking parameters and external dependencies.
+//!
+//! Setters validate cross-field invariants before updating namespaced storage.
+
 use alloc::string::String;
 
 use fluentbase_sdk::{ContextReader, ExitCode, SharedAPI, U256};

--- a/contracts/staking/src/config.rs
+++ b/contracts/staking/src/config.rs
@@ -11,8 +11,8 @@ use crate::{
         U64Command,
     },
     util::{
-        decode, ensure_governance, ensure_initialized, ensure_mutable, ensure_non_payable, revert,
-        revert_with, write_abi,
+        decode, ensure_governance, ensure_mutable, ensure_non_payable, revert, revert_with,
+        write_abi,
     },
 };
 
@@ -86,14 +86,8 @@ fn require_undelegate_window<SDK: SharedAPI>(
 }
 
 pub fn configure_dependencies<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_mutable(sdk)?;
-    ensure_initialized(sdk)?;
+    ensure_governance_mutation(sdk)?;
     let storage = staking_storage();
-    let caller = sdk.context().contract_caller();
-    if caller != storage.owner_accessor().get_checked(sdk)? {
-        return revert_with(sdk, ERR_ONLY_OWNER, &caller);
-    }
     let command: ConfigureDependenciesCommand = decode(input)?;
     if command.liveness_slashing.is_zero() {
         return zero_value(sdk, "livenessSlashing");
@@ -392,10 +386,10 @@ pub fn set_epoch_block_interval<SDK: SharedAPI>(
     }
     let config = staking_storage().config_accessor();
     let activation = config.dpos_activation_block_accessor().get_checked(sdk)?;
-    if activation != 0 && sdk.context().block_number() >= activation {
+    if sdk.context().block_number() >= activation {
         return revert(sdk, ERR_DPOS_ALREADY_ACTIVE);
     }
-    if activation != 0 && activation % value as u64 != 0 {
+    if activation % value as u64 != 0 {
         return revert(sdk, ERR_UNALIGNED_ACTIVATION_BLOCK);
     }
     let undelegate = config.undelegate_period_accessor().get_checked(sdk)?;
@@ -418,7 +412,7 @@ pub fn set_dpos_activation_block<SDK: SharedAPI>(
     let value = decode::<U64Command>(input)?.value;
     let config = staking_storage().config_accessor();
     let previous = config.dpos_activation_block_accessor().get_checked(sdk)?;
-    if previous != 0 && sdk.context().block_number() >= previous {
+    if sdk.context().block_number() >= previous {
         return revert(sdk, ERR_DPOS_ALREADY_ACTIVE);
     }
     let interval = config.epoch_block_interval_accessor().get_checked(sdk)?;

--- a/contracts/staking/src/consensus.rs
+++ b/contracts/staking/src/consensus.rs
@@ -1,0 +1,450 @@
+use alloc::vec::Vec;
+
+use fluentbase_sdk::{
+    bytes::BytesMut, codec::SolidityABI, Address, Bytes, ContextReader, ExitCode, SharedAPI, B256,
+    U256,
+};
+
+use crate::{
+    consts::*,
+    events,
+    storage::{current_epoch, staking_storage, STATUS_NOT_FOUND},
+    types::{
+        AddressCommand, ConsensusKeys, EpochSignerCommand, SetConsensusKeysCommand, U64Command,
+    },
+    util::{
+        decode, decode_args, ensure_initialized, ensure_mutable, ensure_non_payable, next_epoch,
+        revert, revert_with, selected_validators, selected_validators_at, selection_visible_at,
+        validator_total_at, write_abi, write_returns,
+    },
+};
+
+const BLS_POP_DST: &[u8] = b"BLS_POP_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_";
+
+fn external_call<SDK, T>(
+    sdk: &mut SDK,
+    target: Address,
+    selector: u32,
+    params: &T,
+) -> Result<Bytes, ExitCode>
+where
+    SDK: SharedAPI,
+    T: fluentbase_sdk::codec::FunctionArgs<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let mut encoded = BytesMut::new();
+    SolidityABI::<T>::encode_function_args(params, &mut encoded)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    let mut input = selector.to_be_bytes().to_vec();
+    input.extend_from_slice(&encoded);
+    let result = sdk.call(target, U256::ZERO, &input, None);
+    if !result.status.is_ok() {
+        sdk.write(result.data);
+        return Err(result.status);
+    }
+    Ok(result.data)
+}
+
+fn read_consensus_keys<SDK: SharedAPI>(
+    sdk: &SDK,
+    validator: Address,
+) -> Result<ConsensusKeys, ExitCode> {
+    let keys = staking_storage().consensus_keys_accessor().entry(validator);
+    Ok(ConsensusKeys {
+        bls_pubkey: keys.bls_pubkey_accessor().load(sdk)?,
+        peer_pubkey: keys.peer_pubkey_accessor().get_checked(sdk)?,
+        activation_epoch: keys.activation_epoch_accessor().get_checked(sdk)?,
+    })
+}
+
+fn fluent_namespace<SDK: SharedAPI>(sdk: &SDK) -> Vec<u8> {
+    let mut namespace = b"FLUENT_DPOS_V1_".to_vec();
+    namespace.extend_from_slice(&sdk.context().block_chain_id().to_be_bytes());
+    namespace
+}
+
+pub fn set_consensus_keys<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let (validator, bls_pubkey_uncompressed, bls_pop_uncompressed, peer_pubkey) =
+        decode_args::<(Address, Vec<u8>, Vec<u8>, B256)>(input)?;
+    let command = SetConsensusKeysCommand {
+        validator,
+        bls_pubkey_uncompressed,
+        bls_pop_uncompressed,
+        peer_pubkey,
+    };
+    let storage = staking_storage();
+    if storage
+        .tombstoned_accessor()
+        .entry(command.validator)
+        .get_checked(sdk)?
+    {
+        return revert_with(
+            sdk,
+            ERR_ALREADY_SLASHED_FOR_EQUIVOCATION,
+            &command.validator,
+        );
+    }
+    let record = storage.validators_accessor().entry(command.validator);
+    if record.status_accessor().get_checked(sdk)? == STATUS_NOT_FOUND {
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &command.validator);
+    }
+    let owner = record.owner_accessor().get_checked(sdk)?;
+    if sdk.context().contract_caller() != owner {
+        return revert_with(sdk, ERR_ONLY_VALIDATOR_OWNER, &owner);
+    }
+    if command.bls_pubkey_uncompressed.len() != BLS_PUBKEY_UNCOMPRESSED_LENGTH
+        || command.bls_pop_uncompressed.len() != BLS_POP_UNCOMPRESSED_LENGTH
+        || command.peer_pubkey.is_zero()
+    {
+        return revert(sdk, ERR_INVALID_CONSENSUS_KEY_ENCODING);
+    }
+    let keys = storage.consensus_keys_accessor().entry(command.validator);
+    if keys.bls_pubkey_accessor().len(sdk) != 0 {
+        return revert_with(sdk, ERR_CONSENSUS_KEYS_ALREADY_SET, &command.validator);
+    }
+    if !storage
+        .peer_pubkey_owner_accessor()
+        .entry(command.peer_pubkey)
+        .get_checked(sdk)?
+        .is_zero()
+    {
+        return revert_with(sdk, ERR_PEER_PUBKEY_ALREADY_IN_USE, &command.peer_pubkey);
+    }
+
+    let verifier = storage
+        .config_accessor()
+        .bls_verifier_accessor()
+        .get_checked(sdk)?;
+    if verifier.is_zero() {
+        return revert(sdk, ERR_BLS_VERIFIER_NOT_CONFIGURED);
+    }
+    let compressed_output = external_call(
+        sdk,
+        verifier,
+        SIG_BLS_COMPRESS_G2_UNCHECKED,
+        &(command.bls_pubkey_uncompressed.clone(),),
+    )?;
+    let compressed = SolidityABI::<Vec<u8>>::decode(&compressed_output, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    let verify_output = external_call(
+        sdk,
+        verifier,
+        SIG_BLS_VERIFY,
+        &(
+            fluent_namespace(sdk),
+            compressed.clone(),
+            BLS_POP_DST.to_vec(),
+            command.bls_pop_uncompressed,
+            command.bls_pubkey_uncompressed,
+        ),
+    )?;
+    let valid = SolidityABI::<bool>::decode(&verify_output, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    if !valid {
+        return revert_with(sdk, ERR_INVALID_PROOF_OF_POSSESSION, &command.validator);
+    }
+
+    let activation_epoch = if selection_visible_at(sdk, command.validator, 0)? {
+        0
+    } else {
+        next_epoch(sdk)?
+    };
+    keys.bls_pubkey_accessor().store(sdk, &compressed)?;
+    keys.peer_pubkey_accessor()
+        .set_checked(sdk, command.peer_pubkey)?;
+    keys.activation_epoch_accessor()
+        .set_checked(sdk, activation_epoch)?;
+    storage
+        .peer_pubkey_owner_accessor()
+        .entry(command.peer_pubkey)
+        .set_checked(sdk, command.validator)?;
+    events::ConsensusKeysSet {
+        validator: command.validator,
+        bls_pubkey: compressed,
+        peer_pubkey: command.peer_pubkey,
+        activation_epoch,
+    }
+    .emit(sdk)
+}
+
+pub fn get_consensus_keys<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let keys = read_consensus_keys(sdk, decode::<AddressCommand>(input)?.value)?;
+    write_returns(
+        sdk,
+        &(keys.bls_pubkey, keys.peer_pubkey, keys.activation_epoch),
+    )
+}
+
+fn write_validators_with_keys<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validators: Vec<Address>,
+    visible_at: Option<u64>,
+) -> Result<(), ExitCode> {
+    let mut keys = Vec::with_capacity(validators.len());
+    for validator in &validators {
+        let mut value = read_consensus_keys(sdk, *validator)?;
+        if visible_at.is_some_and(|epoch| value.activation_epoch > epoch) {
+            value = ConsensusKeys::default();
+        }
+        keys.push(value);
+    }
+    write_returns(sdk, &(validators, keys))
+}
+
+pub fn get_validators_with_keys<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    write_validators_with_keys(sdk, selected_validators(sdk)?, None)
+}
+
+pub fn get_registry_with_keys<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let active = staking_storage().active_validators_accessor();
+    let len = active.len_checked(sdk)?;
+    let mut validators = Vec::with_capacity(len as usize);
+    for index in 0..len {
+        validators.push(active.at(index).get_checked(sdk)?);
+    }
+    write_validators_with_keys(sdk, validators, None)
+}
+
+pub fn get_validators_with_keys_at<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let epoch = decode::<U64Command>(input)?.value;
+    write_validators_with_keys(sdk, selected_validators_at(sdk, epoch)?, Some(epoch))
+}
+
+pub fn next_epoch_to_commit<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .last_committed_epoch_p1_accessor()
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn committee_selection_epoch<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let target = staking_storage()
+        .last_committed_epoch_p1_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &target.saturating_sub(2))
+}
+
+fn committee_changed<SDK: SharedAPI>(
+    sdk: &SDK,
+    target: u64,
+    submitted: &[Address],
+) -> Result<bool, ExitCode> {
+    if target == 0 {
+        return Ok(false);
+    }
+    let incumbent = staking_storage()
+        .epoch_committees_accessor()
+        .entry(target - 1);
+    if incumbent.len_checked(sdk)? as usize != submitted.len() {
+        return Ok(true);
+    }
+    for (index, member) in submitted.iter().enumerate() {
+        if incumbent.at(index as u64).get_checked(sdk)? != *member {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn prune_committees<SDK: SharedAPI>(sdk: &mut SDK, current: u64) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    let retention = storage
+        .config_accessor()
+        .undelegate_period_accessor()
+        .get_checked(sdk)?
+        .checked_add(EPOCH_COMMITTEE_RETENTION_MARGIN)
+        .ok_or(ExitCode::IntegerOverflow)?;
+    if current <= retention {
+        return Ok(());
+    }
+    let prune_to = current - retention - 1;
+    let mut cursor = storage.pruned_up_to_p1_accessor().get_checked(sdk)?;
+    let mut deleted = 0;
+    while cursor <= prune_to && deleted < 16 {
+        storage
+            .epoch_committees_accessor()
+            .entry(cursor)
+            .clear_checked(sdk)?;
+        cursor += 1;
+        deleted += 1;
+    }
+    storage.pruned_up_to_p1_accessor().set_checked(sdk, cursor)
+}
+
+pub fn commit_epoch_committee<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    if sdk.context().contract_caller() != SYSTEM_CALLER {
+        return revert(sdk, ERR_ONLY_SYSTEM_CALL);
+    }
+    let (submitted,) = decode_args::<(Vec<Address>,)>(input)?;
+    let storage = staking_storage();
+    let current = current_epoch(sdk)?;
+    let target = storage
+        .last_committed_epoch_p1_accessor()
+        .get_checked(sdk)?;
+    if target > current.checked_add(2).ok_or(ExitCode::IntegerOverflow)? {
+        return revert_with(sdk, ERR_EPOCH_NOT_YET_COMMITTABLE, &(target, current));
+    }
+    let selection_epoch = target.saturating_sub(2);
+    let top = selected_validators_at(sdk, selection_epoch)?;
+    let mut eligible = Vec::new();
+    for validator in top {
+        let keys = read_consensus_keys(sdk, validator)?;
+        if !keys.peer_pubkey.is_zero() && keys.activation_epoch <= selection_epoch {
+            eligible.push(validator);
+        }
+    }
+    if submitted.len() != eligible.len() {
+        return revert_with(
+            sdk,
+            ERR_COMMITTEE_LENGTH_MISMATCH,
+            &(U256::from(eligible.len()), U256::from(submitted.len())),
+        );
+    }
+
+    let mut previous_peer = B256::ZERO;
+    for validator in &submitted {
+        let keys = read_consensus_keys(sdk, *validator)?;
+        if keys.peer_pubkey.is_zero() || keys.activation_epoch > selection_epoch {
+            return revert_with(sdk, ERR_COMMITTEE_MEMBER_KEYLESS, validator);
+        }
+        if !eligible.contains(validator) {
+            return revert_with(sdk, ERR_COMMITTEE_MEMBER_NOT_IN_ACTIVE_SET, validator);
+        }
+        if keys.peer_pubkey <= previous_peer {
+            return revert_with(sdk, ERR_COMMITTEE_NOT_STRICTLY_ASCENDING, validator);
+        }
+        previous_peer = keys.peer_pubkey;
+    }
+
+    let changed = committee_changed(sdk, target, &submitted)?;
+    let stored = storage.epoch_committees_accessor().entry(target);
+    for validator in &submitted {
+        stored.push_checked(sdk, *validator)?;
+    }
+    storage
+        .dkg_qual_accessor()
+        .entry(target)
+        .set_checked(sdk, changed)?;
+    storage
+        .last_committed_epoch_p1_accessor()
+        .set_checked(sdk, target.checked_add(1).ok_or(ExitCode::IntegerOverflow)?)?;
+    prune_committees(sdk, current)?;
+    events::EpochCommitteeCommitted {
+        epoch: target,
+        committee: submitted,
+    }
+    .emit(sdk)
+}
+
+pub fn get_dkg_qual<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let epoch = decode::<U64Command>(input)?.value;
+    write_abi(
+        sdk,
+        &staking_storage()
+            .dkg_qual_accessor()
+            .entry(epoch)
+            .get_checked(sdk)?,
+    )
+}
+
+pub fn resolve_signer<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command = decode::<EpochSignerCommand>(input)?;
+    let committee = staking_storage()
+        .epoch_committees_accessor()
+        .entry(command.epoch);
+    let len = committee.len_checked(sdk)?;
+    if len == 0 {
+        return revert_with(sdk, ERR_EPOCH_COMMITTEE_NOT_COMMITTED, &command.epoch);
+    }
+    if command.signer_idx as u64 >= len {
+        return revert_with(
+            sdk,
+            ERR_SIGNER_INDEX_OUT_OF_RANGE,
+            &(command.epoch, command.signer_idx, U256::from(len)),
+        );
+    }
+    write_abi(
+        sdk,
+        &committee.at(command.signer_idx as u64).get_checked(sdk)?,
+    )
+}
+
+fn read_committee<SDK: SharedAPI>(sdk: &SDK, epoch: u64) -> Result<Vec<Address>, ExitCode> {
+    let committee = staking_storage().epoch_committees_accessor().entry(epoch);
+    let len = committee.len_checked(sdk)?;
+    let mut result = Vec::with_capacity(len as usize);
+    for index in 0..len {
+        result.push(committee.at(index).get_checked(sdk)?);
+    }
+    Ok(result)
+}
+
+pub fn get_epoch_committee<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    write_abi(
+        sdk,
+        &read_committee(sdk, decode::<U64Command>(input)?.value)?,
+    )
+}
+
+pub fn get_epoch_committee_length<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let epoch = decode::<U64Command>(input)?.value;
+    write_abi(
+        sdk,
+        &U256::from(
+            staking_storage()
+                .epoch_committees_accessor()
+                .entry(epoch)
+                .len_checked(sdk)?,
+        ),
+    )
+}
+
+pub fn get_epoch_committee_with_stakes<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let epoch = decode::<U64Command>(input)?.value;
+    let validators = read_committee(sdk, epoch)?;
+    let mut keys = Vec::with_capacity(validators.len());
+    let mut stakes = Vec::with_capacity(validators.len());
+    for validator in &validators {
+        keys.push(read_consensus_keys(sdk, *validator)?);
+        stakes.push(validator_total_at(sdk, *validator, epoch)?);
+    }
+    write_returns(sdk, &(validators, keys, stakes))
+}

--- a/contracts/staking/src/consensus.rs
+++ b/contracts/staking/src/consensus.rs
@@ -1,3 +1,5 @@
+//! Consensus-key registration and deterministic epoch committee commits.
+
 use alloc::vec::Vec;
 
 use fluentbase_sdk::{
@@ -279,6 +281,7 @@ fn prune_committees<SDK: SharedAPI>(sdk: &mut SDK, current: u64) -> Result<(), E
     let prune_to = current - retention - 1;
     let mut cursor = storage.pruned_up_to_p1_accessor().get_checked(sdk)?;
     let mut deleted = 0;
+    // Bound cleanup so a long-idle chain cannot make one system call unbounded.
     while cursor <= prune_to && deleted < 16 {
         storage
             .epoch_committees_accessor()
@@ -332,6 +335,7 @@ pub fn commit_epoch_committee<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Re
         if !eligible.contains(validator) {
             return revert_with(sdk, ERR_COMMITTEE_MEMBER_NOT_IN_ACTIVE_SET, validator);
         }
+        // Peer-key order gives every producer one canonical committee encoding.
         if keys.peer_pubkey <= previous_peer {
             return revert_with(sdk, ERR_COMMITTEE_NOT_STRICTLY_ASCENDING, validator);
         }

--- a/contracts/staking/src/consts.rs
+++ b/contracts/staking/src/consts.rs
@@ -23,8 +23,25 @@ pub const SIG_GET_STAKING: u32 = 0x7b13_91a6;
 pub const SIG_GET_GOVERNANCE: u32 = 0x289b_3c0d;
 pub const SIG_GET_CHAIN_CONFIG: u32 = 0x606c_0c94;
 pub const SIG_GET_STAKING_TOKEN: u32 = 0x9f91_06d1;
+pub const SIG_GET_ACTIVE_VALIDATORS_LENGTH: u32 =
+    derive_keccak256_id!("getActiveValidatorsLength()");
+pub const SIG_GET_EPOCH_BLOCK_INTERVAL: u32 = derive_keccak256_id!("getEpochBlockInterval()");
+pub const SIG_GET_DPOS_ACTIVATION_BLOCK: u32 = derive_keccak256_id!("getDposActivationBlock()");
+pub const SIG_GET_UNDELEGATE_PERIOD: u32 = derive_keccak256_id!("getUndelegatePeriod()");
+pub const SIG_GET_MIN_VALIDATOR_STAKE_AMOUNT: u32 =
+    derive_keccak256_id!("getMinValidatorStakeAmount()");
+pub const SIG_GET_MIN_STAKING_AMOUNT: u32 = derive_keccak256_id!("getMinStakingAmount()");
+pub const SIG_GET_VALIDATOR_DELEGATION: u32 =
+    derive_keccak256_id!("getValidatorDelegation(address,address)");
+pub const SIG_GET_VALIDATOR_DELEGATED_STAKE_AT: u32 =
+    derive_keccak256_id!("getValidatorDelegatedStakeAt(address,uint256)");
+pub const SIG_REGISTER_VALIDATOR: u32 =
+    derive_keccak256_id!("registerValidator(address,uint16,uint256)");
+pub const SIG_DELEGATE: u32 = derive_keccak256_id!("delegate(address,uint256)");
+pub const SIG_UNDELEGATE: u32 = derive_keccak256_id!("undelegate(address,uint256)");
 pub const SIG_CONFIGURE: u32 =
     derive_keccak256_id!("configure(address,uint64,uint64,uint256,uint256)");
+pub const SIG_ERC20_TRANSFER_FROM: u32 = 0x23b8_72dd;
 
 pub const ERR_ALREADY_INITIALIZED: u32 = derive_keccak256_id!("InvalidInitialization()");
 pub const ERR_NOT_INITIALIZED: u32 = derive_keccak256_id!("NotInitialized()");
@@ -47,12 +64,24 @@ pub const ERR_ONLY_VALIDATOR_OWNER: u32 = derive_keccak256_id!("OnlyValidatorOwn
 pub const ERR_ONLY_OWNER: u32 = derive_keccak256_id!("OwnableUnauthorizedAccount(address)");
 pub const ERR_ZERO_STAKING_TOKEN: u32 = derive_keccak256_id!("ZeroStakingToken()");
 pub const ERR_INVALID_CHAIN_CONFIG: u32 = derive_keccak256_id!("InvalidChainConfig()");
+pub const ERR_AMOUNT_TOO_LOW: u32 = derive_keccak256_id!("AmountTooLow(uint256)");
+pub const ERR_INITIAL_STAKE_TOO_LOW: u32 = derive_keccak256_id!("InitialStakeTooLow(uint256)");
+pub const ERR_OWNER_SELF_STAKE_BELOW_MINIMUM: u32 =
+    derive_keccak256_id!("OwnerSelfStakeBelowMinimum()");
+pub const ERR_INSUFFICIENT_BALANCE: u32 = derive_keccak256_id!("InsufficientBalance()");
+pub const ERR_DELEGATION_QUEUE_EMPTY: u32 = derive_keccak256_id!("DelegationQueueEmpty()");
+pub const ERR_DELEGATION_QUEUE_NOT_EMPTY: u32 =
+    derive_keccak256_id!("DelegationQueueNotEmpty(uint256)");
+pub const ERR_STAKING_TOKEN_CALL_FAILED: u32 = derive_keccak256_id!("StakingTokenCallFailed()");
 pub const ERR_UNKNOWN_METHOD: u32 = derive_keccak256_id!("UnknownMethod()");
 
 pub const BALANCE_COMPACT_PRECISION: U256 = U256::from_limbs([10_000_000_000, 0, 0, 0]);
 pub const COMMISSION_RATE_MAX: u16 = 3_000;
 pub const DEFAULT_EPOCH_BLOCK_INTERVAL: u64 = 200;
 pub const DEFAULT_ACTIVE_VALIDATORS_LENGTH: u64 = 21;
+pub const MAX_ACTIVE_VALIDATORS_LENGTH: u64 = 51;
+pub const DEFAULT_UNDELEGATE_PERIOD: u64 = 7;
+pub const WARMUP_DELAY: u64 = 2;
 pub const DEFAULT_MIN_VALIDATOR_STAKE: U256 =
     U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 pub const DEFAULT_MIN_STAKING_AMOUNT: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);

--- a/contracts/staking/src/consts.rs
+++ b/contracts/staking/src/consts.rs
@@ -2,46 +2,82 @@ use fluentbase_sdk::{derive::derive_keccak256_id, derive::erc7201_slot, U256};
 
 pub const SIG_LEN_BYTES: usize = 4;
 
-// Existing Solidity ABI selectors. Keeping these explicit makes accidental ABI
-// drift visible in review.
-pub const SIG_INITIALIZE: u32 = 0x01f6_bb50;
-pub const SIG_CURRENT_EPOCH: u32 = 0x7667_1808;
-pub const SIG_NEXT_EPOCH: u32 = 0xaea0_e78b;
-pub const SIG_OWNER: u32 = 0x8da5_cb5b;
-pub const SIG_IS_VALIDATOR: u32 = 0xfacd_743b;
-pub const SIG_IS_VALIDATOR_ACTIVE: u32 = 0x42ad_55ac;
-pub const SIG_GET_VALIDATOR_STATUS: u32 = 0xa310_624f;
-pub const SIG_GET_VALIDATOR_BY_OWNER: u32 = 0x3010_8c22;
-pub const SIG_GET_VALIDATORS: u32 = 0xb7ab_4db5;
-pub const SIG_ADD_VALIDATOR: u32 = 0x4d23_8c8e;
-pub const SIG_REMOVE_VALIDATOR: u32 = 0x40a1_41ff;
-pub const SIG_ACTIVATE_VALIDATOR: u32 = 0xb46e_5520;
-pub const SIG_DISABLE_VALIDATOR: u32 = 0x1fe9_7684;
-pub const SIG_CHANGE_VALIDATOR_COMMISSION_RATE: u32 = 0x14f8_649f;
-pub const SIG_CHANGE_VALIDATOR_OWNER: u32 = 0x0052_c9e1;
-pub const SIG_GET_STAKING: u32 = 0x7b13_91a6;
-pub const SIG_GET_GOVERNANCE: u32 = 0x289b_3c0d;
-pub const SIG_GET_CHAIN_CONFIG: u32 = 0x606c_0c94;
-pub const SIG_GET_STAKING_TOKEN: u32 = 0x9f91_06d1;
+// ABI selectors are derived from their canonical signatures. The pinned hex
+// values remain beside them to make ABI drift visible during review.
+// 0x01f6bb50
+pub const SIG_INITIALIZE: u32 =
+    derive_keccak256_id!("initialize(address,address[],uint256[],uint16)");
+// 0x76671808
+pub const SIG_CURRENT_EPOCH: u32 = derive_keccak256_id!("currentEpoch()");
+// 0xaea0e78b
+pub const SIG_NEXT_EPOCH: u32 = derive_keccak256_id!("nextEpoch()");
+// 0x8da5cb5b
+pub const SIG_OWNER: u32 = derive_keccak256_id!("owner()");
+// 0xfacd743b
+pub const SIG_IS_VALIDATOR: u32 = derive_keccak256_id!("isValidator(address)");
+// 0x42ad55ac
+pub const SIG_IS_VALIDATOR_ACTIVE: u32 = derive_keccak256_id!("isValidatorActive(address)");
+// 0xa310624f
+pub const SIG_GET_VALIDATOR_STATUS: u32 = derive_keccak256_id!("getValidatorStatus(address)");
+// 0x30108c22
+pub const SIG_GET_VALIDATOR_BY_OWNER: u32 = derive_keccak256_id!("getValidatorByOwner(address)");
+// 0xb7ab4db5
+pub const SIG_GET_VALIDATORS: u32 = derive_keccak256_id!("getValidators()");
+// 0x4d238c8e
+pub const SIG_ADD_VALIDATOR: u32 = derive_keccak256_id!("addValidator(address)");
+// 0x40a141ff
+pub const SIG_REMOVE_VALIDATOR: u32 = derive_keccak256_id!("removeValidator(address)");
+// 0xb46e5520
+pub const SIG_ACTIVATE_VALIDATOR: u32 = derive_keccak256_id!("activateValidator(address)");
+// 0x1fe97684
+pub const SIG_DISABLE_VALIDATOR: u32 = derive_keccak256_id!("disableValidator(address)");
+// 0x14f8649f
+pub const SIG_CHANGE_VALIDATOR_COMMISSION_RATE: u32 =
+    derive_keccak256_id!("changeValidatorCommissionRate(address,uint16)");
+// 0x0052c9e1
+pub const SIG_CHANGE_VALIDATOR_OWNER: u32 =
+    derive_keccak256_id!("changeValidatorOwner(address,address)");
+// 0x7b1391a6
+pub const SIG_GET_STAKING: u32 = derive_keccak256_id!("getStaking()");
+// 0x289b3c0d
+pub const SIG_GET_GOVERNANCE: u32 = derive_keccak256_id!("getGovernance()");
+// 0x606c0c94
+pub const SIG_GET_CHAIN_CONFIG: u32 = derive_keccak256_id!("getChainConfig()");
+// 0x9f9106d1
+pub const SIG_GET_STAKING_TOKEN: u32 = derive_keccak256_id!("getStakingToken()");
+// 0x32cc6f08
 pub const SIG_GET_ACTIVE_VALIDATORS_LENGTH: u32 =
     derive_keccak256_id!("getActiveValidatorsLength()");
+// 0x346c90a8
 pub const SIG_GET_EPOCH_BLOCK_INTERVAL: u32 = derive_keccak256_id!("getEpochBlockInterval()");
+// 0xa2a50528
 pub const SIG_GET_DPOS_ACTIVATION_BLOCK: u32 = derive_keccak256_id!("getDposActivationBlock()");
+// 0x5e7b72ad
 pub const SIG_GET_UNDELEGATE_PERIOD: u32 = derive_keccak256_id!("getUndelegatePeriod()");
+// 0x6f856847
 pub const SIG_GET_MIN_VALIDATOR_STAKE_AMOUNT: u32 =
     derive_keccak256_id!("getMinValidatorStakeAmount()");
+// 0xeea9a01b
 pub const SIG_GET_MIN_STAKING_AMOUNT: u32 = derive_keccak256_id!("getMinStakingAmount()");
+// 0xd951e186
 pub const SIG_GET_VALIDATOR_DELEGATION: u32 =
     derive_keccak256_id!("getValidatorDelegation(address,address)");
+// 0xe8810ea7
 pub const SIG_GET_VALIDATOR_DELEGATED_STAKE_AT: u32 =
     derive_keccak256_id!("getValidatorDelegatedStakeAt(address,uint256)");
+// 0xdd0fb5df
 pub const SIG_REGISTER_VALIDATOR: u32 =
     derive_keccak256_id!("registerValidator(address,uint16,uint256)");
+// 0x026e402b
 pub const SIG_DELEGATE: u32 = derive_keccak256_id!("delegate(address,uint256)");
+// 0x4d99dd16
 pub const SIG_UNDELEGATE: u32 = derive_keccak256_id!("undelegate(address,uint256)");
+// 0xdc871561
 pub const SIG_CONFIGURE: u32 =
     derive_keccak256_id!("configure(address,uint64,uint64,uint256,uint256)");
-pub const SIG_ERC20_TRANSFER_FROM: u32 = 0x23b8_72dd;
+// 0x23b872dd
+pub const SIG_ERC20_TRANSFER_FROM: u32 =
+    derive_keccak256_id!("transferFrom(address,address,uint256)");
 
 pub const ERR_ALREADY_INITIALIZED: u32 = derive_keccak256_id!("InvalidInitialization()");
 pub const ERR_NOT_INITIALIZED: u32 = derive_keccak256_id!("NotInitialized()");

--- a/contracts/staking/src/consts.rs
+++ b/contracts/staking/src/consts.rs
@@ -1,3 +1,5 @@
+//! Canonical ABI selectors, error IDs, protocol limits, and default values.
+
 use fluentbase_sdk::{address, derive::derive_keccak256_id, derive::erc7201_slot, Address, U256};
 
 pub const SIG_LEN_BYTES: usize = 4;

--- a/contracts/staking/src/consts.rs
+++ b/contracts/staking/src/consts.rs
@@ -19,6 +19,12 @@ pub const SIG_ACTIVATE_VALIDATOR: u32 = 0xb46e_5520;
 pub const SIG_DISABLE_VALIDATOR: u32 = 0x1fe9_7684;
 pub const SIG_CHANGE_VALIDATOR_COMMISSION_RATE: u32 = 0x14f8_649f;
 pub const SIG_CHANGE_VALIDATOR_OWNER: u32 = 0x0052_c9e1;
+pub const SIG_GET_STAKING: u32 = 0x7b13_91a6;
+pub const SIG_GET_GOVERNANCE: u32 = 0x289b_3c0d;
+pub const SIG_GET_CHAIN_CONFIG: u32 = 0x606c_0c94;
+pub const SIG_GET_STAKING_TOKEN: u32 = 0x9f91_06d1;
+pub const SIG_CONFIGURE: u32 =
+    derive_keccak256_id!("configure(address,uint64,uint64,uint256,uint256)");
 
 pub const ERR_ALREADY_INITIALIZED: u32 = derive_keccak256_id!("InvalidInitialization()");
 pub const ERR_NOT_INITIALIZED: u32 = derive_keccak256_id!("NotInitialized()");
@@ -38,31 +44,17 @@ pub const ERR_NOT_ACTIVE_VALIDATOR: u32 = derive_keccak256_id!("NotActiveValidat
 pub const ERR_VALIDATOR_HAS_ACTIVE_DELEGATIONS: u32 =
     derive_keccak256_id!("ValidatorHasActiveDelegations(address)");
 pub const ERR_ONLY_VALIDATOR_OWNER: u32 = derive_keccak256_id!("OnlyValidatorOwner(address)");
+pub const ERR_ONLY_OWNER: u32 = derive_keccak256_id!("OwnableUnauthorizedAccount(address)");
+pub const ERR_ZERO_STAKING_TOKEN: u32 = derive_keccak256_id!("ZeroStakingToken()");
+pub const ERR_INVALID_CHAIN_CONFIG: u32 = derive_keccak256_id!("InvalidChainConfig()");
 pub const ERR_UNKNOWN_METHOD: u32 = derive_keccak256_id!("UnknownMethod()");
 
 pub const BALANCE_COMPACT_PRECISION: U256 = U256::from_limbs([10_000_000_000, 0, 0, 0]);
 pub const COMMISSION_RATE_MAX: u16 = 3_000;
 pub const DEFAULT_EPOCH_BLOCK_INTERVAL: u64 = 200;
 pub const DEFAULT_ACTIVE_VALIDATORS_LENGTH: u64 = 21;
+pub const DEFAULT_MIN_VALIDATOR_STAKE: U256 =
+    U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+pub const DEFAULT_MIN_STAKING_AMOUNT: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 
-pub const INITIALIZED_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.initialized");
-pub const OWNER_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.owner");
-pub const ACTIVATION_BLOCK_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.activation-block");
-pub const EPOCH_INTERVAL_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.epoch-interval");
-pub const ACTIVE_VALIDATORS_LENGTH_SLOT: U256 =
-    erc7201_slot!("Fluent.storage.Staking.active-validators-length");
-pub const ACTIVE_VALIDATORS_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.active-validators");
-pub const VALIDATOR_OWNER_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.validator-owner");
-pub const OWNER_VALIDATOR_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.owner-validator");
-pub const VALIDATOR_STATUS_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.validator-status");
-pub const VALIDATOR_TOTAL_DELEGATED_SLOT: U256 =
-    erc7201_slot!("Fluent.storage.Staking.validator-total-delegated");
-pub const VALIDATOR_SLASHES_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.validator-slashes");
-pub const VALIDATOR_CHANGED_AT_SLOT: U256 =
-    erc7201_slot!("Fluent.storage.Staking.validator-changed-at");
-pub const VALIDATOR_JAILED_BEFORE_SLOT: U256 =
-    erc7201_slot!("Fluent.storage.Staking.validator-jailed-before");
-pub const VALIDATOR_CLAIMED_AT_SLOT: U256 =
-    erc7201_slot!("Fluent.storage.Staking.validator-claimed-at");
-pub const VALIDATOR_COMMISSION_RATE_SLOT: U256 =
-    erc7201_slot!("Fluent.storage.Staking.validator-commission-rate");
+pub const STAKING_STORAGE_SLOT: U256 = erc7201_slot!("Fluent.storage.StakingStorage");

--- a/contracts/staking/src/consts.rs
+++ b/contracts/staking/src/consts.rs
@@ -341,6 +341,8 @@ pub const ERR_EVIDENCE_DECODER_NOT_CONFIGURED: u32 =
     derive_keccak256_id!("EvidenceDecoderNotConfigured()");
 pub const ERR_VALIDATOR_NOT_IN_JAIL: u32 = derive_keccak256_id!("ValidatorNotInJail(address)");
 pub const ERR_STILL_IN_JAIL: u32 = derive_keccak256_id!("StillInJail(address)");
+pub const ERR_RESERVE_SHORT_DISBURSEMENT: u32 =
+    derive_keccak256_id!("ReserveShortDisbursement(uint256,uint256)");
 
 pub const BALANCE_COMPACT_PRECISION: U256 = U256::from_limbs([10_000_000_000, 0, 0, 0]);
 pub const COMMISSION_RATE_MAX: u16 = 3_000;

--- a/contracts/staking/src/consts.rs
+++ b/contracts/staking/src/consts.rs
@@ -1,4 +1,4 @@
-use fluentbase_sdk::{derive::derive_keccak256_id, derive::erc7201_slot, U256};
+use fluentbase_sdk::{address, derive::derive_keccak256_id, derive::erc7201_slot, Address, U256};
 
 pub const SIG_LEN_BYTES: usize = 4;
 
@@ -72,12 +72,192 @@ pub const SIG_REGISTER_VALIDATOR: u32 =
 pub const SIG_DELEGATE: u32 = derive_keccak256_id!("delegate(address,uint256)");
 // 0x4d99dd16
 pub const SIG_UNDELEGATE: u32 = derive_keccak256_id!("undelegate(address,uint256)");
-// 0xdc871561
+// 0xc4bb1bdd
 pub const SIG_CONFIGURE: u32 =
-    derive_keccak256_id!("configure(address,uint64,uint64,uint256,uint256)");
+    derive_keccak256_id!(
+        "configure(address,uint32,uint32,uint32,uint32,uint32,uint256,uint256,uint64,address,address,uint256)"
+    );
+// 0xd2bcdd7b
+pub const SIG_CONFIGURE_DEPENDENCIES: u32 =
+    derive_keccak256_id!("configureDependencies(address,address)");
+// 0x2c1d88e8
+pub const SIG_DEFAULT_PARTICIPATION_FLOOR_BPS: u32 =
+    derive_keccak256_id!("DEFAULT_PARTICIPATION_FLOOR_BPS()");
+// 0x6cc69027
+pub const SIG_DEFAULT_SLASH_REPORTER_BPS: u32 =
+    derive_keccak256_id!("DEFAULT_SLASH_REPORTER_BPS()");
+// 0x5d887462
+pub const SIG_MAX_ACTIVE_VALIDATORS: u32 = derive_keccak256_id!("MAX_ACTIVE_VALIDATORS()");
+// 0x2bc2fec4
+pub const SIG_MAX_BLEND_STIPEND_PER_EPOCH: u32 =
+    derive_keccak256_id!("MAX_BLEND_STIPEND_PER_EPOCH()");
+// 0x9dbdf12b
+pub const SIG_MAX_PARTICIPATION_FLOOR_BPS: u32 =
+    derive_keccak256_id!("MAX_PARTICIPATION_FLOOR_BPS()");
+// 0x0a3a6183
+pub const SIG_MAX_SLASH_REPORTER_BPS: u32 = derive_keccak256_id!("MAX_SLASH_REPORTER_BPS()");
 // 0x23b872dd
 pub const SIG_ERC20_TRANSFER_FROM: u32 =
     derive_keccak256_id!("transferFrom(address,address,uint256)");
+// 0xa9059cbb
+pub const SIG_ERC20_TRANSFER: u32 = derive_keccak256_id!("transfer(address,uint256)");
+// 0xbe199738
+pub const SIG_GET_FELONY_THRESHOLD: u32 = derive_keccak256_id!("getFelonyThreshold()");
+// 0xfcd6cb3e
+pub const SIG_SET_FELONY_THRESHOLD: u32 = derive_keccak256_id!("setFelonyThreshold(uint32)");
+// 0x6cbe6cd8
+pub const SIG_GET_VALIDATOR_JAIL_EPOCH_LENGTH: u32 =
+    derive_keccak256_id!("getValidatorJailEpochLength()");
+// 0xc8652bd5
+pub const SIG_SET_VALIDATOR_JAIL_EPOCH_LENGTH: u32 =
+    derive_keccak256_id!("setValidatorJailEpochLength(uint32)");
+// 0xce534df5
+pub const SIG_GET_SLASH_REPORTER_REWARD_BPS: u32 =
+    derive_keccak256_id!("getSlashReporterRewardBps()");
+// 0x58702003
+pub const SIG_SET_SLASH_REPORTER_REWARD_BPS: u32 =
+    derive_keccak256_id!("setSlashReporterRewardBps(uint32)");
+// 0xc910df38
+pub const SIG_GET_SLASH_FUND_ADDRESS: u32 = derive_keccak256_id!("getSlashFundAddress()");
+// 0xa79e7263
+pub const SIG_SET_SLASH_FUND_ADDRESS: u32 = derive_keccak256_id!("setSlashFundAddress(address)");
+// 0x4baffdc4
+pub const SIG_GET_PARTICIPATION_FLOOR_BPS: u32 = derive_keccak256_id!("getParticipationFloorBps()");
+// 0xd0a01007
+pub const SIG_SET_PARTICIPATION_FLOOR_BPS: u32 =
+    derive_keccak256_id!("setParticipationFloorBps(uint32)");
+// 0x485fd959
+pub const SIG_GET_PARTICIPATION_JAIL_DISABLED: u32 =
+    derive_keccak256_id!("getParticipationJailDisabled()");
+// 0x8664f2e7
+pub const SIG_SET_PARTICIPATION_JAIL_DISABLED: u32 =
+    derive_keccak256_id!("setParticipationJailDisabled(bool)");
+// 0xc8f45d87
+pub const SIG_GET_BLEND_STIPEND_PER_EPOCH: u32 = derive_keccak256_id!("getBlendStipendPerEpoch()");
+// 0x2c91b879
+pub const SIG_SET_BLEND_STIPEND_PER_EPOCH: u32 =
+    derive_keccak256_id!("setBlendStipendPerEpoch(uint256)");
+// 0xc227a412
+pub const SIG_SET_ACTIVE_VALIDATORS_LENGTH: u32 =
+    derive_keccak256_id!("setActiveValidatorsLength(uint32)");
+// 0xaf70fa2c
+pub const SIG_SET_EPOCH_BLOCK_INTERVAL: u32 = derive_keccak256_id!("setEpochBlockInterval(uint32)");
+// 0xf517ca6a
+pub const SIG_SET_DPOS_ACTIVATION_BLOCK: u32 =
+    derive_keccak256_id!("setDposActivationBlock(uint64)");
+// 0x41d8a080
+pub const SIG_SET_UNDELEGATE_PERIOD: u32 = derive_keccak256_id!("setUndelegatePeriod(uint32)");
+// 0xe1a2e863
+pub const SIG_SET_MIN_VALIDATOR_STAKE_AMOUNT: u32 =
+    derive_keccak256_id!("setMinValidatorStakeAmount(uint256)");
+// 0x612d669e
+pub const SIG_SET_MIN_STAKING_AMOUNT: u32 = derive_keccak256_id!("setMinStakingAmount(uint256)");
+// 0xc6b904ad
+pub const SIG_GET_BLS_VERIFIER: u32 = derive_keccak256_id!("getBlsVerifier()");
+// 0x466ae541
+pub const SIG_SET_BLS_VERIFIER: u32 = derive_keccak256_id!("setBlsVerifier(address)");
+// 0xe2cf72f9
+pub const SIG_GET_EVIDENCE_DECODER: u32 = derive_keccak256_id!("getEvidenceDecoder()");
+// 0x00857c90
+pub const SIG_SET_EVIDENCE_DECODER: u32 = derive_keccak256_id!("setEvidenceDecoder(address)");
+// 0x457179fd
+pub const SIG_GET_VALIDATOR_FEE: u32 = derive_keccak256_id!("getValidatorFee(address)");
+// 0xc6fb9065
+pub const SIG_GET_PENDING_VALIDATOR_FEE: u32 =
+    derive_keccak256_id!("getPendingValidatorFee(address)");
+// 0xff4794fc
+pub const SIG_CLAIM_VALIDATOR_FEE: u32 = derive_keccak256_id!("claimValidatorFee(address)");
+// 0xadf2a79c
+pub const SIG_CLAIM_VALIDATOR_FEE_AT_EPOCH: u32 =
+    derive_keccak256_id!("claimValidatorFeeAtEpoch(address,uint64)");
+// 0x52b7bea2
+pub const SIG_GET_DELEGATOR_FEE: u32 = derive_keccak256_id!("getDelegatorFee(address,address)");
+// 0xc2fd58fc
+pub const SIG_GET_PENDING_DELEGATOR_FEE: u32 =
+    derive_keccak256_id!("getPendingDelegatorFee(address,address)");
+// 0x426594b1
+pub const SIG_CLAIM_DELEGATOR_FEE: u32 = derive_keccak256_id!("claimDelegatorFee(address)");
+// 0xfe38ebef
+pub const SIG_CLAIM_DELEGATOR_FEE_AT_EPOCH: u32 =
+    derive_keccak256_id!("claimDelegatorFeeAtEpoch(address,uint64)");
+// 0x5ef9e8c6
+pub const SIG_CALC_AVAILABLE_FOR_REDELEGATE_AMOUNT: u32 =
+    derive_keccak256_id!("calcAvailableForRedelegateAmount(address,address)");
+// 0x8ecb3fc9
+pub const SIG_REDELEGATE_DELEGATOR_FEE: u32 =
+    derive_keccak256_id!("redelegateDelegatorFee(address)");
+// 0xa631344a
+pub const SIG_SETTLE_EPOCH_STIPEND: u32 = derive_keccak256_id!("settleEpochStipend(uint64)");
+// 0x54c3e84b
+pub const SIG_GET_EPOCH_REWARDS: u32 = derive_keccak256_id!("getEpochRewards(uint64)");
+// 0x225cba85
+pub const SIG_SET_CONSENSUS_KEYS: u32 =
+    derive_keccak256_id!("setConsensusKeys(address,bytes,bytes,bytes32)");
+// 0xad36f42f
+pub const SIG_GET_CONSENSUS_KEYS: u32 = derive_keccak256_id!("getConsensusKeys(address)");
+// 0xd41c52eb
+pub const SIG_GET_VALIDATORS_WITH_KEYS: u32 = derive_keccak256_id!("getValidatorsWithKeys()");
+// 0xd96cbd7b
+pub const SIG_GET_REGISTRY_WITH_KEYS: u32 = derive_keccak256_id!("getRegistryWithKeys()");
+// 0x7cfba9f3
+pub const SIG_GET_VALIDATORS_WITH_KEYS_AT: u32 =
+    derive_keccak256_id!("getValidatorsWithKeysAt(uint64)");
+// 0xc06a82de
+pub const SIG_NEXT_EPOCH_TO_COMMIT: u32 = derive_keccak256_id!("nextEpochToCommit()");
+// 0x8bd070e4
+pub const SIG_COMMITTEE_SELECTION_EPOCH: u32 = derive_keccak256_id!("committeeSelectionEpoch()");
+// 0x87401d8a
+pub const SIG_COMMIT_EPOCH_COMMITTEE: u32 = derive_keccak256_id!("commitEpochCommittee(address[])");
+// 0x2660899f
+pub const SIG_GET_DKG_QUAL: u32 = derive_keccak256_id!("getDkgQual(uint64)");
+// 0xd7f1733d
+pub const SIG_RESOLVE_SIGNER: u32 = derive_keccak256_id!("resolveSigner(uint64,uint32)");
+// 0x80b562de
+pub const SIG_GET_EPOCH_COMMITTEE: u32 = derive_keccak256_id!("getEpochCommittee(uint64)");
+// 0xe3e6cedc
+pub const SIG_GET_EPOCH_COMMITTEE_LENGTH: u32 =
+    derive_keccak256_id!("getEpochCommitteeLength(uint64)");
+// 0xa4d160c1
+pub const SIG_GET_EPOCH_COMMITTEE_WITH_STAKES: u32 =
+    derive_keccak256_id!("getEpochCommitteeWithStakes(uint64)");
+// 0x73a3dda6
+pub const SIG_RELEASE_VALIDATOR_FROM_JAIL: u32 =
+    derive_keccak256_id!("releaseValidatorFromJail(address)");
+// 0x67d80300
+pub const SIG_READMIT_EXPIRED_JAILS: u32 = derive_keccak256_id!("readmitExpiredJails(uint64)");
+// 0xc96be4cb
+pub const SIG_SLASH: u32 = derive_keccak256_id!("slash(address)");
+// 0xa5d2dd22
+pub const SIG_BLS_COMPRESS_G2_UNCHECKED: u32 = derive_keccak256_id!("compressG2Unchecked(bytes)");
+// 0x8bf26133
+pub const SIG_BLS_VERIFY: u32 = derive_keccak256_id!("verify(bytes,bytes,bytes,bytes,bytes)");
+// 0x52736f7b
+pub const SIG_LAST_FINALIZED_EPOCH_P1: u32 = derive_keccak256_id!("lastFinalizedEpochP1()");
+// 0x6a4a209f
+pub const SIG_PARTICIPATION: u32 = derive_keccak256_id!("participation(uint64,uint32)");
+// 0xa10954fe
+pub const SIG_RESERVE_BALANCE: u32 = derive_keccak256_id!("reserveBalance()");
+// 0x7f3bd56e
+pub const SIG_RESERVE_DISBURSE: u32 = derive_keccak256_id!("disburse(address,uint256)");
+// 0xe28d2f63
+pub const SIG_SLASH_EQUIVOCATION_NOTARIZE: u32 =
+    derive_keccak256_id!("slashEquivocationNotarize(bytes,bytes,bytes,bytes)");
+// 0xadd07a3e
+pub const SIG_SLASH_EQUIVOCATION_FINALIZE: u32 =
+    derive_keccak256_id!("slashEquivocationFinalize(bytes,bytes,bytes,bytes)");
+// 0xa10827e9
+pub const SIG_SLASH_EQUIVOCATION_NULLIFY_FINALIZE: u32 =
+    derive_keccak256_id!("slashEquivocationNullifyFinalize(bytes,bytes,bytes,bytes)");
+// 0x27e7ff4b
+pub const SIG_DECODE_CONFLICTING_NOTARIZE: u32 =
+    derive_keccak256_id!("decodeConflictingNotarize(bytes)");
+// 0xce4b0b3a
+pub const SIG_DECODE_CONFLICTING_FINALIZE: u32 =
+    derive_keccak256_id!("decodeConflictingFinalize(bytes)");
+// 0x2d85f570
+pub const SIG_DECODE_NULLIFY_FINALIZE: u32 = derive_keccak256_id!("decodeNullifyFinalize(bytes)");
+// 0x8f498050
+pub const SIG_BLS_COMPRESS_G1_UNCHECKED: u32 = derive_keccak256_id!("compressG1Unchecked(bytes)");
 
 pub const ERR_ALREADY_INITIALIZED: u32 = derive_keccak256_id!("InvalidInitialization()");
 pub const ERR_NOT_INITIALIZED: u32 = derive_keccak256_id!("NotInitialized()");
@@ -100,6 +280,7 @@ pub const ERR_ONLY_VALIDATOR_OWNER: u32 = derive_keccak256_id!("OnlyValidatorOwn
 pub const ERR_ONLY_OWNER: u32 = derive_keccak256_id!("OwnableUnauthorizedAccount(address)");
 pub const ERR_ZERO_STAKING_TOKEN: u32 = derive_keccak256_id!("ZeroStakingToken()");
 pub const ERR_INVALID_CHAIN_CONFIG: u32 = derive_keccak256_id!("InvalidChainConfig()");
+pub const ERR_ALREADY_CONFIGURED: u32 = derive_keccak256_id!("AlreadyConfigured()");
 pub const ERR_AMOUNT_TOO_LOW: u32 = derive_keccak256_id!("AmountTooLow(uint256)");
 pub const ERR_INITIAL_STAKE_TOO_LOW: u32 = derive_keccak256_id!("InitialStakeTooLow(uint256)");
 pub const ERR_OWNER_SELF_STAKE_BELOW_MINIMUM: u32 =
@@ -110,6 +291,56 @@ pub const ERR_DELEGATION_QUEUE_NOT_EMPTY: u32 =
     derive_keccak256_id!("DelegationQueueNotEmpty(uint256)");
 pub const ERR_STAKING_TOKEN_CALL_FAILED: u32 = derive_keccak256_id!("StakingTokenCallFailed()");
 pub const ERR_UNKNOWN_METHOD: u32 = derive_keccak256_id!("UnknownMethod()");
+pub const ERR_ONLY_SYSTEM_CALL: u32 = derive_keccak256_id!("OnlySystemCall()");
+pub const ERR_ONLY_LIVENESS_SLASHING: u32 = derive_keccak256_id!("OnlyLivenessSlashing()");
+pub const ERR_ZERO_VALUE: u32 = derive_keccak256_id!("ZeroValue(string)");
+pub const ERR_MAX_ACTIVE_VALIDATORS_EXCEEDED: u32 =
+    derive_keccak256_id!("MaxActiveValidatorsExceeded(uint32,uint32)");
+pub const ERR_DPOS_ALREADY_ACTIVE: u32 = derive_keccak256_id!("DposAlreadyActive()");
+pub const ERR_UNALIGNED_ACTIVATION_BLOCK: u32 = derive_keccak256_id!("UnalignedActivationBlock()");
+pub const ERR_ACTIVATION_BLOCK_IN_PAST: u32 = derive_keccak256_id!("ActivationBlockInPast()");
+pub const ERR_UNDELEGATE_WINDOW_TOO_SHORT: u32 =
+    derive_keccak256_id!("UndelegateWindowTooShort(uint256,uint256)");
+pub const ERR_SLASH_REPORTER_REWARD_BPS_TOO_HIGH: u32 =
+    derive_keccak256_id!("SlashReporterRewardBpsTooHigh(uint32,uint32)");
+pub const ERR_PARTICIPATION_FLOOR_BPS_TOO_HIGH: u32 =
+    derive_keccak256_id!("ParticipationFloorBpsTooHigh(uint32,uint32)");
+pub const ERR_BLEND_STIPEND_PER_EPOCH_TOO_HIGH: u32 =
+    derive_keccak256_id!("BlendStipendPerEpochTooHigh(uint256,uint256)");
+pub const ERR_INVALID_CLAIM_EPOCH: u32 = derive_keccak256_id!("InvalidClaimEpoch()");
+pub const ERR_CONSENSUS_KEYS_ALREADY_SET: u32 =
+    derive_keccak256_id!("ConsensusKeysAlreadySet(address)");
+pub const ERR_PEER_PUBKEY_ALREADY_IN_USE: u32 =
+    derive_keccak256_id!("PeerPubkeyAlreadyInUse(bytes32)");
+pub const ERR_CONSENSUS_KEYS_NOT_SET: u32 = derive_keccak256_id!("ConsensusKeysNotSet(address)");
+pub const ERR_EPOCH_COMMITTEE_NOT_COMMITTED: u32 =
+    derive_keccak256_id!("EpochCommitteeNotCommitted(uint64)");
+pub const ERR_SIGNER_INDEX_OUT_OF_RANGE: u32 =
+    derive_keccak256_id!("SignerIndexOutOfRange(uint64,uint32,uint256)");
+pub const ERR_COMMITTEE_LENGTH_MISMATCH: u32 =
+    derive_keccak256_id!("CommitteeLengthMismatch(uint256,uint256)");
+pub const ERR_EPOCH_NOT_YET_COMMITTABLE: u32 =
+    derive_keccak256_id!("EpochNotYetCommittable(uint64,uint64)");
+pub const ERR_COMMITTEE_MEMBER_KEYLESS: u32 =
+    derive_keccak256_id!("CommitteeMemberKeyless(address)");
+pub const ERR_COMMITTEE_MEMBER_NOT_IN_ACTIVE_SET: u32 =
+    derive_keccak256_id!("CommitteeMemberNotInActiveSet(address)");
+pub const ERR_COMMITTEE_NOT_STRICTLY_ASCENDING: u32 =
+    derive_keccak256_id!("CommitteeNotStrictlyAscending(address)");
+pub const ERR_ALREADY_SLASHED_FOR_EQUIVOCATION: u32 =
+    derive_keccak256_id!("AlreadySlashedForEquivocation(address)");
+pub const ERR_BLS_VERIFIER_NOT_CONFIGURED: u32 = derive_keccak256_id!("BlsVerifierNotConfigured()");
+pub const ERR_INVALID_PROOF_OF_POSSESSION: u32 =
+    derive_keccak256_id!("InvalidProofOfPossession(address)");
+pub const ERR_INVALID_CONSENSUS_KEY_ENCODING: u32 =
+    derive_keccak256_id!("InvalidConsensusKeyEncoding()");
+pub const ERR_EQUIVOCATION_SIGNATURE_INVALID: u32 =
+    derive_keccak256_id!("EquivocationSignatureInvalid()");
+pub const ERR_EQUIVOCATION_KEY_MISMATCH: u32 = derive_keccak256_id!("EquivocationKeyMismatch()");
+pub const ERR_EVIDENCE_DECODER_NOT_CONFIGURED: u32 =
+    derive_keccak256_id!("EvidenceDecoderNotConfigured()");
+pub const ERR_VALIDATOR_NOT_IN_JAIL: u32 = derive_keccak256_id!("ValidatorNotInJail(address)");
+pub const ERR_STILL_IN_JAIL: u32 = derive_keccak256_id!("StillInJail(address)");
 
 pub const BALANCE_COMPACT_PRECISION: U256 = U256::from_limbs([10_000_000_000, 0, 0, 0]);
 pub const COMMISSION_RATE_MAX: u16 = 3_000;
@@ -118,6 +349,22 @@ pub const DEFAULT_ACTIVE_VALIDATORS_LENGTH: u64 = 21;
 pub const MAX_ACTIVE_VALIDATORS_LENGTH: u64 = 51;
 pub const DEFAULT_UNDELEGATE_PERIOD: u64 = 7;
 pub const WARMUP_DELAY: u64 = 2;
+pub const MAX_EPOCHS_PER_CLAIM: u64 = 1_000;
+pub const MAX_SETTLE_CATCHUP: u64 = 32;
+pub const EPOCH_COMMITTEE_RETENTION_MARGIN: u64 = 8;
+pub const BLS_PUBKEY_UNCOMPRESSED_LENGTH: usize = 256;
+pub const BLS_POP_UNCOMPRESSED_LENGTH: usize = 128;
+pub const BLS_PUBKEY_LENGTH: usize = 96;
+pub const DEFAULT_FELONY_THRESHOLD: u32 = 1;
+pub const DEFAULT_VALIDATOR_JAIL_EPOCH_LENGTH: u32 = 1;
+pub const DEFAULT_SLASH_REPORTER_REWARD_BPS: u32 = 3_000;
+pub const MAX_SLASH_REPORTER_REWARD_BPS: u32 = 5_000;
+pub const DEFAULT_PARTICIPATION_FLOOR_BPS: u32 = 1_500;
+pub const MAX_PARTICIPATION_FLOOR_BPS: u32 = 2_000;
+pub const MAX_BLEND_STIPEND_PER_EPOCH: U256 =
+    U256::from_limbs([2_003_764_205_206_896_640, 54_210, 0, 0]);
+pub const SYSTEM_CALLER: Address = address!("0xfffffffffffffffffffffffffffffffffffffffe");
+pub const EQUIVOCATION_BURN_SINK: Address = address!("0x000000000000000000000000000000000000dead");
 pub const DEFAULT_MIN_VALIDATOR_STAKE: U256 =
     U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
 pub const DEFAULT_MIN_STAKING_AMOUNT: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);

--- a/contracts/staking/src/consts.rs
+++ b/contracts/staking/src/consts.rs
@@ -1,0 +1,68 @@
+use fluentbase_sdk::{derive::derive_keccak256_id, derive::erc7201_slot, U256};
+
+pub const SIG_LEN_BYTES: usize = 4;
+
+// Existing Solidity ABI selectors. Keeping these explicit makes accidental ABI
+// drift visible in review.
+pub const SIG_INITIALIZE: u32 = 0x01f6_bb50;
+pub const SIG_CURRENT_EPOCH: u32 = 0x7667_1808;
+pub const SIG_NEXT_EPOCH: u32 = 0xaea0_e78b;
+pub const SIG_OWNER: u32 = 0x8da5_cb5b;
+pub const SIG_IS_VALIDATOR: u32 = 0xfacd_743b;
+pub const SIG_IS_VALIDATOR_ACTIVE: u32 = 0x42ad_55ac;
+pub const SIG_GET_VALIDATOR_STATUS: u32 = 0xa310_624f;
+pub const SIG_GET_VALIDATOR_BY_OWNER: u32 = 0x3010_8c22;
+pub const SIG_GET_VALIDATORS: u32 = 0xb7ab_4db5;
+pub const SIG_ADD_VALIDATOR: u32 = 0x4d23_8c8e;
+pub const SIG_REMOVE_VALIDATOR: u32 = 0x40a1_41ff;
+pub const SIG_ACTIVATE_VALIDATOR: u32 = 0xb46e_5520;
+pub const SIG_DISABLE_VALIDATOR: u32 = 0x1fe9_7684;
+pub const SIG_CHANGE_VALIDATOR_COMMISSION_RATE: u32 = 0x14f8_649f;
+pub const SIG_CHANGE_VALIDATOR_OWNER: u32 = 0x0052_c9e1;
+
+pub const ERR_ALREADY_INITIALIZED: u32 = derive_keccak256_id!("InvalidInitialization()");
+pub const ERR_NOT_INITIALIZED: u32 = derive_keccak256_id!("NotInitialized()");
+pub const ERR_ONLY_GOVERNANCE: u32 = derive_keccak256_id!("OnlyGovernanceContract()");
+pub const ERR_ZERO_OWNER: u32 = derive_keccak256_id!("ZeroOwner()");
+pub const ERR_ZERO_VALIDATOR: u32 = derive_keccak256_id!("ZeroValidator()");
+pub const ERR_MALFORMED_INPUT_LENGTH: u32 = derive_keccak256_id!("MalformedInputLength()");
+pub const ERR_WRONG_AMOUNT_PRECISION: u32 = derive_keccak256_id!("WrongAmountPrecision()");
+pub const ERR_BAD_COMMISSION_RATE: u32 = derive_keccak256_id!("BadCommissionRate(uint16)");
+pub const ERR_VALIDATOR_ALREADY_EXISTS: u32 =
+    derive_keccak256_id!("ValidatorAlreadyExists(address)");
+pub const ERR_VALIDATOR_NOT_FOUND: u32 = derive_keccak256_id!("ValidatorNotFound(address)");
+pub const ERR_VALIDATOR_OWNER_ALREADY_IN_USE: u32 =
+    derive_keccak256_id!("ValidatorOwnerAlreadyInUse(address)");
+pub const ERR_NOT_PENDING_VALIDATOR: u32 = derive_keccak256_id!("NotPendingValidator(address)");
+pub const ERR_NOT_ACTIVE_VALIDATOR: u32 = derive_keccak256_id!("NotActiveValidator()");
+pub const ERR_VALIDATOR_HAS_ACTIVE_DELEGATIONS: u32 =
+    derive_keccak256_id!("ValidatorHasActiveDelegations(address)");
+pub const ERR_ONLY_VALIDATOR_OWNER: u32 = derive_keccak256_id!("OnlyValidatorOwner(address)");
+pub const ERR_UNKNOWN_METHOD: u32 = derive_keccak256_id!("UnknownMethod()");
+
+pub const BALANCE_COMPACT_PRECISION: U256 = U256::from_limbs([10_000_000_000, 0, 0, 0]);
+pub const COMMISSION_RATE_MAX: u16 = 3_000;
+pub const DEFAULT_EPOCH_BLOCK_INTERVAL: u64 = 200;
+pub const DEFAULT_ACTIVE_VALIDATORS_LENGTH: u64 = 21;
+
+pub const INITIALIZED_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.initialized");
+pub const OWNER_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.owner");
+pub const ACTIVATION_BLOCK_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.activation-block");
+pub const EPOCH_INTERVAL_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.epoch-interval");
+pub const ACTIVE_VALIDATORS_LENGTH_SLOT: U256 =
+    erc7201_slot!("Fluent.storage.Staking.active-validators-length");
+pub const ACTIVE_VALIDATORS_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.active-validators");
+pub const VALIDATOR_OWNER_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.validator-owner");
+pub const OWNER_VALIDATOR_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.owner-validator");
+pub const VALIDATOR_STATUS_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.validator-status");
+pub const VALIDATOR_TOTAL_DELEGATED_SLOT: U256 =
+    erc7201_slot!("Fluent.storage.Staking.validator-total-delegated");
+pub const VALIDATOR_SLASHES_SLOT: U256 = erc7201_slot!("Fluent.storage.Staking.validator-slashes");
+pub const VALIDATOR_CHANGED_AT_SLOT: U256 =
+    erc7201_slot!("Fluent.storage.Staking.validator-changed-at");
+pub const VALIDATOR_JAILED_BEFORE_SLOT: U256 =
+    erc7201_slot!("Fluent.storage.Staking.validator-jailed-before");
+pub const VALIDATOR_CLAIMED_AT_SLOT: U256 =
+    erc7201_slot!("Fluent.storage.Staking.validator-claimed-at");
+pub const VALIDATOR_COMMISSION_RATE_SLOT: U256 =
+    erc7201_slot!("Fluent.storage.Staking.validator-commission-rate");

--- a/contracts/staking/src/economics.rs
+++ b/contracts/staking/src/economics.rs
@@ -1,3 +1,7 @@
+//! Validator registration and BLEND delegation principal accounting.
+//!
+//! Balance changes are recorded as epoch-stamped checkpoints.
+
 use fluentbase_sdk::{Address, ContextReader, ExitCode, SharedAPI, U256};
 
 use crate::{
@@ -129,6 +133,7 @@ pub fn delegate_to<SDK: SharedAPI>(
         return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
     }
 
+    // New stake affects accounting only after the warm-up delay.
     let at_epoch = current_epoch(sdk)?
         .checked_add(WARMUP_DELAY)
         .ok_or(ExitCode::IntegerOverflow)?;
@@ -257,6 +262,7 @@ pub fn undelegate_from<SDK: SharedAPI>(
         operation.epoch_accessor().set_checked(sdk, before_epoch)?;
     }
 
+    // Principal remains custodial until the configured undelegation delay ends.
     let maturity_epoch = before_epoch
         .checked_add(config.undelegate_period_accessor().get_checked(sdk)?)
         .ok_or(ExitCode::IntegerOverflow)?;

--- a/contracts/staking/src/economics.rs
+++ b/contracts/staking/src/economics.rs
@@ -39,7 +39,7 @@ pub fn get_validator_delegation<SDK: SharedAPI>(
     }
     let latest = queue.at(len - 1);
     let result = (
-        latest.amount_accessor().get_checked(sdk)?,
+        math::expand_balance(latest.amount_accessor().get_checked(sdk)?),
         latest.epoch_accessor().get_checked(sdk)?,
     );
     write_abi(sdk, &result)
@@ -120,9 +120,9 @@ pub fn delegate_to<SDK: SharedAPI>(
     if amount.is_zero() || amount < minimum {
         return revert_with(sdk, ERR_AMOUNT_TOO_LOW, &amount);
     }
-    if math::compact_balance(amount).is_none() {
+    let Some(compact_amount) = math::compact_balance(amount) else {
         return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
-    }
+    };
     if storage
         .validators_accessor()
         .entry(validator)
@@ -141,7 +141,7 @@ pub fn delegate_to<SDK: SharedAPI>(
     let next_total = snapshot
         .total_delegated_accessor()
         .get_checked(sdk)?
-        .checked_add(amount)
+        .checked_add(compact_amount)
         .ok_or(ExitCode::IntegerOverflow)?;
     snapshot
         .total_delegated_accessor()
@@ -155,13 +155,15 @@ pub fn delegate_to<SDK: SharedAPI>(
     let len = queue.len_checked(sdk)?;
     if len == 0 {
         let operation = queue.grow_checked(sdk)?;
-        operation.amount_accessor().set_checked(sdk, amount)?;
+        operation
+            .amount_accessor()
+            .set_checked(sdk, compact_amount)?;
         operation.epoch_accessor().set_checked(sdk, at_epoch)?;
     } else {
         let latest = queue.at(len - 1);
         let previous_amount = latest.amount_accessor().get_checked(sdk)?;
         let next_amount = previous_amount
-            .checked_add(amount)
+            .checked_add(compact_amount)
             .ok_or(ExitCode::IntegerOverflow)?;
         if latest.epoch_accessor().get_checked(sdk)? >= at_epoch {
             latest.amount_accessor().set_checked(sdk, next_amount)?;
@@ -206,9 +208,9 @@ pub fn undelegate_from<SDK: SharedAPI>(
     if amount.is_zero() || amount < minimum {
         return revert_with(sdk, ERR_AMOUNT_TOO_LOW, &amount);
     }
-    if math::compact_balance(amount).is_none() {
+    let Some(compact_amount) = math::compact_balance(amount) else {
         return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
-    }
+    };
     let record = storage.validators_accessor().entry(validator);
     let status = record.status_accessor().get_checked(sdk)?;
     if status == STATUS_NOT_FOUND {
@@ -218,7 +220,7 @@ pub fn undelegate_from<SDK: SharedAPI>(
     let before_epoch = next_epoch(sdk)?;
     let snapshot = touch_validator_snapshot(sdk, validator, before_epoch)?;
     let total = snapshot.total_delegated_accessor().get_checked(sdk)?;
-    let Some(next_total) = total.checked_sub(amount) else {
+    let Some(next_total) = total.checked_sub(compact_amount) else {
         return revert(sdk, ERR_INSUFFICIENT_BALANCE);
     };
 
@@ -233,7 +235,7 @@ pub fn undelegate_from<SDK: SharedAPI>(
     }
     let latest = queue.at(len - 1);
     let delegated = latest.amount_accessor().get_checked(sdk)?;
-    let Some(next_delegated) = delegated.checked_sub(amount) else {
+    let Some(next_delegated) = delegated.checked_sub(compact_amount) else {
         return revert(sdk, ERR_INSUFFICIENT_BALANCE);
     };
 
@@ -242,7 +244,7 @@ pub fn undelegate_from<SDK: SharedAPI>(
         let min_validator_stake = config
             .min_validator_stake_amount_accessor()
             .get_checked(sdk)?;
-        if next_delegated < min_validator_stake
+        if math::expand_balance(next_delegated) < min_validator_stake
             && (!next_delegated.is_zero() || next_total != next_delegated)
         {
             return revert(sdk, ERR_OWNER_SELF_STAKE_BELOW_MINIMUM);
@@ -267,7 +269,9 @@ pub fn undelegate_from<SDK: SharedAPI>(
         .checked_add(config.undelegate_period_accessor().get_checked(sdk)?)
         .ok_or(ExitCode::IntegerOverflow)?;
     let pending = delegation.undelegate_queue_accessor().grow_checked(sdk)?;
-    pending.amount_accessor().set_checked(sdk, amount)?;
+    pending
+        .amount_accessor()
+        .set_checked(sdk, compact_amount)?;
     pending.epoch_accessor().set_checked(sdk, maturity_epoch)?;
 
     events::Undelegated {

--- a/contracts/staking/src/economics.rs
+++ b/contracts/staking/src/economics.rs
@@ -13,7 +13,8 @@ use crate::{
     },
     util::{
         decode, ensure_initialized, ensure_mutable, ensure_non_payable, next_epoch, revert,
-        safe_transfer_from, set_validator, touch_validator_snapshot, validator_total_at, write_abi,
+        revert_with, safe_transfer_from, set_validator, touch_validator_snapshot,
+        validator_total_at, write_abi,
     },
 };
 
@@ -63,7 +64,7 @@ pub fn register_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result
         .min_validator_stake_amount_accessor()
         .get_checked(sdk)?;
     if command.initial_stake < minimum {
-        return revert(sdk, ERR_INITIAL_STAKE_TOO_LOW);
+        return revert_with(sdk, ERR_INITIAL_STAKE_TOO_LOW, &command.initial_stake);
     }
     let owner = sdk.context().contract_caller();
     let since_epoch = next_epoch(sdk)?;
@@ -101,7 +102,7 @@ pub fn delegate_to<SDK: SharedAPI>(
         .min_staking_amount_accessor()
         .get_checked(sdk)?;
     if amount.is_zero() || amount < minimum {
-        return revert(sdk, ERR_AMOUNT_TOO_LOW);
+        return revert_with(sdk, ERR_AMOUNT_TOO_LOW, &amount);
     }
     if math::compact_balance(amount).is_none() {
         return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
@@ -113,7 +114,7 @@ pub fn delegate_to<SDK: SharedAPI>(
         .get_checked(sdk)?
         == STATUS_NOT_FOUND
     {
-        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
     }
 
     let at_epoch = current_epoch(sdk)?
@@ -186,7 +187,7 @@ pub fn undelegate_from<SDK: SharedAPI>(
     let config = storage.config_accessor();
     let minimum = config.min_staking_amount_accessor().get_checked(sdk)?;
     if amount.is_zero() || amount < minimum {
-        return revert(sdk, ERR_AMOUNT_TOO_LOW);
+        return revert_with(sdk, ERR_AMOUNT_TOO_LOW, &amount);
     }
     if math::compact_balance(amount).is_none() {
         return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
@@ -194,7 +195,7 @@ pub fn undelegate_from<SDK: SharedAPI>(
     let record = storage.validators_accessor().entry(validator);
     let status = record.status_accessor().get_checked(sdk)?;
     if status == STATUS_NOT_FOUND {
-        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
     }
 
     let before_epoch = next_epoch(sdk)?;

--- a/contracts/staking/src/economics.rs
+++ b/contracts/staking/src/economics.rs
@@ -1,0 +1,260 @@
+use fluentbase_sdk::{Address, ContextReader, ExitCode, SharedAPI, U256};
+
+use crate::{
+    consts::*,
+    events, math,
+    storage::{
+        current_epoch, current_epoch_at_block, staking_storage, STATUS_ACTIVE, STATUS_NOT_FOUND,
+        STATUS_PENDING,
+    },
+    types::{
+        AddressAmountCommand, RegisterValidatorCommand, ValidatorBlockCommand,
+        ValidatorDelegatorCommand,
+    },
+    util::{
+        decode, ensure_initialized, ensure_mutable, ensure_non_payable, next_epoch, revert,
+        safe_transfer_from, set_validator, touch_validator_snapshot, validator_total_at, write_abi,
+    },
+};
+
+pub fn get_validator_delegation<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let command: ValidatorDelegatorCommand = decode(input)?;
+    let queue = staking_storage()
+        .validator_delegations_accessor()
+        .entry(command.validator)
+        .entry(command.delegator)
+        .delegate_queue_accessor();
+    let len = queue.len_checked(sdk)?;
+    if len == 0 {
+        return write_abi(sdk, &(U256::ZERO, 0u64));
+    }
+    let latest = queue.at(len - 1);
+    let result = (
+        latest.amount_accessor().get_checked(sdk)?,
+        latest.epoch_accessor().get_checked(sdk)?,
+    );
+    write_abi(sdk, &result)
+}
+
+pub fn get_validator_delegated_stake_at<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let command: ValidatorBlockCommand = decode(input)?;
+    if command.block_number > U256::from(u64::MAX) {
+        return Err(ExitCode::IntegerOverflow);
+    }
+    let epoch = current_epoch_at_block(sdk, command.block_number.to::<u64>())?;
+    write_abi(sdk, &validator_total_at(sdk, command.validator, epoch)?)
+}
+
+pub fn register_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command: RegisterValidatorCommand = decode(input)?;
+    let minimum = staking_storage()
+        .config_accessor()
+        .min_validator_stake_amount_accessor()
+        .get_checked(sdk)?;
+    if command.initial_stake < minimum {
+        return revert(sdk, ERR_INITIAL_STAKE_TOO_LOW);
+    }
+    let owner = sdk.context().contract_caller();
+    let since_epoch = next_epoch(sdk)?;
+    set_validator(
+        sdk,
+        command.validator,
+        owner,
+        STATUS_PENDING,
+        command.commission_rate,
+        command.initial_stake,
+        since_epoch,
+    )?;
+    safe_transfer_from(sdk, owner, command.initial_stake)
+}
+
+pub fn delegate<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command: AddressAmountCommand = decode(input)?;
+    let delegator = sdk.context().contract_caller();
+    delegate_to(sdk, delegator, command.validator, command.amount, true)
+}
+
+pub fn delegate_to<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    delegator: Address,
+    validator: Address,
+    amount: U256,
+    pull_tokens: bool,
+) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    let minimum = storage
+        .config_accessor()
+        .min_staking_amount_accessor()
+        .get_checked(sdk)?;
+    if amount.is_zero() || amount < minimum {
+        return revert(sdk, ERR_AMOUNT_TOO_LOW);
+    }
+    if math::compact_balance(amount).is_none() {
+        return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
+    }
+    if storage
+        .validators_accessor()
+        .entry(validator)
+        .status_accessor()
+        .get_checked(sdk)?
+        == STATUS_NOT_FOUND
+    {
+        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+    }
+
+    let at_epoch = current_epoch(sdk)?
+        .checked_add(WARMUP_DELAY)
+        .ok_or(ExitCode::IntegerOverflow)?;
+    let snapshot = touch_validator_snapshot(sdk, validator, at_epoch)?;
+    let next_total = snapshot
+        .total_delegated_accessor()
+        .get_checked(sdk)?
+        .checked_add(amount)
+        .ok_or(ExitCode::IntegerOverflow)?;
+    snapshot
+        .total_delegated_accessor()
+        .set_checked(sdk, next_total)?;
+
+    let queue = storage
+        .validator_delegations_accessor()
+        .entry(validator)
+        .entry(delegator)
+        .delegate_queue_accessor();
+    let len = queue.len_checked(sdk)?;
+    if len == 0 {
+        let operation = queue.grow_checked(sdk)?;
+        operation.amount_accessor().set_checked(sdk, amount)?;
+        operation.epoch_accessor().set_checked(sdk, at_epoch)?;
+    } else {
+        let latest = queue.at(len - 1);
+        let previous_amount = latest.amount_accessor().get_checked(sdk)?;
+        let next_amount = previous_amount
+            .checked_add(amount)
+            .ok_or(ExitCode::IntegerOverflow)?;
+        if latest.epoch_accessor().get_checked(sdk)? >= at_epoch {
+            latest.amount_accessor().set_checked(sdk, next_amount)?;
+        } else {
+            let operation = queue.grow_checked(sdk)?;
+            operation.amount_accessor().set_checked(sdk, next_amount)?;
+            operation.epoch_accessor().set_checked(sdk, at_epoch)?;
+        }
+    }
+
+    if pull_tokens {
+        safe_transfer_from(sdk, delegator, amount)?;
+    }
+    events::Delegated {
+        validator,
+        staker: delegator,
+        amount,
+        epoch: at_epoch,
+    }
+    .emit(sdk)?;
+    Ok(())
+}
+
+pub fn undelegate<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command: AddressAmountCommand = decode(input)?;
+    let delegator = sdk.context().contract_caller();
+    undelegate_from(sdk, delegator, command.validator, command.amount)
+}
+
+pub fn undelegate_from<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    delegator: Address,
+    validator: Address,
+    amount: U256,
+) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    let config = storage.config_accessor();
+    let minimum = config.min_staking_amount_accessor().get_checked(sdk)?;
+    if amount.is_zero() || amount < minimum {
+        return revert(sdk, ERR_AMOUNT_TOO_LOW);
+    }
+    if math::compact_balance(amount).is_none() {
+        return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
+    }
+    let record = storage.validators_accessor().entry(validator);
+    let status = record.status_accessor().get_checked(sdk)?;
+    if status == STATUS_NOT_FOUND {
+        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+    }
+
+    let before_epoch = next_epoch(sdk)?;
+    let snapshot = touch_validator_snapshot(sdk, validator, before_epoch)?;
+    let total = snapshot.total_delegated_accessor().get_checked(sdk)?;
+    let Some(next_total) = total.checked_sub(amount) else {
+        return revert(sdk, ERR_INSUFFICIENT_BALANCE);
+    };
+
+    let delegation = storage
+        .validator_delegations_accessor()
+        .entry(validator)
+        .entry(delegator);
+    let queue = delegation.delegate_queue_accessor();
+    let len = queue.len_checked(sdk)?;
+    if len == 0 {
+        return revert(sdk, ERR_DELEGATION_QUEUE_EMPTY);
+    }
+    let latest = queue.at(len - 1);
+    let delegated = latest.amount_accessor().get_checked(sdk)?;
+    let Some(next_delegated) = delegated.checked_sub(amount) else {
+        return revert(sdk, ERR_INSUFFICIENT_BALANCE);
+    };
+
+    let owner = record.owner_accessor().get_checked(sdk)?;
+    if delegator == owner && (status == STATUS_ACTIVE || status == STATUS_PENDING) {
+        let min_validator_stake = config
+            .min_validator_stake_amount_accessor()
+            .get_checked(sdk)?;
+        if next_delegated < min_validator_stake && next_total != next_delegated {
+            return revert(sdk, ERR_OWNER_SELF_STAKE_BELOW_MINIMUM);
+        }
+    }
+
+    snapshot
+        .total_delegated_accessor()
+        .set_checked(sdk, next_total)?;
+    if latest.epoch_accessor().get_checked(sdk)? >= before_epoch {
+        latest.amount_accessor().set_checked(sdk, next_delegated)?;
+    } else {
+        let operation = queue.grow_checked(sdk)?;
+        operation
+            .amount_accessor()
+            .set_checked(sdk, next_delegated)?;
+        operation.epoch_accessor().set_checked(sdk, before_epoch)?;
+    }
+
+    let maturity_epoch = before_epoch
+        .checked_add(config.undelegate_period_accessor().get_checked(sdk)?)
+        .ok_or(ExitCode::IntegerOverflow)?;
+    let pending = delegation.undelegate_queue_accessor().grow_checked(sdk)?;
+    pending.amount_accessor().set_checked(sdk, amount)?;
+    pending.epoch_accessor().set_checked(sdk, maturity_epoch)?;
+
+    events::Undelegated {
+        validator,
+        staker: delegator,
+        amount,
+        epoch: before_epoch,
+    }
+    .emit(sdk)?;
+    Ok(())
+}

--- a/contracts/staking/src/economics.rs
+++ b/contracts/staking/src/economics.rs
@@ -59,6 +59,18 @@ pub fn register_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result
     ensure_mutable(sdk)?;
     ensure_initialized(sdk)?;
     let command: RegisterValidatorCommand = decode(input)?;
+    if command.commission_rate > COMMISSION_RATE_MAX {
+        return revert_with(sdk, ERR_BAD_COMMISSION_RATE, &command.commission_rate);
+    }
+    if staking_storage()
+        .validators_accessor()
+        .entry(command.validator)
+        .status_accessor()
+        .get_checked(sdk)?
+        != STATUS_NOT_FOUND
+    {
+        return revert_with(sdk, ERR_VALIDATOR_ALREADY_EXISTS, &command.validator);
+    }
     let minimum = staking_storage()
         .config_accessor()
         .min_validator_stake_amount_accessor()
@@ -225,7 +237,9 @@ pub fn undelegate_from<SDK: SharedAPI>(
         let min_validator_stake = config
             .min_validator_stake_amount_accessor()
             .get_checked(sdk)?;
-        if next_delegated < min_validator_stake && next_total != next_delegated {
+        if next_delegated < min_validator_stake
+            && (!next_delegated.is_zero() || next_total != next_delegated)
+        {
             return revert(sdk, ERR_OWNER_SELF_STAKE_BELOW_MINIMUM);
         }
     }

--- a/contracts/staking/src/equivocation.rs
+++ b/contracts/staking/src/equivocation.rs
@@ -239,10 +239,11 @@ fn slash_equivocation<SDK: SharedAPI>(
         .entry(validator)
         .set_checked(sdk, true)?;
     let record = storage.validators_accessor().entry(validator);
-    if record.status_accessor().get_checked(sdk)? == STATUS_NOT_FOUND {
+    let status = record.status_accessor().get_checked(sdk)?;
+    if status == STATUS_NOT_FOUND {
         return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
     }
-    if record.status_accessor().get_checked(sdk)? == STATUS_ACTIVE {
+    if status == STATUS_ACTIVE {
         remove_active(sdk, validator)?;
     }
     record.status_accessor().set_checked(sdk, STATUS_JAIL)?;

--- a/contracts/staking/src/equivocation.rs
+++ b/contracts/staking/src/equivocation.rs
@@ -1,3 +1,5 @@
+//! Permissionless equivocation proofs and permanent validator tombstoning.
+
 use alloc::vec::Vec;
 
 use fluentbase_sdk::{
@@ -234,6 +236,8 @@ fn slash_equivocation<SDK: SharedAPI>(
         return revert(sdk, ERR_EQUIVOCATION_SIGNATURE_INVALID);
     }
 
+    // A verified conflict is terminal: the validator cannot re-register keys
+    // or return through the ordinary jail-release path.
     storage
         .tombstoned_accessor()
         .entry(validator)

--- a/contracts/staking/src/equivocation.rs
+++ b/contracts/staking/src/equivocation.rs
@@ -1,0 +1,309 @@
+use alloc::vec::Vec;
+
+use fluentbase_sdk::{
+    bytes::BytesMut, codec::SolidityABI, keccak256, Address, Bytes, ContextReader, ExitCode,
+    SharedAPI, U256,
+};
+
+use crate::{
+    consts::*,
+    events,
+    storage::{
+        current_epoch, remove_active, staking_storage, STATUS_ACTIVE, STATUS_JAIL, STATUS_NOT_FOUND,
+    },
+    types::{DecodedEvidence, EquivocationCommand},
+    util::{
+        decode_args, ensure_initialized, ensure_mutable, ensure_non_payable, revert, revert_with,
+        safe_transfer, set_selection_visible,
+    },
+};
+
+const BLS_SIG_DST: &[u8] = b"BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_";
+
+fn external_call<SDK, T>(
+    sdk: &mut SDK,
+    target: Address,
+    selector: u32,
+    params: &T,
+) -> Result<Bytes, ExitCode>
+where
+    SDK: SharedAPI,
+    T: fluentbase_sdk::codec::FunctionArgs<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let mut encoded = BytesMut::new();
+    SolidityABI::<T>::encode_function_args(params, &mut encoded)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    let mut input = selector.to_be_bytes().to_vec();
+    input.extend_from_slice(&encoded);
+    let result = sdk.call(target, U256::ZERO, &input, None);
+    if !result.status.is_ok() {
+        sdk.write(result.data);
+        return Err(result.status);
+    }
+    Ok(result.data)
+}
+
+fn call_decode<SDK, T, R>(
+    sdk: &mut SDK,
+    target: Address,
+    selector: u32,
+    params: &T,
+) -> Result<R, ExitCode>
+where
+    SDK: SharedAPI,
+    T: fluentbase_sdk::codec::FunctionArgs<fluentbase_sdk::byteorder::BE, 32, true, false>,
+    R: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let output = external_call(sdk, target, selector, params)?;
+    SolidityABI::<R>::decode(&output, 0).map_err(|_| ExitCode::MalformedBuiltinParams)
+}
+
+fn namespace<SDK: SharedAPI>(sdk: &SDK, kind: u8) -> Vec<u8> {
+    let mut result = b"FLUENT_DPOS_V1_".to_vec();
+    result.extend_from_slice(&sdk.context().block_chain_id().to_be_bytes());
+    result.extend_from_slice(match kind {
+        0 => b"_NOTARIZE",
+        1 => b"_NULLIFY",
+        _ => b"_FINALIZE",
+    });
+    result
+}
+
+fn seize_self_stake<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    owner: Address,
+    reporter: Address,
+) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    let delegation = storage
+        .validator_delegations_accessor()
+        .entry(validator)
+        .entry(owner);
+    let queue = delegation.delegate_queue_accessor();
+    let len = queue.len_checked(sdk)?;
+    if len == 0 {
+        return Ok(());
+    }
+    let seized = queue.at(len - 1).amount_accessor().get_checked(sdk)?;
+    if seized.is_zero() {
+        return Ok(());
+    }
+    queue.clear_checked(sdk)?;
+    delegation.delegate_gap_accessor().set_checked(sdk, 0)?;
+
+    let config = storage.config_accessor();
+    let stored_bps = config
+        .slash_reporter_reward_bps_accessor()
+        .get_checked(sdk)?;
+    let bps = if stored_bps == 0 {
+        DEFAULT_SLASH_REPORTER_REWARD_BPS
+    } else {
+        stored_bps
+    };
+    let mut reporter_reward = seized
+        .checked_mul(U256::from(bps))
+        .ok_or(ExitCode::IntegerOverflow)?
+        / U256::from(10_000);
+    let mut remainder = seized - reporter_reward;
+    if reporter.is_zero() {
+        remainder = remainder
+            .checked_add(reporter_reward)
+            .ok_or(ExitCode::IntegerOverflow)?;
+        reporter_reward = U256::ZERO;
+    } else {
+        safe_transfer(sdk, reporter, reporter_reward)?;
+    }
+    let configured_fund = config.slash_fund_address_accessor().get_checked(sdk)?;
+    let recipient = if configured_fund.is_zero() {
+        EQUIVOCATION_BURN_SINK
+    } else {
+        configured_fund
+    };
+    safe_transfer(sdk, recipient, remainder)?;
+    events::EquivocationStakeSeized {
+        validator,
+        reporter,
+        reporter_reward,
+        remainder,
+        recipient,
+    }
+    .emit(sdk)
+}
+
+fn slash_equivocation<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    command: EquivocationCommand,
+    decoder_selector: u32,
+) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    let config = storage.config_accessor();
+    let decoder = config.evidence_decoder_accessor().get_checked(sdk)?;
+    if decoder.is_zero() {
+        return revert(sdk, ERR_EVIDENCE_DECODER_NOT_CONFIGURED);
+    }
+    let evidence =
+        call_decode::<_, _, DecodedEvidence>(sdk, decoder, decoder_selector, &(command.evidence,))?;
+    let committee = storage.epoch_committees_accessor().entry(evidence.epoch);
+    let committee_len = committee.len_checked(sdk)?;
+    if committee_len == 0 {
+        return revert_with(sdk, ERR_EPOCH_COMMITTEE_NOT_COMMITTED, &evidence.epoch);
+    }
+    if evidence.signer_idx as u64 >= committee_len {
+        return revert_with(
+            sdk,
+            ERR_SIGNER_INDEX_OUT_OF_RANGE,
+            &(
+                evidence.epoch,
+                evidence.signer_idx,
+                U256::from(committee_len),
+            ),
+        );
+    }
+    let validator = committee.at(evidence.signer_idx as u64).get_checked(sdk)?;
+    if storage
+        .tombstoned_accessor()
+        .entry(validator)
+        .get_checked(sdk)?
+    {
+        return revert_with(sdk, ERR_ALREADY_SLASHED_FOR_EQUIVOCATION, &validator);
+    }
+    let stored_key = storage
+        .consensus_keys_accessor()
+        .entry(validator)
+        .bls_pubkey_accessor()
+        .load(sdk)?;
+    if stored_key.len() != BLS_PUBKEY_LENGTH {
+        return revert_with(sdk, ERR_CONSENSUS_KEYS_NOT_SET, &validator);
+    }
+    let verifier = config.bls_verifier_accessor().get_checked(sdk)?;
+    if verifier.is_zero() {
+        return revert(sdk, ERR_BLS_VERIFIER_NOT_CONFIGURED);
+    }
+    let supplied_key = call_decode::<_, _, Vec<u8>>(
+        sdk,
+        verifier,
+        SIG_BLS_COMPRESS_G2_UNCHECKED,
+        &(command.pk_uncompressed.clone(),),
+    )?;
+    if keccak256(&supplied_key) != keccak256(&stored_key) {
+        return revert(sdk, ERR_EQUIVOCATION_KEY_MISMATCH);
+    }
+    let supplied_sig1 = call_decode::<_, _, Vec<u8>>(
+        sdk,
+        verifier,
+        SIG_BLS_COMPRESS_G1_UNCHECKED,
+        &(command.sig1_uncompressed.clone(),),
+    )?;
+    let supplied_sig2 = call_decode::<_, _, Vec<u8>>(
+        sdk,
+        verifier,
+        SIG_BLS_COMPRESS_G1_UNCHECKED,
+        &(command.sig2_uncompressed.clone(),),
+    )?;
+    if keccak256(&supplied_sig1) != keccak256(&evidence.sig1)
+        || keccak256(&supplied_sig2) != keccak256(&evidence.sig2)
+    {
+        return revert(sdk, ERR_EQUIVOCATION_SIGNATURE_INVALID);
+    }
+    let valid1 = call_decode::<_, _, bool>(
+        sdk,
+        verifier,
+        SIG_BLS_VERIFY,
+        &(
+            namespace(sdk, evidence.kind1),
+            evidence.msg1,
+            BLS_SIG_DST.to_vec(),
+            command.sig1_uncompressed,
+            command.pk_uncompressed.clone(),
+        ),
+    )?;
+    let valid2 = call_decode::<_, _, bool>(
+        sdk,
+        verifier,
+        SIG_BLS_VERIFY,
+        &(
+            namespace(sdk, evidence.kind2),
+            evidence.msg2,
+            BLS_SIG_DST.to_vec(),
+            command.sig2_uncompressed,
+            command.pk_uncompressed,
+        ),
+    )?;
+    if !valid1 || !valid2 {
+        return revert(sdk, ERR_EQUIVOCATION_SIGNATURE_INVALID);
+    }
+
+    storage
+        .tombstoned_accessor()
+        .entry(validator)
+        .set_checked(sdk, true)?;
+    let record = storage.validators_accessor().entry(validator);
+    if record.status_accessor().get_checked(sdk)? == STATUS_NOT_FOUND {
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
+    }
+    if record.status_accessor().get_checked(sdk)? == STATUS_ACTIVE {
+        remove_active(sdk, validator)?;
+    }
+    record.status_accessor().set_checked(sdk, STATUS_JAIL)?;
+    let penalty_epoch = current_epoch(sdk)?;
+    set_selection_visible(sdk, validator, false, penalty_epoch)?;
+    let owner = record.owner_accessor().get_checked(sdk)?;
+    let reporter = sdk.context().contract_caller();
+    seize_self_stake(sdk, validator, owner, reporter)?;
+    events::ValidatorJailed {
+        validator,
+        epoch: penalty_epoch,
+    }
+    .emit(sdk)?;
+    events::EquivocationSlashed {
+        validator,
+        epoch: evidence.epoch,
+        reporter,
+    }
+    .emit(sdk)
+}
+
+pub fn slash_notarize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    slash_equivocation(
+        sdk,
+        decode_equivocation(input)?,
+        SIG_DECODE_CONFLICTING_NOTARIZE,
+    )
+}
+
+pub fn slash_finalize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    slash_equivocation(
+        sdk,
+        decode_equivocation(input)?,
+        SIG_DECODE_CONFLICTING_FINALIZE,
+    )
+}
+
+pub fn slash_nullify_finalize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    slash_equivocation(
+        sdk,
+        decode_equivocation(input)?,
+        SIG_DECODE_NULLIFY_FINALIZE,
+    )
+}
+
+fn decode_equivocation(input: &[u8]) -> Result<EquivocationCommand, ExitCode> {
+    let (evidence, pk_uncompressed, sig1_uncompressed, sig2_uncompressed) =
+        decode_args::<(Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>)>(input)?;
+    Ok(EquivocationCommand {
+        evidence,
+        pk_uncompressed,
+        sig1_uncompressed,
+        sig2_uncompressed,
+    })
+}

--- a/contracts/staking/src/equivocation.rs
+++ b/contracts/staking/src/equivocation.rs
@@ -87,10 +87,11 @@ fn seize_self_stake<SDK: SharedAPI>(
     if len == 0 {
         return Ok(());
     }
-    let seized = queue.at(len - 1).amount_accessor().get_checked(sdk)?;
-    if seized.is_zero() {
+    let compact_seized = queue.at(len - 1).amount_accessor().get_checked(sdk)?;
+    if compact_seized.is_zero() {
         return Ok(());
     }
+    let seized = crate::math::expand_balance(compact_seized);
     queue.clear_checked(sdk)?;
     delegation.delegate_gap_accessor().set_checked(sdk, 0)?;
 

--- a/contracts/staking/src/events.rs
+++ b/contracts/staking/src/events.rs
@@ -1,0 +1,27 @@
+use fluentbase_sdk::{derive::Event, Address};
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct ValidatorAdded {
+    #[indexed]
+    pub validator: Address,
+    #[indexed]
+    pub owner: Address,
+    pub status: u8,
+    pub commission_rate: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct ValidatorModified {
+    #[indexed]
+    pub validator: Address,
+    #[indexed]
+    pub owner: Address,
+    pub status: u8,
+    pub commission_rate: u16,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct ValidatorRemoved {
+    #[indexed]
+    pub validator: Address,
+}

--- a/contracts/staking/src/events.rs
+++ b/contracts/staking/src/events.rs
@@ -1,4 +1,4 @@
-use fluentbase_sdk::{derive::Event, Address};
+use fluentbase_sdk::{derive::Event, Address, U256};
 
 #[derive(Debug, Clone, PartialEq, Eq, Event)]
 pub struct ValidatorAdded {
@@ -24,4 +24,24 @@ pub struct ValidatorModified {
 pub struct ValidatorRemoved {
     #[indexed]
     pub validator: Address,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct Delegated {
+    #[indexed]
+    pub validator: Address,
+    #[indexed]
+    pub staker: Address,
+    pub amount: U256,
+    pub epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct Undelegated {
+    #[indexed]
+    pub validator: Address,
+    #[indexed]
+    pub staker: Address,
+    pub amount: U256,
+    pub epoch: u64,
 }

--- a/contracts/staking/src/events.rs
+++ b/contracts/staking/src/events.rs
@@ -1,4 +1,5 @@
-use fluentbase_sdk::{derive::Event, Address, U256};
+use alloc::vec::Vec;
+use fluentbase_sdk::{derive::Event, Address, B256, U256};
 
 #[derive(Debug, Clone, PartialEq, Eq, Event)]
 pub struct ValidatorAdded {
@@ -44,4 +45,203 @@ pub struct Undelegated {
     pub staker: Address,
     pub amount: U256,
     pub epoch: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct ActiveValidatorsLengthChanged {
+    pub prev_value: u32,
+    pub new_value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct EpochBlockIntervalChanged {
+    pub prev_value: u32,
+    pub new_value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct DposActivationBlockChanged {
+    pub prev_value: u64,
+    pub new_value: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct FelonyThresholdChanged {
+    pub prev_value: u32,
+    pub new_value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct ValidatorJailEpochLengthChanged {
+    pub prev_value: u32,
+    pub new_value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct SlashReporterRewardBpsChanged {
+    pub prev_value: u32,
+    pub new_value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct SlashFundAddressChanged {
+    pub prev_value: Address,
+    pub new_value: Address,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct ParticipationFloorBpsChanged {
+    pub prev_value: u32,
+    pub new_value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct ParticipationJailDisabledChanged {
+    pub prev_value: bool,
+    pub new_value: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct BlendStipendPerEpochChanged {
+    pub prev_value: U256,
+    pub new_value: U256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct UndelegatePeriodChanged {
+    pub prev_value: u32,
+    pub new_value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct MinValidatorStakeAmountChanged {
+    pub prev_value: U256,
+    pub new_value: U256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct MinStakingAmountChanged {
+    pub prev_value: U256,
+    pub new_value: U256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct BlsVerifierChanged {
+    pub prev_value: Address,
+    pub new_value: Address,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Event)]
+pub struct EvidenceDecoderChanged {
+    pub prev_value: Address,
+    pub new_value: Address,
+}
+
+#[derive(Event)]
+pub struct ValidatorOwnerClaimed {
+    #[indexed]
+    pub validator: Address,
+    pub amount: U256,
+    pub epoch: u64,
+}
+
+#[derive(Event)]
+pub struct Claimed {
+    #[indexed]
+    pub validator: Address,
+    #[indexed]
+    pub staker: Address,
+    pub amount: U256,
+    pub epoch: u64,
+}
+
+#[derive(Event)]
+pub struct Redelegated {
+    #[indexed]
+    pub validator: Address,
+    #[indexed]
+    pub staker: Address,
+    pub amount: U256,
+    pub dust: U256,
+    pub epoch: u64,
+}
+
+#[derive(Event)]
+pub struct EpochBlendRewardsCommitted {
+    #[indexed]
+    pub epoch: u64,
+    pub blend_amount: U256,
+}
+
+#[derive(Event)]
+pub struct StipendSkipped {
+    #[indexed]
+    pub epoch: u64,
+}
+
+#[derive(Event)]
+pub struct ConsensusKeysSet {
+    #[indexed]
+    pub validator: Address,
+    pub bls_pubkey: Vec<u8>,
+    pub peer_pubkey: B256,
+    pub activation_epoch: u64,
+}
+
+#[derive(Event)]
+pub struct EpochCommitteeCommitted {
+    #[indexed]
+    pub epoch: u64,
+    pub committee: Vec<Address>,
+}
+
+#[derive(Event)]
+pub struct ValidatorReleased {
+    #[indexed]
+    pub validator: Address,
+    pub epoch: u64,
+}
+
+#[derive(Event)]
+pub struct ValidatorJailed {
+    #[indexed]
+    pub validator: Address,
+    pub epoch: u64,
+}
+
+#[derive(Event)]
+pub struct ValidatorSlashed {
+    #[indexed]
+    pub validator: Address,
+    pub slashes: u32,
+    pub epoch: u64,
+}
+
+#[derive(Event)]
+pub struct LivenessJailSkippedHaltGuard {
+    #[indexed]
+    pub validator: Address,
+    pub epoch: u64,
+    pub active_set_size: U256,
+    pub quorum_floor: U256,
+}
+
+#[derive(Event)]
+pub struct EquivocationSlashed {
+    #[indexed]
+    pub validator: Address,
+    pub epoch: u64,
+    #[indexed]
+    pub reporter: Address,
+}
+
+#[derive(Event)]
+pub struct EquivocationStakeSeized {
+    #[indexed]
+    pub validator: Address,
+    #[indexed]
+    pub reporter: Address,
+    pub reporter_reward: U256,
+    pub remainder: U256,
+    pub recipient: Address,
 }

--- a/contracts/staking/src/events.rs
+++ b/contracts/staking/src/events.rs
@@ -1,3 +1,5 @@
+//! Solidity-compatible staking event definitions.
+
 use alloc::vec::Vec;
 use fluentbase_sdk::{derive::Event, Address, B256, U256};
 

--- a/contracts/staking/src/handlers.rs
+++ b/contracts/staking/src/handlers.rs
@@ -11,7 +11,7 @@ use crate::{
     util::{
         address_arg, decode, emit_modified, ensure_governance, ensure_initialized, ensure_mutable,
         ensure_non_payable, next_epoch, revert, selected_validators, set_validator,
-        total_delegated, validator_status, write_abi,
+        total_delegated, touch_validator_snapshot, validator_status, write_abi,
     },
 };
 
@@ -44,6 +44,9 @@ pub fn initialize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exi
     config
         .epoch_block_interval_accessor()
         .set_checked(sdk, DEFAULT_EPOCH_BLOCK_INTERVAL)?;
+    config
+        .undelegate_period_accessor()
+        .set_checked(sdk, DEFAULT_UNDELEGATE_PERIOD)?;
     config
         .active_validators_length_accessor()
         .set_checked(sdk, DEFAULT_ACTIVE_VALIDATORS_LENGTH)?;
@@ -86,7 +89,14 @@ pub fn configure<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exit
     if command.staking_token.is_zero() {
         return revert(sdk, ERR_ZERO_STAKING_TOKEN);
     }
-    if command.active_validators_length == 0 || command.epoch_block_interval == 0 {
+    if command.active_validators_length == 0
+        || command.active_validators_length > MAX_ACTIVE_VALIDATORS_LENGTH
+        || command.epoch_block_interval == 0
+        || command.min_validator_stake_amount.is_zero()
+        || command.min_staking_amount.is_zero()
+        || crate::math::compact_balance(command.min_validator_stake_amount).is_none()
+        || crate::math::compact_balance(command.min_staking_amount).is_none()
+    {
         return revert(sdk, ERR_INVALID_CHAIN_CONFIG);
     }
 
@@ -156,6 +166,60 @@ pub fn get_staking_token<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> 
     write_abi(sdk, &token)
 }
 
+pub fn get_active_validators_length<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let value = staking_storage()
+        .config_accessor()
+        .active_validators_length_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &value)
+}
+
+pub fn get_epoch_block_interval<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let value = staking_storage()
+        .config_accessor()
+        .epoch_block_interval_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &value)
+}
+
+pub fn get_dpos_activation_block<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let value = staking_storage()
+        .config_accessor()
+        .dpos_activation_block_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &value)
+}
+
+pub fn get_undelegate_period<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let value = staking_storage()
+        .config_accessor()
+        .undelegate_period_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &value)
+}
+
+pub fn get_min_validator_stake_amount<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let value = staking_storage()
+        .config_accessor()
+        .min_validator_stake_amount_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &value)
+}
+
+pub fn get_min_staking_amount<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let value = staking_storage()
+        .config_accessor()
+        .min_staking_amount_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &value)
+}
+
 pub fn is_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
     ensure_non_payable(sdk)?;
     let result = validator_status(sdk, address_arg(input)?)? != STATUS_NOT_FOUND;
@@ -174,15 +238,20 @@ pub fn get_validator_status<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Resu
     ensure_non_payable(sdk)?;
     let validator = address_arg(input)?;
     let record = staking_storage().validators_accessor().entry(validator);
+    let changed_at = record.changed_at_accessor().get_checked(sdk)?;
+    let snapshot = staking_storage()
+        .validator_snapshots_accessor()
+        .entry(validator)
+        .entry(changed_at);
     let result = (
         record.owner_accessor().get_checked(sdk)?,
         record.status_accessor().get_checked(sdk)?,
-        record.total_delegated_accessor().get_checked(sdk)?,
-        record.slashes_count_accessor().get_checked(sdk)?,
-        record.changed_at_accessor().get_checked(sdk)?,
+        snapshot.total_delegated_accessor().get_checked(sdk)?,
+        snapshot.slashes_count_accessor().get_checked(sdk)?,
+        changed_at,
         record.jailed_before_accessor().get_checked(sdk)?,
         record.claimed_at_accessor().get_checked(sdk)?,
-        record.commission_rate_accessor().get_checked(sdk)?,
+        snapshot.commission_rate_accessor().get_checked(sdk)?,
     );
     write_abi(sdk, &result)
 }
@@ -300,7 +369,9 @@ pub fn change_commission<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<
     if validator_owner != sdk.context().contract_caller() {
         return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
     }
-    record
+    let changed_at = next_epoch(sdk)?;
+    let snapshot = touch_validator_snapshot(sdk, command.validator, changed_at)?;
+    snapshot
         .commission_rate_accessor()
         .set_checked(sdk, command.value)?;
     emit_modified(sdk, command.validator)

--- a/contracts/staking/src/handlers.rs
+++ b/contracts/staking/src/handlers.rs
@@ -25,6 +25,15 @@ pub fn initialize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exi
     if storage.initialized_accessor().get_checked(sdk)? {
         return revert(sdk, ERR_ALREADY_INITIALIZED);
     }
+    let caller = sdk.context().contract_caller();
+    let configured_owner = storage.owner_accessor().get_checked(sdk)?;
+    if configured_owner.is_zero() {
+        if caller != fluentbase_sdk::GENESIS_GOVERNANCE {
+            return revert_with(sdk, ERR_ONLY_OWNER, &caller);
+        }
+    } else if caller != configured_owner {
+        return revert_with(sdk, ERR_ONLY_OWNER, &caller);
+    }
     let (initial_owner, validators, initial_stakes, commission_rate) =
         decode_args::<(Address, Vec<Address>, Vec<U256>, u16)>(input)?;
     let command = InitializeCommand {
@@ -39,8 +48,9 @@ pub fn initialize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exi
     if command.validators.len() != command.initial_stakes.len() {
         return revert(sdk, ERR_MALFORMED_INPUT_LENGTH);
     }
-
-    let configured_owner = storage.owner_accessor().get_checked(sdk)?;
+    if command.commission_rate > COMMISSION_RATE_MAX {
+        return revert_with(sdk, ERR_BAD_COMMISSION_RATE, &command.commission_rate);
+    }
     if !configured_owner.is_zero() && configured_owner != command.initial_owner {
         return revert_with(sdk, ERR_ONLY_OWNER, &command.initial_owner);
     }
@@ -136,11 +146,12 @@ pub fn configure<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exit
     let storage = staking_storage();
     let caller = sdk.context().contract_caller();
     let owner = storage.owner_accessor().get_checked(sdk)?;
-    if !owner.is_zero() && caller != owner {
-        return revert_with(sdk, ERR_ONLY_OWNER, &caller);
-    }
     if owner.is_zero() {
-        storage.owner_accessor().set_checked(sdk, caller)?;
+        if caller != fluentbase_sdk::GENESIS_GOVERNANCE {
+            return revert_with(sdk, ERR_ONLY_OWNER, &caller);
+        }
+    } else if caller != owner {
+        return revert_with(sdk, ERR_ONLY_OWNER, &caller);
     }
     let config = storage.config_accessor();
     if config.configured_accessor().get_checked(sdk)? {
@@ -502,7 +513,20 @@ pub fn remove_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(
     }
     remove_active(sdk, validator)?;
     remove_selection_member(sdk, validator)?;
+    crate::liveness::remove_jailed(sdk, validator)?;
     let storage = staking_storage();
+    let keys = storage.consensus_keys_accessor().entry(validator);
+    let peer_pubkey = keys.peer_pubkey_accessor().get_checked(sdk)?;
+    if !peer_pubkey.is_zero() {
+        storage
+            .peer_pubkey_owner_accessor()
+            .entry(peer_pubkey)
+            .set_checked(sdk, Address::ZERO)?;
+    }
+    keys.bls_pubkey_accessor().clear(sdk)?;
+    keys.peer_pubkey_accessor()
+        .set_checked(sdk, fluentbase_sdk::B256::ZERO)?;
+    keys.activation_epoch_accessor().set_checked(sdk, 0)?;
     let record = storage.validators_accessor().entry(validator);
     let validator_owner = record.owner_accessor().get_checked(sdk)?;
     storage
@@ -513,6 +537,7 @@ pub fn remove_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(
     record
         .status_accessor()
         .set_checked(sdk, STATUS_NOT_FOUND)?;
+    record.first_snapshot_epoch_p1_accessor().set_checked(sdk, 0)?;
     events::ValidatorRemoved { validator }.emit(sdk)?;
     Ok(())
 }

--- a/contracts/staking/src/handlers.rs
+++ b/contracts/staking/src/handlers.rs
@@ -1,0 +1,344 @@
+use fluentbase_sdk::{Address, ContextReader, ExitCode, SharedAPI, U256};
+
+use crate::{
+    consts::*,
+    events,
+    storage::{
+        current_epoch, remove_active, staking_storage, STATUS_ACTIVE, STATUS_NOT_FOUND,
+        STATUS_PENDING,
+    },
+    types::{AddressU16Command, ConfigureCommand, InitializeCommand, TwoAddressesCommand},
+    util::{
+        address_arg, decode, emit_modified, ensure_governance, ensure_initialized, ensure_mutable,
+        ensure_non_payable, next_epoch, revert, selected_validators, set_validator,
+        total_delegated, validator_status, write_abi,
+    },
+};
+
+pub fn initialize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    let storage = staking_storage();
+    if storage.initialized_accessor().get_checked(sdk)? {
+        return revert(sdk, ERR_ALREADY_INITIALIZED);
+    }
+    let command: InitializeCommand = decode(input)?;
+    if command.initial_owner.is_zero() {
+        return revert(sdk, ERR_ZERO_OWNER);
+    }
+    if command.validators.len() != command.initial_stakes.len() {
+        return revert(sdk, ERR_MALFORMED_INPUT_LENGTH);
+    }
+
+    storage
+        .owner_accessor()
+        .set_checked(sdk, command.initial_owner)?;
+    let activation_block = sdk.context().block_number();
+    let config = storage.config_accessor();
+    config
+        .governance_accessor()
+        .set_checked(sdk, fluentbase_sdk::GENESIS_GOVERNANCE)?;
+    config
+        .dpos_activation_block_accessor()
+        .set_checked(sdk, activation_block)?;
+    config
+        .epoch_block_interval_accessor()
+        .set_checked(sdk, DEFAULT_EPOCH_BLOCK_INTERVAL)?;
+    config
+        .active_validators_length_accessor()
+        .set_checked(sdk, DEFAULT_ACTIVE_VALIDATORS_LENGTH)?;
+    config
+        .min_validator_stake_amount_accessor()
+        .set_checked(sdk, DEFAULT_MIN_VALIDATOR_STAKE)?;
+    config
+        .min_staking_amount_accessor()
+        .set_checked(sdk, DEFAULT_MIN_STAKING_AMOUNT)?;
+
+    for (validator, stake) in command.validators.into_iter().zip(command.initial_stakes) {
+        set_validator(
+            sdk,
+            validator,
+            validator,
+            STATUS_ACTIVE,
+            command.commission_rate,
+            stake,
+            0,
+        )?;
+    }
+    storage.initialized_accessor().set_checked(sdk, true)?;
+    Ok(())
+}
+
+/// Configure the BLEND token and the chain parameters now owned by staking.
+///
+/// This additive rWasm ABI replaces reads from the former `ChainConfig`
+/// contract. It is owner-gated so genesis can initialize code first and wire
+/// the canonical BLEND address once its deterministic address is known.
+pub fn configure<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let storage = staking_storage();
+    if sdk.context().contract_caller() != storage.owner_accessor().get_checked(sdk)? {
+        return revert(sdk, ERR_ONLY_OWNER);
+    }
+    let command: ConfigureCommand = decode(input)?;
+    if command.staking_token.is_zero() {
+        return revert(sdk, ERR_ZERO_STAKING_TOKEN);
+    }
+    if command.active_validators_length == 0 || command.epoch_block_interval == 0 {
+        return revert(sdk, ERR_INVALID_CHAIN_CONFIG);
+    }
+
+    let config = storage.config_accessor();
+    config
+        .staking_token_accessor()
+        .set_checked(sdk, command.staking_token)?;
+    config
+        .active_validators_length_accessor()
+        .set_checked(sdk, command.active_validators_length)?;
+    config
+        .epoch_block_interval_accessor()
+        .set_checked(sdk, command.epoch_block_interval)?;
+    config
+        .min_validator_stake_amount_accessor()
+        .set_checked(sdk, command.min_validator_stake_amount)?;
+    config
+        .min_staking_amount_accessor()
+        .set_checked(sdk, command.min_staking_amount)?;
+    Ok(())
+}
+
+pub fn current_epoch_read<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    write_abi(sdk, &current_epoch(sdk)?)
+}
+
+pub fn next_epoch_read<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    write_abi(sdk, &next_epoch(sdk)?)
+}
+
+pub fn owner<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &staking_storage().owner_accessor().get_checked(sdk)?)
+}
+
+pub fn get_staking<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let staking = sdk.context().contract_address();
+    write_abi(sdk, &staking)
+}
+
+pub fn get_chain_config<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    // Chain configuration is embedded in staking, so the compatibility getter
+    // resolves to this contract.
+    get_staking(sdk)
+}
+
+pub fn get_governance<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let governance = staking_storage()
+        .config_accessor()
+        .governance_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &governance)
+}
+
+pub fn get_staking_token<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let token = staking_storage()
+        .config_accessor()
+        .staking_token_accessor()
+        .get_checked(sdk)?;
+    write_abi(sdk, &token)
+}
+
+pub fn is_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let result = validator_status(sdk, address_arg(input)?)? != STATUS_NOT_FOUND;
+    write_abi(sdk, &result)
+}
+
+pub fn is_validator_active<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let validator = address_arg(input)?;
+    let result = validator_status(sdk, validator)? == STATUS_ACTIVE
+        && selected_validators(sdk)?.contains(&validator);
+    write_abi(sdk, &result)
+}
+
+pub fn get_validator_status<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let validator = address_arg(input)?;
+    let record = staking_storage().validators_accessor().entry(validator);
+    let result = (
+        record.owner_accessor().get_checked(sdk)?,
+        record.status_accessor().get_checked(sdk)?,
+        record.total_delegated_accessor().get_checked(sdk)?,
+        record.slashes_count_accessor().get_checked(sdk)?,
+        record.changed_at_accessor().get_checked(sdk)?,
+        record.jailed_before_accessor().get_checked(sdk)?,
+        record.claimed_at_accessor().get_checked(sdk)?,
+        record.commission_rate_accessor().get_checked(sdk)?,
+    );
+    write_abi(sdk, &result)
+}
+
+pub fn get_validator_by_owner<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let result = staking_storage()
+        .owner_validators_accessor()
+        .entry(address_arg(input)?)
+        .get_checked(sdk)?;
+    write_abi(sdk, &result)
+}
+
+pub fn get_validators<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &selected_validators(sdk)?)
+}
+
+pub fn add_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)?;
+    let validator = address_arg(input)?;
+    let changed_at = next_epoch(sdk)?;
+    set_validator(
+        sdk,
+        validator,
+        validator,
+        STATUS_ACTIVE,
+        0,
+        U256::ZERO,
+        changed_at,
+    )
+}
+
+pub fn activate_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)?;
+    let validator = address_arg(input)?;
+    if validator_status(sdk, validator)? != STATUS_PENDING {
+        return revert(sdk, ERR_NOT_PENDING_VALIDATOR);
+    }
+    let storage = staking_storage();
+    storage
+        .validators_accessor()
+        .entry(validator)
+        .status_accessor()
+        .set_checked(sdk, STATUS_ACTIVE)?;
+    storage
+        .active_validators_accessor()
+        .push_checked(sdk, validator)?;
+    emit_modified(sdk, validator)
+}
+
+pub fn disable_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)?;
+    let validator = address_arg(input)?;
+    if validator_status(sdk, validator)? != STATUS_ACTIVE {
+        return revert(sdk, ERR_NOT_ACTIVE_VALIDATOR);
+    }
+    remove_active(sdk, validator)?;
+    staking_storage()
+        .validators_accessor()
+        .entry(validator)
+        .status_accessor()
+        .set_checked(sdk, STATUS_PENDING)?;
+    emit_modified(sdk, validator)
+}
+
+pub fn remove_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)?;
+    let validator = address_arg(input)?;
+    if validator_status(sdk, validator)? == STATUS_NOT_FOUND {
+        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+    }
+    if !total_delegated(sdk, validator)?.is_zero() {
+        return revert(sdk, ERR_VALIDATOR_HAS_ACTIVE_DELEGATIONS);
+    }
+    remove_active(sdk, validator)?;
+    let storage = staking_storage();
+    let record = storage.validators_accessor().entry(validator);
+    let validator_owner = record.owner_accessor().get_checked(sdk)?;
+    storage
+        .owner_validators_accessor()
+        .entry(validator_owner)
+        .set_checked(sdk, Address::ZERO)?;
+    record.owner_accessor().set_checked(sdk, Address::ZERO)?;
+    record
+        .status_accessor()
+        .set_checked(sdk, STATUS_NOT_FOUND)?;
+    events::ValidatorRemoved { validator }.emit(sdk)?;
+    Ok(())
+}
+
+pub fn change_commission<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command: AddressU16Command = decode(input)?;
+    if command.value > COMMISSION_RATE_MAX {
+        return revert(sdk, ERR_BAD_COMMISSION_RATE);
+    }
+    let record = staking_storage()
+        .validators_accessor()
+        .entry(command.validator);
+    let validator_owner = record.owner_accessor().get_checked(sdk)?;
+    if validator_owner.is_zero() {
+        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+    }
+    if validator_owner != sdk.context().contract_caller() {
+        return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
+    }
+    record
+        .commission_rate_accessor()
+        .set_checked(sdk, command.value)?;
+    emit_modified(sdk, command.validator)
+}
+
+pub fn change_owner<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command: TwoAddressesCommand = decode(input)?;
+    let storage = staking_storage();
+    let record = storage.validators_accessor().entry(command.validator);
+    let old_owner = record.owner_accessor().get_checked(sdk)?;
+    if old_owner.is_zero() {
+        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+    }
+    if old_owner != sdk.context().contract_caller() {
+        return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
+    }
+    if command.value.is_zero() {
+        return revert(sdk, ERR_ZERO_OWNER);
+    }
+    if !storage
+        .owner_validators_accessor()
+        .entry(command.value)
+        .get_checked(sdk)?
+        .is_zero()
+    {
+        return revert(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE);
+    }
+    storage
+        .owner_validators_accessor()
+        .entry(old_owner)
+        .set_checked(sdk, Address::ZERO)?;
+    storage
+        .owner_validators_accessor()
+        .entry(command.value)
+        .set_checked(sdk, command.validator)?;
+    record.owner_accessor().set_checked(sdk, command.value)?;
+    emit_modified(sdk, command.validator)
+}

--- a/contracts/staking/src/handlers.rs
+++ b/contracts/staking/src/handlers.rs
@@ -1,3 +1,5 @@
+//! Initialization, compatibility getters, and governance validator lifecycle.
+
 use alloc::vec::Vec;
 
 use fluentbase_sdk::{Address, ContextReader, ExitCode, SharedAPI, U256};

--- a/contracts/staking/src/handlers.rs
+++ b/contracts/staking/src/handlers.rs
@@ -419,7 +419,7 @@ pub fn get_validator_status<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Resu
     let result = (
         record.owner_accessor().get_checked(sdk)?,
         record.status_accessor().get_checked(sdk)?,
-        snapshot.total_delegated_accessor().get_checked(sdk)?,
+        crate::math::expand_balance(snapshot.total_delegated_accessor().get_checked(sdk)?),
         snapshot.slashes_count_accessor().get_checked(sdk)?,
         changed_at,
         record.jailed_before_accessor().get_checked(sdk)?,

--- a/contracts/staking/src/handlers.rs
+++ b/contracts/staking/src/handlers.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use fluentbase_sdk::{Address, ContextReader, ExitCode, SharedAPI, U256};
 
 use crate::{
@@ -9,8 +11,9 @@ use crate::{
     },
     types::{AddressU16Command, ConfigureCommand, InitializeCommand, TwoAddressesCommand},
     util::{
-        address_arg, decode, emit_modified, ensure_governance, ensure_initialized, ensure_mutable,
-        ensure_non_payable, next_epoch, revert, selected_validators, set_validator,
+        address_arg, decode, decode_args, emit_modified, ensure_governance, ensure_initialized,
+        ensure_mutable, ensure_non_payable, ensure_rostered, next_epoch, remove_selection_member,
+        revert, revert_with, selected_validators, set_selection_visible, set_validator,
         total_delegated, touch_validator_snapshot, validator_status, write_abi,
     },
 };
@@ -22,7 +25,14 @@ pub fn initialize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exi
     if storage.initialized_accessor().get_checked(sdk)? {
         return revert(sdk, ERR_ALREADY_INITIALIZED);
     }
-    let command: InitializeCommand = decode(input)?;
+    let (initial_owner, validators, initial_stakes, commission_rate) =
+        decode_args::<(Address, Vec<Address>, Vec<U256>, u16)>(input)?;
+    let command = InitializeCommand {
+        initial_owner,
+        validators,
+        initial_stakes,
+        commission_rate,
+    };
     if command.initial_owner.is_zero() {
         return revert(sdk, ERR_ZERO_OWNER);
     }
@@ -30,34 +40,50 @@ pub fn initialize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exi
         return revert(sdk, ERR_MALFORMED_INPUT_LENGTH);
     }
 
+    let configured_owner = storage.owner_accessor().get_checked(sdk)?;
+    if !configured_owner.is_zero() && configured_owner != command.initial_owner {
+        return revert_with(sdk, ERR_ONLY_OWNER, &command.initial_owner);
+    }
     storage
         .owner_accessor()
         .set_checked(sdk, command.initial_owner)?;
-    let activation_block = sdk.context().block_number();
     let config = storage.config_accessor();
     config
         .governance_accessor()
         .set_checked(sdk, fluentbase_sdk::GENESIS_GOVERNANCE)?;
-    config
-        .dpos_activation_block_accessor()
-        .set_checked(sdk, activation_block)?;
-    config
-        .epoch_block_interval_accessor()
-        .set_checked(sdk, DEFAULT_EPOCH_BLOCK_INTERVAL)?;
-    config
-        .undelegate_period_accessor()
-        .set_checked(sdk, DEFAULT_UNDELEGATE_PERIOD)?;
-    config
-        .active_validators_length_accessor()
-        .set_checked(sdk, DEFAULT_ACTIVE_VALIDATORS_LENGTH)?;
-    config
-        .min_validator_stake_amount_accessor()
-        .set_checked(sdk, DEFAULT_MIN_VALIDATOR_STAKE)?;
-    config
-        .min_staking_amount_accessor()
-        .set_checked(sdk, DEFAULT_MIN_STAKING_AMOUNT)?;
+    if !config.configured_accessor().get_checked(sdk)? {
+        let activation_block = sdk.context().block_number();
+        config
+            .dpos_activation_block_accessor()
+            .set_checked(sdk, activation_block)?;
+        config
+            .epoch_block_interval_accessor()
+            .set_checked(sdk, DEFAULT_EPOCH_BLOCK_INTERVAL)?;
+        config
+            .undelegate_period_accessor()
+            .set_checked(sdk, DEFAULT_UNDELEGATE_PERIOD)?;
+        config
+            .active_validators_length_accessor()
+            .set_checked(sdk, DEFAULT_ACTIVE_VALIDATORS_LENGTH)?;
+        config
+            .min_validator_stake_amount_accessor()
+            .set_checked(sdk, DEFAULT_MIN_VALIDATOR_STAKE)?;
+        config
+            .min_staking_amount_accessor()
+            .set_checked(sdk, DEFAULT_MIN_STAKING_AMOUNT)?;
+        config
+            .felony_threshold_accessor()
+            .set_checked(sdk, DEFAULT_FELONY_THRESHOLD)?;
+        config
+            .validator_jail_epoch_length_accessor()
+            .set_checked(sdk, DEFAULT_VALIDATOR_JAIL_EPOCH_LENGTH)?;
+    }
 
+    let mut total_stakes = U256::ZERO;
     for (validator, stake) in command.validators.into_iter().zip(command.initial_stakes) {
+        total_stakes = total_stakes
+            .checked_add(stake)
+            .ok_or(ExitCode::IntegerOverflow)?;
         set_validator(
             sdk,
             validator,
@@ -68,30 +94,68 @@ pub fn initialize<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exi
             0,
         )?;
     }
+    // Match Solidity's `initializer` reentrancy guard before the first
+    // external token call. A failed call reverts the transaction and storage.
     storage.initialized_accessor().set_checked(sdk, true)?;
+    pull_initial_stakes(sdk, command.initial_owner, total_stakes)?;
+    Ok(())
+}
+
+#[cfg(not(test))]
+fn pull_initial_stakes<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    owner: Address,
+    total_stakes: U256,
+) -> Result<(), ExitCode> {
+    if total_stakes.is_zero() {
+        return Ok(());
+    }
+    crate::util::safe_transfer_from(sdk, owner, total_stakes)
+}
+
+// Unit storage tests use a host without nested-call support. The real genesis
+// integration test exercises the ERC-20 pull through the compiled rWasm.
+#[cfg(test)]
+fn pull_initial_stakes<SDK: SharedAPI>(
+    _sdk: &mut SDK,
+    _owner: Address,
+    _total_stakes: U256,
+) -> Result<(), ExitCode> {
     Ok(())
 }
 
 /// Configure the BLEND token and the chain parameters now owned by staking.
 ///
 /// This additive rWasm ABI replaces reads from the former `ChainConfig`
-/// contract. It is owner-gated so genesis can initialize code first and wire
-/// the canonical BLEND address once its deterministic address is known.
+/// contract. Genesis may call this before `initialize` so non-zero initial
+/// stakes are pulled by the original initializer ABI. Zero-stake deployments
+/// may initialize first and configure immediately afterwards.
 pub fn configure<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
     ensure_non_payable(sdk)?;
     ensure_mutable(sdk)?;
-    ensure_initialized(sdk)?;
     let storage = staking_storage();
-    if sdk.context().contract_caller() != storage.owner_accessor().get_checked(sdk)? {
-        return revert(sdk, ERR_ONLY_OWNER);
+    let caller = sdk.context().contract_caller();
+    let owner = storage.owner_accessor().get_checked(sdk)?;
+    if !owner.is_zero() && caller != owner {
+        return revert_with(sdk, ERR_ONLY_OWNER, &caller);
+    }
+    if owner.is_zero() {
+        storage.owner_accessor().set_checked(sdk, caller)?;
+    }
+    let config = storage.config_accessor();
+    if config.configured_accessor().get_checked(sdk)? {
+        return revert(sdk, ERR_ALREADY_CONFIGURED);
     }
     let command: ConfigureCommand = decode(input)?;
     if command.staking_token.is_zero() {
         return revert(sdk, ERR_ZERO_STAKING_TOKEN);
     }
     if command.active_validators_length == 0
-        || command.active_validators_length > MAX_ACTIVE_VALIDATORS_LENGTH
+        || command.active_validators_length as u64 > MAX_ACTIVE_VALIDATORS_LENGTH
         || command.epoch_block_interval == 0
+        || command.felony_threshold == 0
+        || command.validator_jail_epoch_length == 0
+        || command.undelegate_period == 0
         || command.min_validator_stake_amount.is_zero()
         || command.min_staking_amount.is_zero()
         || crate::math::compact_balance(command.min_validator_stake_amount).is_none()
@@ -99,23 +163,119 @@ pub fn configure<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), Exit
     {
         return revert(sdk, ERR_INVALID_CHAIN_CONFIG);
     }
+    if !command
+        .dpos_activation_block
+        .is_multiple_of(command.epoch_block_interval as u64)
+    {
+        return revert(sdk, ERR_UNALIGNED_ACTIVATION_BLOCK);
+    }
+    let undelegate_window = U256::from(command.undelegate_period)
+        .checked_mul(U256::from(command.epoch_block_interval))
+        .ok_or(ExitCode::IntegerOverflow)?;
+    if undelegate_window < command.min_undelegate_blocks {
+        return revert_with(
+            sdk,
+            ERR_UNDELEGATE_WINDOW_TOO_SHORT,
+            &(undelegate_window, command.min_undelegate_blocks),
+        );
+    }
 
-    let config = storage.config_accessor();
     config
         .staking_token_accessor()
         .set_checked(sdk, command.staking_token)?;
     config
         .active_validators_length_accessor()
-        .set_checked(sdk, command.active_validators_length)?;
+        .set_checked(sdk, command.active_validators_length as u64)?;
     config
         .epoch_block_interval_accessor()
-        .set_checked(sdk, command.epoch_block_interval)?;
+        .set_checked(sdk, command.epoch_block_interval as u64)?;
+    config
+        .felony_threshold_accessor()
+        .set_checked(sdk, command.felony_threshold)?;
+    config
+        .validator_jail_epoch_length_accessor()
+        .set_checked(sdk, command.validator_jail_epoch_length)?;
+    config
+        .undelegate_period_accessor()
+        .set_checked(sdk, command.undelegate_period as u64)?;
     config
         .min_validator_stake_amount_accessor()
         .set_checked(sdk, command.min_validator_stake_amount)?;
     config
         .min_staking_amount_accessor()
         .set_checked(sdk, command.min_staking_amount)?;
+    config
+        .min_undelegate_blocks_accessor()
+        .set_checked(sdk, command.min_undelegate_blocks)?;
+    config
+        .dpos_activation_block_accessor()
+        .set_checked(sdk, command.dpos_activation_block)?;
+    if !command.bls_verifier.is_zero() {
+        config
+            .bls_verifier_accessor()
+            .set_checked(sdk, command.bls_verifier)?;
+    }
+    if !command.evidence_decoder.is_zero() {
+        config
+            .evidence_decoder_accessor()
+            .set_checked(sdk, command.evidence_decoder)?;
+    }
+    config.configured_accessor().set_checked(sdk, true)?;
+
+    events::ActiveValidatorsLengthChanged {
+        prev_value: 0,
+        new_value: command.active_validators_length,
+    }
+    .emit(sdk)?;
+    events::EpochBlockIntervalChanged {
+        prev_value: 0,
+        new_value: command.epoch_block_interval,
+    }
+    .emit(sdk)?;
+    events::FelonyThresholdChanged {
+        prev_value: 0,
+        new_value: command.felony_threshold,
+    }
+    .emit(sdk)?;
+    events::ValidatorJailEpochLengthChanged {
+        prev_value: 0,
+        new_value: command.validator_jail_epoch_length,
+    }
+    .emit(sdk)?;
+    events::UndelegatePeriodChanged {
+        prev_value: 0,
+        new_value: command.undelegate_period,
+    }
+    .emit(sdk)?;
+    events::MinValidatorStakeAmountChanged {
+        prev_value: U256::ZERO,
+        new_value: command.min_validator_stake_amount,
+    }
+    .emit(sdk)?;
+    events::MinStakingAmountChanged {
+        prev_value: U256::ZERO,
+        new_value: command.min_staking_amount,
+    }
+    .emit(sdk)?;
+    events::DposActivationBlockChanged {
+        prev_value: 0,
+        new_value: command.dpos_activation_block,
+    }
+    .emit(sdk)?;
+    if !command.bls_verifier.is_zero() {
+        events::BlsVerifierChanged {
+            prev_value: Address::ZERO,
+            new_value: command.bls_verifier,
+        }
+        .emit(sdk)?;
+    }
+    if !command.evidence_decoder.is_zero() {
+        events::EvidenceDecoderChanged {
+            prev_value: Address::ZERO,
+            new_value: command.evidence_decoder,
+        }
+        .emit(sdk)?;
+    }
     Ok(())
 }
 
@@ -293,7 +453,7 @@ pub fn activate_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result
     ensure_governance(sdk)?;
     let validator = address_arg(input)?;
     if validator_status(sdk, validator)? != STATUS_PENDING {
-        return revert(sdk, ERR_NOT_PENDING_VALIDATOR);
+        return revert_with(sdk, ERR_NOT_PENDING_VALIDATOR, &validator);
     }
     let storage = staking_storage();
     storage
@@ -304,6 +464,9 @@ pub fn activate_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result
     storage
         .active_validators_accessor()
         .push_checked(sdk, validator)?;
+    ensure_rostered(sdk, validator)?;
+    set_selection_visible(sdk, validator, true, current_epoch(sdk)?)?;
+    touch_validator_snapshot(sdk, validator, next_epoch(sdk)?)?;
     emit_modified(sdk, validator)
 }
 
@@ -321,6 +484,8 @@ pub fn disable_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<
         .entry(validator)
         .status_accessor()
         .set_checked(sdk, STATUS_PENDING)?;
+    set_selection_visible(sdk, validator, false, current_epoch(sdk)?)?;
+    touch_validator_snapshot(sdk, validator, next_epoch(sdk)?)?;
     emit_modified(sdk, validator)
 }
 
@@ -330,12 +495,13 @@ pub fn remove_validator<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(
     ensure_governance(sdk)?;
     let validator = address_arg(input)?;
     if validator_status(sdk, validator)? == STATUS_NOT_FOUND {
-        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
     }
     if !total_delegated(sdk, validator)?.is_zero() {
-        return revert(sdk, ERR_VALIDATOR_HAS_ACTIVE_DELEGATIONS);
+        return revert_with(sdk, ERR_VALIDATOR_HAS_ACTIVE_DELEGATIONS, &validator);
     }
     remove_active(sdk, validator)?;
+    remove_selection_member(sdk, validator)?;
     let storage = staking_storage();
     let record = storage.validators_accessor().entry(validator);
     let validator_owner = record.owner_accessor().get_checked(sdk)?;
@@ -357,17 +523,17 @@ pub fn change_commission<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<
     ensure_initialized(sdk)?;
     let command: AddressU16Command = decode(input)?;
     if command.value > COMMISSION_RATE_MAX {
-        return revert(sdk, ERR_BAD_COMMISSION_RATE);
+        return revert_with(sdk, ERR_BAD_COMMISSION_RATE, &command.value);
     }
     let record = staking_storage()
         .validators_accessor()
         .entry(command.validator);
     let validator_owner = record.owner_accessor().get_checked(sdk)?;
     if validator_owner.is_zero() {
-        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &command.validator);
     }
     if validator_owner != sdk.context().contract_caller() {
-        return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
+        return revert_with(sdk, ERR_ONLY_VALIDATOR_OWNER, &validator_owner);
     }
     let changed_at = next_epoch(sdk)?;
     let snapshot = touch_validator_snapshot(sdk, command.validator, changed_at)?;
@@ -386,10 +552,10 @@ pub fn change_owner<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), E
     let record = storage.validators_accessor().entry(command.validator);
     let old_owner = record.owner_accessor().get_checked(sdk)?;
     if old_owner.is_zero() {
-        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &command.validator);
     }
     if old_owner != sdk.context().contract_caller() {
-        return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
+        return revert_with(sdk, ERR_ONLY_VALIDATOR_OWNER, &old_owner);
     }
     if command.value.is_zero() {
         return revert(sdk, ERR_ZERO_OWNER);
@@ -400,7 +566,7 @@ pub fn change_owner<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), E
         .get_checked(sdk)?
         .is_zero()
     {
-        return revert(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE);
+        return revert_with(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE, &command.validator);
     }
     storage
         .owner_validators_accessor()
@@ -411,5 +577,6 @@ pub fn change_owner<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), E
         .entry(command.value)
         .set_checked(sdk, command.validator)?;
     record.owner_accessor().set_checked(sdk, command.value)?;
+    touch_validator_snapshot(sdk, command.validator, next_epoch(sdk)?)?;
     emit_modified(sdk, command.validator)
 }

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -8,6 +8,7 @@
 extern crate alloc;
 
 mod consts;
+mod economics;
 mod events;
 mod handlers;
 mod math;
@@ -43,6 +44,19 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_GET_CHAIN_CONFIG => handlers::get_chain_config(sdk),
         SIG_GET_GOVERNANCE => handlers::get_governance(sdk),
         SIG_GET_STAKING_TOKEN => handlers::get_staking_token(sdk),
+        SIG_GET_ACTIVE_VALIDATORS_LENGTH => handlers::get_active_validators_length(sdk),
+        SIG_GET_EPOCH_BLOCK_INTERVAL => handlers::get_epoch_block_interval(sdk),
+        SIG_GET_DPOS_ACTIVATION_BLOCK => handlers::get_dpos_activation_block(sdk),
+        SIG_GET_UNDELEGATE_PERIOD => handlers::get_undelegate_period(sdk),
+        SIG_GET_MIN_VALIDATOR_STAKE_AMOUNT => handlers::get_min_validator_stake_amount(sdk),
+        SIG_GET_MIN_STAKING_AMOUNT => handlers::get_min_staking_amount(sdk),
+        SIG_GET_VALIDATOR_DELEGATION => economics::get_validator_delegation(sdk, params),
+        SIG_GET_VALIDATOR_DELEGATED_STAKE_AT => {
+            economics::get_validator_delegated_stake_at(sdk, params)
+        }
+        SIG_REGISTER_VALIDATOR => economics::register_validator(sdk, params),
+        SIG_DELEGATE => economics::delegate(sdk, params),
+        SIG_UNDELEGATE => economics::undelegate(sdk, params),
         SIG_IS_VALIDATOR => handlers::is_validator(sdk, params),
         SIG_IS_VALIDATOR_ACTIVE => handlers::is_validator_active(sdk, params),
         SIG_GET_VALIDATOR_STATUS => handlers::get_validator_status(sdk, params),

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -1,0 +1,533 @@
+#![cfg_attr(target_arch = "wasm32", no_std, no_main)]
+//! Fluent validator staking system contract.
+//!
+//! This crate preserves the public Solidity selectors while moving
+//! consensus-critical validator state into a fixed-address Rust system
+//! contract. The first vertical slice implements genesis initialization,
+//! epoch reads, validator registry reads, and governance/owner lifecycle
+//! operations. Delegation, rewards, and equivocation are intentionally kept
+//! out until their former cross-contract token and BLS calls are replaced by
+//! explicit native runtime interfaces.
+
+extern crate alloc;
+
+mod consts;
+mod math;
+mod storage;
+
+#[cfg(test)]
+mod tests;
+
+use alloc::vec::Vec;
+use consts::*;
+use fluentbase_sdk::{
+    bytes::BytesMut,
+    codec::{Codec, SolidityABI},
+    derive::Event,
+    evm::write_evm_exit_message,
+    storage::{StorageAddress, StorageBool, StorageDescriptor, StorageU64},
+    system_entrypoint, Address, ContextReader, ExitCode, SystemAPI, U256,
+};
+use storage::{
+    active_validators, current_epoch, initialized, owner, status, total_delegated, AddressMap,
+    U16Map, U256Map, U32Map, U64Map, U8Map, STATUS_ACTIVE, STATUS_NOT_FOUND, STATUS_PENDING,
+};
+
+#[derive(Default, Debug, Codec)]
+struct InitializeCommand {
+    initial_owner: Address,
+    validators: Vec<Address>,
+    initial_stakes: Vec<U256>,
+    commission_rate: u16,
+}
+
+#[derive(Default, Debug, Codec)]
+struct AddressCommand {
+    value: Address,
+}
+
+#[derive(Default, Debug, Codec)]
+struct AddressU16Command {
+    validator: Address,
+    value: u16,
+}
+
+#[derive(Default, Debug, Codec)]
+struct TwoAddressesCommand {
+    validator: Address,
+    value: Address,
+}
+
+mod events {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Eq, Event)]
+    pub struct ValidatorAdded {
+        #[indexed]
+        pub validator: Address,
+        #[indexed]
+        pub owner: Address,
+        pub status: u8,
+        pub commission_rate: u16,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Event)]
+    pub struct ValidatorModified {
+        #[indexed]
+        pub validator: Address,
+        #[indexed]
+        pub owner: Address,
+        pub status: u8,
+        pub commission_rate: u16,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Event)]
+    pub struct ValidatorRemoved {
+        #[indexed]
+        pub validator: Address,
+    }
+}
+
+fn revert<SDK: SystemAPI>(sdk: &mut SDK, code: u32) -> Result<(), ExitCode> {
+    write_evm_exit_message(code, |slice| sdk.write(slice));
+    Err(ExitCode::Panic)
+}
+
+fn ensure_non_payable<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    if !sdk.context().contract_value().is_zero() {
+        return Err(ExitCode::Panic);
+    }
+    Ok(())
+}
+
+fn ensure_mutable<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    if sdk.context().contract_is_static() {
+        return Err(ExitCode::StateChangeDuringStaticCall);
+    }
+    Ok(())
+}
+
+fn ensure_initialized<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    if !initialized(sdk)? {
+        return revert(sdk, ERR_NOT_INITIALIZED);
+    }
+    Ok(())
+}
+
+fn ensure_governance<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_initialized(sdk)?;
+    if sdk.context().contract_caller() != owner(sdk)? {
+        return revert(sdk, ERR_ONLY_GOVERNANCE);
+    }
+    Ok(())
+}
+
+fn decode<T>(input: &[u8]) -> Result<T, ExitCode>
+where
+    T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    SolidityABI::<T>::decode(&input, 0).map_err(|_| ExitCode::MalformedBuiltinParams)
+}
+
+fn write_abi<SDK, T>(sdk: &mut SDK, value: &T) -> Result<(), ExitCode>
+where
+    SDK: SystemAPI,
+    T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let mut output = BytesMut::new();
+    SolidityABI::<T>::encode(value, &mut output, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    sdk.write(output.freeze());
+    Ok(())
+}
+
+fn set_validator<SDK: SystemAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    validator_owner: Address,
+    validator_status: u8,
+    commission_rate: u16,
+    stake: U256,
+    changed_at: u64,
+) -> Result<(), ExitCode> {
+    if validator.is_zero() {
+        return revert(sdk, ERR_ZERO_VALIDATOR);
+    }
+    if validator_owner.is_zero() {
+        return revert(sdk, ERR_ZERO_OWNER);
+    }
+    if commission_rate > COMMISSION_RATE_MAX {
+        return revert(sdk, ERR_BAD_COMMISSION_RATE);
+    }
+    if math::compact_balance(stake).is_none() {
+        return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
+    }
+    if status(sdk, validator)? != STATUS_NOT_FOUND {
+        return revert(sdk, ERR_VALIDATOR_ALREADY_EXISTS);
+    }
+    if !AddressMap::new(OWNER_VALIDATOR_SLOT)
+        .entry(validator_owner)
+        .get_checked(sdk)?
+        .is_zero()
+    {
+        return revert(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE);
+    }
+
+    AddressMap::new(VALIDATOR_OWNER_SLOT)
+        .entry(validator)
+        .set_checked(sdk, validator_owner)?;
+    AddressMap::new(OWNER_VALIDATOR_SLOT)
+        .entry(validator_owner)
+        .set_checked(sdk, validator)?;
+    U8Map::new(VALIDATOR_STATUS_SLOT)
+        .entry(validator)
+        .set_checked(sdk, validator_status)?;
+    U256Map::new(VALIDATOR_TOTAL_DELEGATED_SLOT)
+        .entry(validator)
+        .set_checked(sdk, stake)?;
+    U64Map::new(VALIDATOR_CHANGED_AT_SLOT)
+        .entry(validator)
+        .set_checked(sdk, changed_at)?;
+    U16Map::new(VALIDATOR_COMMISSION_RATE_SLOT)
+        .entry(validator)
+        .set_checked(sdk, commission_rate)?;
+
+    if validator_status == STATUS_ACTIVE {
+        active_validators().push_checked(sdk, validator)?;
+    }
+    events::ValidatorAdded {
+        validator,
+        owner: validator_owner,
+        status: validator_status,
+        commission_rate,
+    }
+    .emit(sdk)?;
+    Ok(())
+}
+
+fn initialize_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    if initialized(sdk)? {
+        return revert(sdk, ERR_ALREADY_INITIALIZED);
+    }
+    let command: InitializeCommand = decode(input)?;
+    if command.initial_owner.is_zero() {
+        return revert(sdk, ERR_ZERO_OWNER);
+    }
+    if command.validators.len() != command.initial_stakes.len() {
+        return revert(sdk, ERR_MALFORMED_INPUT_LENGTH);
+    }
+
+    StorageAddress::new(OWNER_SLOT, 12).set_checked(sdk, command.initial_owner)?;
+    let activation_block = sdk.context().block_number();
+    StorageU64::new(ACTIVATION_BLOCK_SLOT, 24).set_checked(sdk, activation_block)?;
+    StorageU64::new(EPOCH_INTERVAL_SLOT, 24).set_checked(sdk, DEFAULT_EPOCH_BLOCK_INTERVAL)?;
+    StorageU64::new(ACTIVE_VALIDATORS_LENGTH_SLOT, 24)
+        .set_checked(sdk, DEFAULT_ACTIVE_VALIDATORS_LENGTH)?;
+
+    for (validator, stake) in command.validators.into_iter().zip(command.initial_stakes) {
+        set_validator(
+            sdk,
+            validator,
+            validator,
+            STATUS_ACTIVE,
+            command.commission_rate,
+            stake,
+            0,
+        )?;
+    }
+    // Set this last: a failed initializer cannot leave a partially initialized
+    // instance when executed by a host that rolls storage back on errors.
+    StorageBool::new(INITIALIZED_SLOT, 31).set_checked(sdk, true)?;
+    Ok(())
+}
+
+fn current_epoch_handler<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    write_abi(sdk, &current_epoch(sdk)?)
+}
+
+fn next_epoch_handler<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let next = current_epoch(sdk)?
+        .checked_add(1)
+        .ok_or(ExitCode::IntegerOverflow)?;
+    write_abi(sdk, &next)
+}
+
+fn owner_handler<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &owner(sdk)?)
+}
+
+fn address_arg(input: &[u8]) -> Result<Address, ExitCode> {
+    Ok(decode::<AddressCommand>(input)?.value)
+}
+
+fn is_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let result = status(sdk, address_arg(input)?)? != STATUS_NOT_FOUND;
+    write_abi(sdk, &result)
+}
+
+fn selected_validators<SDK: SystemAPI>(sdk: &SDK) -> Result<Vec<Address>, ExitCode> {
+    let active = active_validators();
+    let active_len = active.len_checked(sdk)?;
+    let mut ranked = Vec::with_capacity(active_len as usize);
+    for index in 0..active_len {
+        let validator = active.at(index).get_checked(sdk)?;
+        if status(sdk, validator)? == STATUS_ACTIVE {
+            ranked.push((validator, total_delegated(sdk, validator)?));
+        }
+    }
+    ranked.sort_unstable_by(|(a_address, a_stake), (b_address, b_stake)| {
+        b_stake.cmp(a_stake).then_with(|| a_address.cmp(b_address))
+    });
+    let cap = StorageU64::new(ACTIVE_VALIDATORS_LENGTH_SLOT, 24).get_checked(sdk)? as usize;
+    ranked.truncate(cap);
+    Ok(ranked.into_iter().map(|(validator, _)| validator).collect())
+}
+
+fn is_validator_active_handler<SDK: SystemAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let validator = address_arg(input)?;
+    let result =
+        status(sdk, validator)? == STATUS_ACTIVE && selected_validators(sdk)?.contains(&validator);
+    write_abi(sdk, &result)
+}
+
+fn get_validator_status_handler<SDK: SystemAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let validator = address_arg(input)?;
+    let result = (
+        AddressMap::new(VALIDATOR_OWNER_SLOT)
+            .entry(validator)
+            .get_checked(sdk)?,
+        status(sdk, validator)?,
+        total_delegated(sdk, validator)?,
+        U32Map::new(VALIDATOR_SLASHES_SLOT)
+            .entry(validator)
+            .get_checked(sdk)?,
+        U64Map::new(VALIDATOR_CHANGED_AT_SLOT)
+            .entry(validator)
+            .get_checked(sdk)?,
+        U64Map::new(VALIDATOR_JAILED_BEFORE_SLOT)
+            .entry(validator)
+            .get_checked(sdk)?,
+        U64Map::new(VALIDATOR_CLAIMED_AT_SLOT)
+            .entry(validator)
+            .get_checked(sdk)?,
+        U16Map::new(VALIDATOR_COMMISSION_RATE_SLOT)
+            .entry(validator)
+            .get_checked(sdk)?,
+    );
+    write_abi(sdk, &result)
+}
+
+fn get_validator_by_owner_handler<SDK: SystemAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    let result = AddressMap::new(OWNER_VALIDATOR_SLOT)
+        .entry(address_arg(input)?)
+        .get_checked(sdk)?;
+    write_abi(sdk, &result)
+}
+
+fn get_validators_handler<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    write_abi(sdk, &selected_validators(sdk)?)
+}
+
+fn add_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)?;
+    let validator = address_arg(input)?;
+    let changed_at = current_epoch(sdk)?
+        .checked_add(1)
+        .ok_or(ExitCode::IntegerOverflow)?;
+    set_validator(
+        sdk,
+        validator,
+        validator,
+        STATUS_ACTIVE,
+        0,
+        U256::ZERO,
+        changed_at,
+    )
+}
+
+fn activate_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)?;
+    let validator = address_arg(input)?;
+    if status(sdk, validator)? != STATUS_PENDING {
+        return revert(sdk, ERR_NOT_PENDING_VALIDATOR);
+    }
+    U8Map::new(VALIDATOR_STATUS_SLOT)
+        .entry(validator)
+        .set_checked(sdk, STATUS_ACTIVE)?;
+    active_validators().push_checked(sdk, validator)?;
+    emit_modified(sdk, validator)
+}
+
+fn disable_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)?;
+    let validator = address_arg(input)?;
+    if status(sdk, validator)? != STATUS_ACTIVE {
+        return revert(sdk, ERR_NOT_ACTIVE_VALIDATOR);
+    }
+    storage::remove_active(sdk, validator)?;
+    U8Map::new(VALIDATOR_STATUS_SLOT)
+        .entry(validator)
+        .set_checked(sdk, STATUS_PENDING)?;
+    emit_modified(sdk, validator)
+}
+
+fn remove_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_governance(sdk)?;
+    let validator = address_arg(input)?;
+    if status(sdk, validator)? == STATUS_NOT_FOUND {
+        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+    }
+    if !total_delegated(sdk, validator)?.is_zero() {
+        return revert(sdk, ERR_VALIDATOR_HAS_ACTIVE_DELEGATIONS);
+    }
+    storage::remove_active(sdk, validator)?;
+    let validator_owner = AddressMap::new(VALIDATOR_OWNER_SLOT)
+        .entry(validator)
+        .get_checked(sdk)?;
+    AddressMap::new(OWNER_VALIDATOR_SLOT)
+        .entry(validator_owner)
+        .set_checked(sdk, Address::ZERO)?;
+    AddressMap::new(VALIDATOR_OWNER_SLOT)
+        .entry(validator)
+        .set_checked(sdk, Address::ZERO)?;
+    U8Map::new(VALIDATOR_STATUS_SLOT)
+        .entry(validator)
+        .set_checked(sdk, STATUS_NOT_FOUND)?;
+    events::ValidatorRemoved { validator }.emit(sdk)?;
+    Ok(())
+}
+
+fn change_commission_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command: AddressU16Command = decode(input)?;
+    if command.value > COMMISSION_RATE_MAX {
+        return revert(sdk, ERR_BAD_COMMISSION_RATE);
+    }
+    let validator_owner = AddressMap::new(VALIDATOR_OWNER_SLOT)
+        .entry(command.validator)
+        .get_checked(sdk)?;
+    if validator_owner.is_zero() {
+        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+    }
+    if validator_owner != sdk.context().contract_caller() {
+        return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
+    }
+    U16Map::new(VALIDATOR_COMMISSION_RATE_SLOT)
+        .entry(command.validator)
+        .set_checked(sdk, command.value)?;
+    emit_modified(sdk, command.validator)
+}
+
+fn change_owner_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command: TwoAddressesCommand = decode(input)?;
+    let old_owner = AddressMap::new(VALIDATOR_OWNER_SLOT)
+        .entry(command.validator)
+        .get_checked(sdk)?;
+    if old_owner.is_zero() {
+        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
+    }
+    if old_owner != sdk.context().contract_caller() {
+        return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
+    }
+    if command.value.is_zero() {
+        return revert(sdk, ERR_ZERO_OWNER);
+    }
+    if !AddressMap::new(OWNER_VALIDATOR_SLOT)
+        .entry(command.value)
+        .get_checked(sdk)?
+        .is_zero()
+    {
+        return revert(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE);
+    }
+    AddressMap::new(OWNER_VALIDATOR_SLOT)
+        .entry(old_owner)
+        .set_checked(sdk, Address::ZERO)?;
+    AddressMap::new(OWNER_VALIDATOR_SLOT)
+        .entry(command.value)
+        .set_checked(sdk, command.validator)?;
+    AddressMap::new(VALIDATOR_OWNER_SLOT)
+        .entry(command.validator)
+        .set_checked(sdk, command.value)?;
+    emit_modified(sdk, command.validator)
+}
+
+fn emit_modified<SDK: SystemAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
+    events::ValidatorModified {
+        validator,
+        owner: AddressMap::new(VALIDATOR_OWNER_SLOT)
+            .entry(validator)
+            .get_checked(sdk)?,
+        status: status(sdk, validator)?,
+        commission_rate: U16Map::new(VALIDATOR_COMMISSION_RATE_SLOT)
+            .entry(validator)
+            .get_checked(sdk)?,
+    }
+    .emit(sdk)
+}
+
+pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    let input = sdk.bytes_input();
+    if input.len() < SIG_LEN_BYTES {
+        return Err(ExitCode::MalformedBuiltinParams);
+    }
+    let (selector, params) = input.split_at(SIG_LEN_BYTES);
+    let selector = u32::from_be_bytes(
+        selector
+            .try_into()
+            .map_err(|_| ExitCode::MalformedBuiltinParams)?,
+    );
+    match selector {
+        SIG_INITIALIZE => initialize_handler(sdk, params),
+        SIG_CURRENT_EPOCH => current_epoch_handler(sdk),
+        SIG_NEXT_EPOCH => next_epoch_handler(sdk),
+        SIG_OWNER => owner_handler(sdk),
+        SIG_IS_VALIDATOR => is_validator_handler(sdk, params),
+        SIG_IS_VALIDATOR_ACTIVE => is_validator_active_handler(sdk, params),
+        SIG_GET_VALIDATOR_STATUS => get_validator_status_handler(sdk, params),
+        SIG_GET_VALIDATOR_BY_OWNER => get_validator_by_owner_handler(sdk, params),
+        SIG_GET_VALIDATORS => get_validators_handler(sdk),
+        SIG_ADD_VALIDATOR => add_validator_handler(sdk, params),
+        SIG_REMOVE_VALIDATOR => remove_validator_handler(sdk, params),
+        SIG_ACTIVATE_VALIDATOR => activate_validator_handler(sdk, params),
+        SIG_DISABLE_VALIDATOR => disable_validator_handler(sdk, params),
+        SIG_CHANGE_VALIDATOR_COMMISSION_RATE => change_commission_handler(sdk, params),
+        SIG_CHANGE_VALIDATOR_OWNER => change_owner_handler(sdk, params),
+        _ => revert(sdk, ERR_UNKNOWN_METHOD),
+    }
+}
+
+system_entrypoint!(main_entry);

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -1,505 +1,28 @@
 #![cfg_attr(target_arch = "wasm32", no_std, no_main)]
-//! Fluent validator staking system contract.
+//! Fluent validator staking rWasm contract.
 //!
-//! This crate preserves the public Solidity selectors while moving
-//! consensus-critical validator state into a fixed-address Rust system
-//! contract. The first vertical slice implements genesis initialization,
-//! epoch reads, validator registry reads, and governance/owner lifecycle
-//! operations. Delegation, rewards, and equivocation are intentionally kept
-//! out until their former cross-contract token and BLS calls are replaced by
-//! explicit native runtime interfaces.
+//! Staking is deployed at a fixed genesis address but executes as a normal
+//! rWasm smart contract. Unlike a system precompile, it uses `SharedAPI`, so
+//! the delegation/reward implementation can call the canonical BLEND ERC-20.
 
 extern crate alloc;
 
 mod consts;
+mod events;
+mod handlers;
 mod math;
 mod storage;
+mod types;
+mod util;
 
 #[cfg(test)]
 mod tests;
 
-use alloc::vec::Vec;
 use consts::*;
-use fluentbase_sdk::{
-    bytes::BytesMut,
-    codec::{Codec, SolidityABI},
-    derive::Event,
-    evm::write_evm_exit_message,
-    storage::{StorageAddress, StorageBool, StorageDescriptor, StorageU64},
-    system_entrypoint, Address, ContextReader, ExitCode, SystemAPI, U256,
-};
-use storage::{
-    active_validators, current_epoch, initialized, owner, status, total_delegated, AddressMap,
-    U16Map, U256Map, U32Map, U64Map, U8Map, STATUS_ACTIVE, STATUS_NOT_FOUND, STATUS_PENDING,
-};
+use fluentbase_sdk::{entrypoint, ExitCode, SharedAPI};
+use util::revert;
 
-#[derive(Default, Debug, Codec)]
-struct InitializeCommand {
-    initial_owner: Address,
-    validators: Vec<Address>,
-    initial_stakes: Vec<U256>,
-    commission_rate: u16,
-}
-
-#[derive(Default, Debug, Codec)]
-struct AddressCommand {
-    value: Address,
-}
-
-#[derive(Default, Debug, Codec)]
-struct AddressU16Command {
-    validator: Address,
-    value: u16,
-}
-
-#[derive(Default, Debug, Codec)]
-struct TwoAddressesCommand {
-    validator: Address,
-    value: Address,
-}
-
-mod events {
-    use super::*;
-
-    #[derive(Debug, Clone, PartialEq, Eq, Event)]
-    pub struct ValidatorAdded {
-        #[indexed]
-        pub validator: Address,
-        #[indexed]
-        pub owner: Address,
-        pub status: u8,
-        pub commission_rate: u16,
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq, Event)]
-    pub struct ValidatorModified {
-        #[indexed]
-        pub validator: Address,
-        #[indexed]
-        pub owner: Address,
-        pub status: u8,
-        pub commission_rate: u16,
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq, Event)]
-    pub struct ValidatorRemoved {
-        #[indexed]
-        pub validator: Address,
-    }
-}
-
-fn revert<SDK: SystemAPI>(sdk: &mut SDK, code: u32) -> Result<(), ExitCode> {
-    write_evm_exit_message(code, |slice| sdk.write(slice));
-    Err(ExitCode::Panic)
-}
-
-fn ensure_non_payable<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    if !sdk.context().contract_value().is_zero() {
-        return Err(ExitCode::Panic);
-    }
-    Ok(())
-}
-
-fn ensure_mutable<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    if sdk.context().contract_is_static() {
-        return Err(ExitCode::StateChangeDuringStaticCall);
-    }
-    Ok(())
-}
-
-fn ensure_initialized<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    if !initialized(sdk)? {
-        return revert(sdk, ERR_NOT_INITIALIZED);
-    }
-    Ok(())
-}
-
-fn ensure_governance<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    ensure_initialized(sdk)?;
-    if sdk.context().contract_caller() != owner(sdk)? {
-        return revert(sdk, ERR_ONLY_GOVERNANCE);
-    }
-    Ok(())
-}
-
-fn decode<T>(input: &[u8]) -> Result<T, ExitCode>
-where
-    T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
-{
-    SolidityABI::<T>::decode(&input, 0).map_err(|_| ExitCode::MalformedBuiltinParams)
-}
-
-fn write_abi<SDK, T>(sdk: &mut SDK, value: &T) -> Result<(), ExitCode>
-where
-    SDK: SystemAPI,
-    T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
-{
-    let mut output = BytesMut::new();
-    SolidityABI::<T>::encode(value, &mut output, 0)
-        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
-    sdk.write(output.freeze());
-    Ok(())
-}
-
-fn set_validator<SDK: SystemAPI>(
-    sdk: &mut SDK,
-    validator: Address,
-    validator_owner: Address,
-    validator_status: u8,
-    commission_rate: u16,
-    stake: U256,
-    changed_at: u64,
-) -> Result<(), ExitCode> {
-    if validator.is_zero() {
-        return revert(sdk, ERR_ZERO_VALIDATOR);
-    }
-    if validator_owner.is_zero() {
-        return revert(sdk, ERR_ZERO_OWNER);
-    }
-    if commission_rate > COMMISSION_RATE_MAX {
-        return revert(sdk, ERR_BAD_COMMISSION_RATE);
-    }
-    if math::compact_balance(stake).is_none() {
-        return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
-    }
-    if status(sdk, validator)? != STATUS_NOT_FOUND {
-        return revert(sdk, ERR_VALIDATOR_ALREADY_EXISTS);
-    }
-    if !AddressMap::new(OWNER_VALIDATOR_SLOT)
-        .entry(validator_owner)
-        .get_checked(sdk)?
-        .is_zero()
-    {
-        return revert(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE);
-    }
-
-    AddressMap::new(VALIDATOR_OWNER_SLOT)
-        .entry(validator)
-        .set_checked(sdk, validator_owner)?;
-    AddressMap::new(OWNER_VALIDATOR_SLOT)
-        .entry(validator_owner)
-        .set_checked(sdk, validator)?;
-    U8Map::new(VALIDATOR_STATUS_SLOT)
-        .entry(validator)
-        .set_checked(sdk, validator_status)?;
-    U256Map::new(VALIDATOR_TOTAL_DELEGATED_SLOT)
-        .entry(validator)
-        .set_checked(sdk, stake)?;
-    U64Map::new(VALIDATOR_CHANGED_AT_SLOT)
-        .entry(validator)
-        .set_checked(sdk, changed_at)?;
-    U16Map::new(VALIDATOR_COMMISSION_RATE_SLOT)
-        .entry(validator)
-        .set_checked(sdk, commission_rate)?;
-
-    if validator_status == STATUS_ACTIVE {
-        active_validators().push_checked(sdk, validator)?;
-    }
-    events::ValidatorAdded {
-        validator,
-        owner: validator_owner,
-        status: validator_status,
-        commission_rate,
-    }
-    .emit(sdk)?;
-    Ok(())
-}
-
-fn initialize_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_mutable(sdk)?;
-    if initialized(sdk)? {
-        return revert(sdk, ERR_ALREADY_INITIALIZED);
-    }
-    let command: InitializeCommand = decode(input)?;
-    if command.initial_owner.is_zero() {
-        return revert(sdk, ERR_ZERO_OWNER);
-    }
-    if command.validators.len() != command.initial_stakes.len() {
-        return revert(sdk, ERR_MALFORMED_INPUT_LENGTH);
-    }
-
-    StorageAddress::new(OWNER_SLOT, 12).set_checked(sdk, command.initial_owner)?;
-    let activation_block = sdk.context().block_number();
-    StorageU64::new(ACTIVATION_BLOCK_SLOT, 24).set_checked(sdk, activation_block)?;
-    StorageU64::new(EPOCH_INTERVAL_SLOT, 24).set_checked(sdk, DEFAULT_EPOCH_BLOCK_INTERVAL)?;
-    StorageU64::new(ACTIVE_VALIDATORS_LENGTH_SLOT, 24)
-        .set_checked(sdk, DEFAULT_ACTIVE_VALIDATORS_LENGTH)?;
-
-    for (validator, stake) in command.validators.into_iter().zip(command.initial_stakes) {
-        set_validator(
-            sdk,
-            validator,
-            validator,
-            STATUS_ACTIVE,
-            command.commission_rate,
-            stake,
-            0,
-        )?;
-    }
-    // Set this last: a failed initializer cannot leave a partially initialized
-    // instance when executed by a host that rolls storage back on errors.
-    StorageBool::new(INITIALIZED_SLOT, 31).set_checked(sdk, true)?;
-    Ok(())
-}
-
-fn current_epoch_handler<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_initialized(sdk)?;
-    write_abi(sdk, &current_epoch(sdk)?)
-}
-
-fn next_epoch_handler<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_initialized(sdk)?;
-    let next = current_epoch(sdk)?
-        .checked_add(1)
-        .ok_or(ExitCode::IntegerOverflow)?;
-    write_abi(sdk, &next)
-}
-
-fn owner_handler<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    write_abi(sdk, &owner(sdk)?)
-}
-
-fn address_arg(input: &[u8]) -> Result<Address, ExitCode> {
-    Ok(decode::<AddressCommand>(input)?.value)
-}
-
-fn is_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    let result = status(sdk, address_arg(input)?)? != STATUS_NOT_FOUND;
-    write_abi(sdk, &result)
-}
-
-fn selected_validators<SDK: SystemAPI>(sdk: &SDK) -> Result<Vec<Address>, ExitCode> {
-    let active = active_validators();
-    let active_len = active.len_checked(sdk)?;
-    let mut ranked = Vec::with_capacity(active_len as usize);
-    for index in 0..active_len {
-        let validator = active.at(index).get_checked(sdk)?;
-        if status(sdk, validator)? == STATUS_ACTIVE {
-            ranked.push((validator, total_delegated(sdk, validator)?));
-        }
-    }
-    ranked.sort_unstable_by(|(a_address, a_stake), (b_address, b_stake)| {
-        b_stake.cmp(a_stake).then_with(|| a_address.cmp(b_address))
-    });
-    let cap = StorageU64::new(ACTIVE_VALIDATORS_LENGTH_SLOT, 24).get_checked(sdk)? as usize;
-    ranked.truncate(cap);
-    Ok(ranked.into_iter().map(|(validator, _)| validator).collect())
-}
-
-fn is_validator_active_handler<SDK: SystemAPI>(
-    sdk: &mut SDK,
-    input: &[u8],
-) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    let validator = address_arg(input)?;
-    let result =
-        status(sdk, validator)? == STATUS_ACTIVE && selected_validators(sdk)?.contains(&validator);
-    write_abi(sdk, &result)
-}
-
-fn get_validator_status_handler<SDK: SystemAPI>(
-    sdk: &mut SDK,
-    input: &[u8],
-) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    let validator = address_arg(input)?;
-    let result = (
-        AddressMap::new(VALIDATOR_OWNER_SLOT)
-            .entry(validator)
-            .get_checked(sdk)?,
-        status(sdk, validator)?,
-        total_delegated(sdk, validator)?,
-        U32Map::new(VALIDATOR_SLASHES_SLOT)
-            .entry(validator)
-            .get_checked(sdk)?,
-        U64Map::new(VALIDATOR_CHANGED_AT_SLOT)
-            .entry(validator)
-            .get_checked(sdk)?,
-        U64Map::new(VALIDATOR_JAILED_BEFORE_SLOT)
-            .entry(validator)
-            .get_checked(sdk)?,
-        U64Map::new(VALIDATOR_CLAIMED_AT_SLOT)
-            .entry(validator)
-            .get_checked(sdk)?,
-        U16Map::new(VALIDATOR_COMMISSION_RATE_SLOT)
-            .entry(validator)
-            .get_checked(sdk)?,
-    );
-    write_abi(sdk, &result)
-}
-
-fn get_validator_by_owner_handler<SDK: SystemAPI>(
-    sdk: &mut SDK,
-    input: &[u8],
-) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    let result = AddressMap::new(OWNER_VALIDATOR_SLOT)
-        .entry(address_arg(input)?)
-        .get_checked(sdk)?;
-    write_abi(sdk, &result)
-}
-
-fn get_validators_handler<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    write_abi(sdk, &selected_validators(sdk)?)
-}
-
-fn add_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_mutable(sdk)?;
-    ensure_governance(sdk)?;
-    let validator = address_arg(input)?;
-    let changed_at = current_epoch(sdk)?
-        .checked_add(1)
-        .ok_or(ExitCode::IntegerOverflow)?;
-    set_validator(
-        sdk,
-        validator,
-        validator,
-        STATUS_ACTIVE,
-        0,
-        U256::ZERO,
-        changed_at,
-    )
-}
-
-fn activate_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_mutable(sdk)?;
-    ensure_governance(sdk)?;
-    let validator = address_arg(input)?;
-    if status(sdk, validator)? != STATUS_PENDING {
-        return revert(sdk, ERR_NOT_PENDING_VALIDATOR);
-    }
-    U8Map::new(VALIDATOR_STATUS_SLOT)
-        .entry(validator)
-        .set_checked(sdk, STATUS_ACTIVE)?;
-    active_validators().push_checked(sdk, validator)?;
-    emit_modified(sdk, validator)
-}
-
-fn disable_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_mutable(sdk)?;
-    ensure_governance(sdk)?;
-    let validator = address_arg(input)?;
-    if status(sdk, validator)? != STATUS_ACTIVE {
-        return revert(sdk, ERR_NOT_ACTIVE_VALIDATOR);
-    }
-    storage::remove_active(sdk, validator)?;
-    U8Map::new(VALIDATOR_STATUS_SLOT)
-        .entry(validator)
-        .set_checked(sdk, STATUS_PENDING)?;
-    emit_modified(sdk, validator)
-}
-
-fn remove_validator_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_mutable(sdk)?;
-    ensure_governance(sdk)?;
-    let validator = address_arg(input)?;
-    if status(sdk, validator)? == STATUS_NOT_FOUND {
-        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
-    }
-    if !total_delegated(sdk, validator)?.is_zero() {
-        return revert(sdk, ERR_VALIDATOR_HAS_ACTIVE_DELEGATIONS);
-    }
-    storage::remove_active(sdk, validator)?;
-    let validator_owner = AddressMap::new(VALIDATOR_OWNER_SLOT)
-        .entry(validator)
-        .get_checked(sdk)?;
-    AddressMap::new(OWNER_VALIDATOR_SLOT)
-        .entry(validator_owner)
-        .set_checked(sdk, Address::ZERO)?;
-    AddressMap::new(VALIDATOR_OWNER_SLOT)
-        .entry(validator)
-        .set_checked(sdk, Address::ZERO)?;
-    U8Map::new(VALIDATOR_STATUS_SLOT)
-        .entry(validator)
-        .set_checked(sdk, STATUS_NOT_FOUND)?;
-    events::ValidatorRemoved { validator }.emit(sdk)?;
-    Ok(())
-}
-
-fn change_commission_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_mutable(sdk)?;
-    ensure_initialized(sdk)?;
-    let command: AddressU16Command = decode(input)?;
-    if command.value > COMMISSION_RATE_MAX {
-        return revert(sdk, ERR_BAD_COMMISSION_RATE);
-    }
-    let validator_owner = AddressMap::new(VALIDATOR_OWNER_SLOT)
-        .entry(command.validator)
-        .get_checked(sdk)?;
-    if validator_owner.is_zero() {
-        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
-    }
-    if validator_owner != sdk.context().contract_caller() {
-        return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
-    }
-    U16Map::new(VALIDATOR_COMMISSION_RATE_SLOT)
-        .entry(command.validator)
-        .set_checked(sdk, command.value)?;
-    emit_modified(sdk, command.validator)
-}
-
-fn change_owner_handler<SDK: SystemAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
-    ensure_non_payable(sdk)?;
-    ensure_mutable(sdk)?;
-    ensure_initialized(sdk)?;
-    let command: TwoAddressesCommand = decode(input)?;
-    let old_owner = AddressMap::new(VALIDATOR_OWNER_SLOT)
-        .entry(command.validator)
-        .get_checked(sdk)?;
-    if old_owner.is_zero() {
-        return revert(sdk, ERR_VALIDATOR_NOT_FOUND);
-    }
-    if old_owner != sdk.context().contract_caller() {
-        return revert(sdk, ERR_ONLY_VALIDATOR_OWNER);
-    }
-    if command.value.is_zero() {
-        return revert(sdk, ERR_ZERO_OWNER);
-    }
-    if !AddressMap::new(OWNER_VALIDATOR_SLOT)
-        .entry(command.value)
-        .get_checked(sdk)?
-        .is_zero()
-    {
-        return revert(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE);
-    }
-    AddressMap::new(OWNER_VALIDATOR_SLOT)
-        .entry(old_owner)
-        .set_checked(sdk, Address::ZERO)?;
-    AddressMap::new(OWNER_VALIDATOR_SLOT)
-        .entry(command.value)
-        .set_checked(sdk, command.validator)?;
-    AddressMap::new(VALIDATOR_OWNER_SLOT)
-        .entry(command.validator)
-        .set_checked(sdk, command.value)?;
-    emit_modified(sdk, command.validator)
-}
-
-fn emit_modified<SDK: SystemAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
-    events::ValidatorModified {
-        validator,
-        owner: AddressMap::new(VALIDATOR_OWNER_SLOT)
-            .entry(validator)
-            .get_checked(sdk)?,
-        status: status(sdk, validator)?,
-        commission_rate: U16Map::new(VALIDATOR_COMMISSION_RATE_SLOT)
-            .entry(validator)
-            .get_checked(sdk)?,
-    }
-    .emit(sdk)
-}
-
-pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
     let input = sdk.bytes_input();
     if input.len() < SIG_LEN_BYTES {
         return Err(ExitCode::MalformedBuiltinParams);
@@ -511,23 +34,35 @@ pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
             .map_err(|_| ExitCode::MalformedBuiltinParams)?,
     );
     match selector {
-        SIG_INITIALIZE => initialize_handler(sdk, params),
-        SIG_CURRENT_EPOCH => current_epoch_handler(sdk),
-        SIG_NEXT_EPOCH => next_epoch_handler(sdk),
-        SIG_OWNER => owner_handler(sdk),
-        SIG_IS_VALIDATOR => is_validator_handler(sdk, params),
-        SIG_IS_VALIDATOR_ACTIVE => is_validator_active_handler(sdk, params),
-        SIG_GET_VALIDATOR_STATUS => get_validator_status_handler(sdk, params),
-        SIG_GET_VALIDATOR_BY_OWNER => get_validator_by_owner_handler(sdk, params),
-        SIG_GET_VALIDATORS => get_validators_handler(sdk),
-        SIG_ADD_VALIDATOR => add_validator_handler(sdk, params),
-        SIG_REMOVE_VALIDATOR => remove_validator_handler(sdk, params),
-        SIG_ACTIVATE_VALIDATOR => activate_validator_handler(sdk, params),
-        SIG_DISABLE_VALIDATOR => disable_validator_handler(sdk, params),
-        SIG_CHANGE_VALIDATOR_COMMISSION_RATE => change_commission_handler(sdk, params),
-        SIG_CHANGE_VALIDATOR_OWNER => change_owner_handler(sdk, params),
+        SIG_INITIALIZE => handlers::initialize(sdk, params),
+        SIG_CONFIGURE => handlers::configure(sdk, params),
+        SIG_CURRENT_EPOCH => handlers::current_epoch_read(sdk),
+        SIG_NEXT_EPOCH => handlers::next_epoch_read(sdk),
+        SIG_OWNER => handlers::owner(sdk),
+        SIG_GET_STAKING => handlers::get_staking(sdk),
+        SIG_GET_CHAIN_CONFIG => handlers::get_chain_config(sdk),
+        SIG_GET_GOVERNANCE => handlers::get_governance(sdk),
+        SIG_GET_STAKING_TOKEN => handlers::get_staking_token(sdk),
+        SIG_IS_VALIDATOR => handlers::is_validator(sdk, params),
+        SIG_IS_VALIDATOR_ACTIVE => handlers::is_validator_active(sdk, params),
+        SIG_GET_VALIDATOR_STATUS => handlers::get_validator_status(sdk, params),
+        SIG_GET_VALIDATOR_BY_OWNER => handlers::get_validator_by_owner(sdk, params),
+        SIG_GET_VALIDATORS => handlers::get_validators(sdk),
+        SIG_ADD_VALIDATOR => handlers::add_validator(sdk, params),
+        SIG_REMOVE_VALIDATOR => handlers::remove_validator(sdk, params),
+        SIG_ACTIVATE_VALIDATOR => handlers::activate_validator(sdk, params),
+        SIG_DISABLE_VALIDATOR => handlers::disable_validator(sdk, params),
+        SIG_CHANGE_VALIDATOR_COMMISSION_RATE => handlers::change_commission(sdk, params),
+        SIG_CHANGE_VALIDATOR_OWNER => handlers::change_owner(sdk, params),
         _ => revert(sdk, ERR_UNKNOWN_METHOD),
     }
 }
 
-system_entrypoint!(main_entry);
+pub fn contract_main<SDK: SharedAPI>(mut sdk: SDK) {
+    match main_entry(&mut sdk) {
+        Ok(()) => sdk.exit(),
+        Err(exit_code) => sdk.native_exit(exit_code),
+    }
+}
+
+entrypoint!(contract_main);

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -4,6 +4,8 @@
 //! Staking is deployed at a fixed genesis address but executes as a normal
 //! rWasm smart contract. Unlike a system precompile, it uses `SharedAPI`, so
 //! the delegation/reward implementation can call the canonical BLEND ERC-20.
+//!
+//! See `README.md` for lifecycle, scope, and accounting invariants.
 
 extern crate alloc;
 
@@ -28,6 +30,7 @@ use consts::*;
 use fluentbase_sdk::{entrypoint, ExitCode, SharedAPI};
 use util::revert;
 
+/// Decode Solidity calldata and route it to the matching staking operation.
 pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
     let input = sdk.bytes_input();
     if input.len() < SIG_LEN_BYTES {
@@ -40,6 +43,7 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
             .map_err(|_| ExitCode::MalformedBuiltinParams)?,
     );
     match selector {
+        // Deployment and governance configuration.
         SIG_INITIALIZE => handlers::initialize(sdk, params),
         SIG_CONFIGURE => handlers::configure(sdk, params),
         SIG_CONFIGURE_DEPENDENCIES => config::configure_dependencies(sdk, params),
@@ -49,6 +53,7 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_MAX_BLEND_STIPEND_PER_EPOCH => config::max_blend_stipend_per_epoch(sdk),
         SIG_MAX_PARTICIPATION_FLOOR_BPS => config::max_participation_floor_bps(sdk),
         SIG_MAX_SLASH_REPORTER_BPS => config::max_slash_reporter_bps(sdk),
+        // Compatibility getters and governance parameter access.
         SIG_CURRENT_EPOCH => handlers::current_epoch_read(sdk),
         SIG_NEXT_EPOCH => handlers::next_epoch_read(sdk),
         SIG_OWNER => handlers::owner(sdk),
@@ -86,6 +91,7 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_SET_BLS_VERIFIER => config::set_bls_verifier(sdk, params),
         SIG_GET_EVIDENCE_DECODER => config::get_evidence_decoder(sdk),
         SIG_SET_EVIDENCE_DECODER => config::set_evidence_decoder(sdk, params),
+        // Validator stake and delegation principal.
         SIG_GET_VALIDATOR_DELEGATION => economics::get_validator_delegation(sdk, params),
         SIG_GET_VALIDATOR_DELEGATED_STAKE_AT => {
             economics::get_validator_delegated_stake_at(sdk, params)
@@ -93,6 +99,7 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_REGISTER_VALIDATOR => economics::register_validator(sdk, params),
         SIG_DELEGATE => economics::delegate(sdk, params),
         SIG_UNDELEGATE => economics::undelegate(sdk, params),
+        // Validator and delegator rewards.
         SIG_GET_VALIDATOR_FEE => rewards::get_validator_fee(sdk, params),
         SIG_GET_PENDING_VALIDATOR_FEE => rewards::get_pending_validator_fee(sdk, params),
         SIG_CLAIM_VALIDATOR_FEE => rewards::claim_validator_fee(sdk, params),
@@ -107,6 +114,7 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_REDELEGATE_DELEGATOR_FEE => rewards::redelegate_delegator_fee(sdk, params),
         SIG_GET_EPOCH_REWARDS => rewards::get_epoch_rewards(sdk, params),
         SIG_SETTLE_EPOCH_STIPEND => rewards::settle_epoch_stipend(sdk, params),
+        // Consensus identities and committed committees.
         SIG_SET_CONSENSUS_KEYS => consensus::set_consensus_keys(sdk, params),
         SIG_GET_CONSENSUS_KEYS => consensus::get_consensus_keys(sdk, params),
         SIG_GET_VALIDATORS_WITH_KEYS => consensus::get_validators_with_keys(sdk),
@@ -122,6 +130,7 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_GET_EPOCH_COMMITTEE_WITH_STAKES => {
             consensus::get_epoch_committee_with_stakes(sdk, params)
         }
+        // Liveness and equivocation penalties.
         SIG_RELEASE_VALIDATOR_FROM_JAIL => liveness::release_validator_from_jail(sdk, params),
         SIG_READMIT_EXPIRED_JAILS => liveness::readmit_expired_jails(sdk, params),
         SIG_SLASH => liveness::slash(sdk, params),
@@ -130,6 +139,7 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_SLASH_EQUIVOCATION_NULLIFY_FINALIZE => {
             equivocation::slash_nullify_finalize(sdk, params)
         }
+        // Validator lifecycle and ownership.
         SIG_IS_VALIDATOR => handlers::is_validator(sdk, params),
         SIG_IS_VALIDATOR_ACTIVE => handlers::is_validator_active(sdk, params),
         SIG_GET_VALIDATOR_STATUS => handlers::get_validator_status(sdk, params),

--- a/contracts/staking/src/lib.rs
+++ b/contracts/staking/src/lib.rs
@@ -7,11 +7,16 @@
 
 extern crate alloc;
 
+mod config;
+mod consensus;
 mod consts;
 mod economics;
+mod equivocation;
 mod events;
 mod handlers;
+mod liveness;
 mod math;
+mod rewards;
 mod storage;
 mod types;
 mod util;
@@ -37,6 +42,13 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
     match selector {
         SIG_INITIALIZE => handlers::initialize(sdk, params),
         SIG_CONFIGURE => handlers::configure(sdk, params),
+        SIG_CONFIGURE_DEPENDENCIES => config::configure_dependencies(sdk, params),
+        SIG_DEFAULT_PARTICIPATION_FLOOR_BPS => config::default_participation_floor_bps(sdk),
+        SIG_DEFAULT_SLASH_REPORTER_BPS => config::default_slash_reporter_bps(sdk),
+        SIG_MAX_ACTIVE_VALIDATORS => config::max_active_validators(sdk),
+        SIG_MAX_BLEND_STIPEND_PER_EPOCH => config::max_blend_stipend_per_epoch(sdk),
+        SIG_MAX_PARTICIPATION_FLOOR_BPS => config::max_participation_floor_bps(sdk),
+        SIG_MAX_SLASH_REPORTER_BPS => config::max_slash_reporter_bps(sdk),
         SIG_CURRENT_EPOCH => handlers::current_epoch_read(sdk),
         SIG_NEXT_EPOCH => handlers::next_epoch_read(sdk),
         SIG_OWNER => handlers::owner(sdk),
@@ -50,6 +62,30 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_GET_UNDELEGATE_PERIOD => handlers::get_undelegate_period(sdk),
         SIG_GET_MIN_VALIDATOR_STAKE_AMOUNT => handlers::get_min_validator_stake_amount(sdk),
         SIG_GET_MIN_STAKING_AMOUNT => handlers::get_min_staking_amount(sdk),
+        SIG_GET_FELONY_THRESHOLD => config::get_felony_threshold(sdk),
+        SIG_SET_FELONY_THRESHOLD => config::set_felony_threshold(sdk, params),
+        SIG_GET_VALIDATOR_JAIL_EPOCH_LENGTH => config::get_validator_jail_epoch_length(sdk),
+        SIG_SET_VALIDATOR_JAIL_EPOCH_LENGTH => config::set_validator_jail_epoch_length(sdk, params),
+        SIG_GET_SLASH_REPORTER_REWARD_BPS => config::get_slash_reporter_reward_bps(sdk),
+        SIG_SET_SLASH_REPORTER_REWARD_BPS => config::set_slash_reporter_reward_bps(sdk, params),
+        SIG_GET_SLASH_FUND_ADDRESS => config::get_slash_fund_address(sdk),
+        SIG_SET_SLASH_FUND_ADDRESS => config::set_slash_fund_address(sdk, params),
+        SIG_GET_PARTICIPATION_FLOOR_BPS => config::get_participation_floor_bps(sdk),
+        SIG_SET_PARTICIPATION_FLOOR_BPS => config::set_participation_floor_bps(sdk, params),
+        SIG_GET_PARTICIPATION_JAIL_DISABLED => config::get_participation_jail_disabled(sdk),
+        SIG_SET_PARTICIPATION_JAIL_DISABLED => config::set_participation_jail_disabled(sdk, params),
+        SIG_GET_BLEND_STIPEND_PER_EPOCH => config::get_blend_stipend_per_epoch(sdk),
+        SIG_SET_BLEND_STIPEND_PER_EPOCH => config::set_blend_stipend_per_epoch(sdk, params),
+        SIG_SET_ACTIVE_VALIDATORS_LENGTH => config::set_active_validators_length(sdk, params),
+        SIG_SET_EPOCH_BLOCK_INTERVAL => config::set_epoch_block_interval(sdk, params),
+        SIG_SET_DPOS_ACTIVATION_BLOCK => config::set_dpos_activation_block(sdk, params),
+        SIG_SET_UNDELEGATE_PERIOD => config::set_undelegate_period(sdk, params),
+        SIG_SET_MIN_VALIDATOR_STAKE_AMOUNT => config::set_min_validator_stake_amount(sdk, params),
+        SIG_SET_MIN_STAKING_AMOUNT => config::set_min_staking_amount(sdk, params),
+        SIG_GET_BLS_VERIFIER => config::get_bls_verifier(sdk),
+        SIG_SET_BLS_VERIFIER => config::set_bls_verifier(sdk, params),
+        SIG_GET_EVIDENCE_DECODER => config::get_evidence_decoder(sdk),
+        SIG_SET_EVIDENCE_DECODER => config::set_evidence_decoder(sdk, params),
         SIG_GET_VALIDATOR_DELEGATION => economics::get_validator_delegation(sdk, params),
         SIG_GET_VALIDATOR_DELEGATED_STAKE_AT => {
             economics::get_validator_delegated_stake_at(sdk, params)
@@ -57,6 +93,43 @@ pub fn main_entry<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
         SIG_REGISTER_VALIDATOR => economics::register_validator(sdk, params),
         SIG_DELEGATE => economics::delegate(sdk, params),
         SIG_UNDELEGATE => economics::undelegate(sdk, params),
+        SIG_GET_VALIDATOR_FEE => rewards::get_validator_fee(sdk, params),
+        SIG_GET_PENDING_VALIDATOR_FEE => rewards::get_pending_validator_fee(sdk, params),
+        SIG_CLAIM_VALIDATOR_FEE => rewards::claim_validator_fee(sdk, params),
+        SIG_CLAIM_VALIDATOR_FEE_AT_EPOCH => rewards::claim_validator_fee_at_epoch(sdk, params),
+        SIG_GET_DELEGATOR_FEE => rewards::get_delegator_fee(sdk, params),
+        SIG_GET_PENDING_DELEGATOR_FEE => rewards::get_pending_delegator_fee(sdk, params),
+        SIG_CLAIM_DELEGATOR_FEE => rewards::claim_delegator_fee(sdk, params),
+        SIG_CLAIM_DELEGATOR_FEE_AT_EPOCH => rewards::claim_delegator_fee_at_epoch(sdk, params),
+        SIG_CALC_AVAILABLE_FOR_REDELEGATE_AMOUNT => {
+            rewards::calc_available_for_redelegate_amount(sdk, params)
+        }
+        SIG_REDELEGATE_DELEGATOR_FEE => rewards::redelegate_delegator_fee(sdk, params),
+        SIG_GET_EPOCH_REWARDS => rewards::get_epoch_rewards(sdk, params),
+        SIG_SETTLE_EPOCH_STIPEND => rewards::settle_epoch_stipend(sdk, params),
+        SIG_SET_CONSENSUS_KEYS => consensus::set_consensus_keys(sdk, params),
+        SIG_GET_CONSENSUS_KEYS => consensus::get_consensus_keys(sdk, params),
+        SIG_GET_VALIDATORS_WITH_KEYS => consensus::get_validators_with_keys(sdk),
+        SIG_GET_REGISTRY_WITH_KEYS => consensus::get_registry_with_keys(sdk),
+        SIG_GET_VALIDATORS_WITH_KEYS_AT => consensus::get_validators_with_keys_at(sdk, params),
+        SIG_NEXT_EPOCH_TO_COMMIT => consensus::next_epoch_to_commit(sdk),
+        SIG_COMMITTEE_SELECTION_EPOCH => consensus::committee_selection_epoch(sdk),
+        SIG_COMMIT_EPOCH_COMMITTEE => consensus::commit_epoch_committee(sdk, params),
+        SIG_GET_DKG_QUAL => consensus::get_dkg_qual(sdk, params),
+        SIG_RESOLVE_SIGNER => consensus::resolve_signer(sdk, params),
+        SIG_GET_EPOCH_COMMITTEE => consensus::get_epoch_committee(sdk, params),
+        SIG_GET_EPOCH_COMMITTEE_LENGTH => consensus::get_epoch_committee_length(sdk, params),
+        SIG_GET_EPOCH_COMMITTEE_WITH_STAKES => {
+            consensus::get_epoch_committee_with_stakes(sdk, params)
+        }
+        SIG_RELEASE_VALIDATOR_FROM_JAIL => liveness::release_validator_from_jail(sdk, params),
+        SIG_READMIT_EXPIRED_JAILS => liveness::readmit_expired_jails(sdk, params),
+        SIG_SLASH => liveness::slash(sdk, params),
+        SIG_SLASH_EQUIVOCATION_NOTARIZE => equivocation::slash_notarize(sdk, params),
+        SIG_SLASH_EQUIVOCATION_FINALIZE => equivocation::slash_finalize(sdk, params),
+        SIG_SLASH_EQUIVOCATION_NULLIFY_FINALIZE => {
+            equivocation::slash_nullify_finalize(sdk, params)
+        }
         SIG_IS_VALIDATOR => handlers::is_validator(sdk, params),
         SIG_IS_VALIDATOR_ACTIVE => handlers::is_validator_active(sdk, params),
         SIG_GET_VALIDATOR_STATUS => handlers::get_validator_status(sdk, params),

--- a/contracts/staking/src/liveness.rs
+++ b/contracts/staking/src/liveness.rs
@@ -1,3 +1,5 @@
+//! Authorized liveness slashing, jail transitions, and bounded readmission.
+
 use fluentbase_sdk::{Address, ContextReader, ExitCode, SharedAPI, U256};
 
 use crate::{
@@ -107,6 +109,7 @@ pub fn readmit_expired_jails<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Res
     }
     let mut index = storage.jailed_scan_cursor_accessor().get_checked(sdk)? % len;
     let mut examined = 0;
+    // Persist the cursor so each call does bounded work without starving entries.
     let budget = core::cmp::min(len, MAX_ACTIVE_VALIDATORS_LENGTH);
     while examined < budget {
         let current_len = jailed.len_checked(sdk)?;

--- a/contracts/staking/src/liveness.rs
+++ b/contracts/staking/src/liveness.rs
@@ -28,7 +28,10 @@ fn ensure_liveness<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
     Ok(())
 }
 
-fn remove_jailed<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
+pub(crate) fn remove_jailed<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+) -> Result<(), ExitCode> {
     let jailed = staking_storage().jailed_validators_accessor();
     let len = jailed.len_checked(sdk)?;
     for index in 0..len {
@@ -93,11 +96,27 @@ pub fn release_validator_from_jail<SDK: SharedAPI>(
 
 pub fn readmit_expired_jails<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
     ensure_liveness(sdk)?;
-    let supplied_epoch = decode::<U64Command>(input)?.value;
+    let _: U64Command = decode(input)?;
+    let epoch = current_epoch(sdk)?;
     let storage = staking_storage();
     let jailed = storage.jailed_validators_accessor();
-    let mut index = 0;
-    while index < jailed.len_checked(sdk)? {
+    let len = jailed.len_checked(sdk)?;
+    if len == 0 {
+        storage.jailed_scan_cursor_accessor().set_checked(sdk, 0)?;
+        return Ok(());
+    }
+    let mut index = storage.jailed_scan_cursor_accessor().get_checked(sdk)? % len;
+    let mut examined = 0;
+    let budget = core::cmp::min(len, MAX_ACTIVE_VALIDATORS_LENGTH);
+    while examined < budget {
+        let current_len = jailed.len_checked(sdk)?;
+        if current_len == 0 {
+            index = 0;
+            break;
+        }
+        if index >= current_len {
+            index = 0;
+        }
         let validator = jailed.at(index).get_checked(sdk)?;
         let record = storage.validators_accessor().entry(validator);
         if storage
@@ -107,14 +126,18 @@ pub fn readmit_expired_jails<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Res
         {
             remove_jailed(sdk, validator)?;
         } else if record.status_accessor().get_checked(sdk)? == STATUS_JAIL
-            && supplied_epoch >= record.jailed_before_accessor().get_checked(sdk)?
+            && epoch >= record.jailed_before_accessor().get_checked(sdk)?
         {
             readmit(sdk, validator)?;
         } else {
-            index += 1;
+            index = (index + 1) % current_len;
         }
+        examined += 1;
     }
-    Ok(())
+    let remaining = jailed.len_checked(sdk)?;
+    storage
+        .jailed_scan_cursor_accessor()
+        .set_checked(sdk, if remaining == 0 { 0 } else { index % remaining })
 }
 
 fn quorum(n: u64) -> u64 {
@@ -129,7 +152,8 @@ pub fn slash<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode
     let validator = decode::<AddressCommand>(input)?.value;
     let storage = staking_storage();
     let record = storage.validators_accessor().entry(validator);
-    if record.status_accessor().get_checked(sdk)? == STATUS_NOT_FOUND {
+    let status = record.status_accessor().get_checked(sdk)?;
+    if status == STATUS_NOT_FOUND {
         return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
     }
     let epoch = current_epoch(sdk)?;
@@ -171,7 +195,7 @@ pub fn slash<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode
                         .get_checked(sdk)? as u64,
                 )
                 .ok_or(ExitCode::IntegerOverflow)?;
-            if record.status_accessor().get_checked(sdk)? != STATUS_JAIL {
+            if status != STATUS_JAIL {
                 record.status_accessor().set_checked(sdk, STATUS_JAIL)?;
                 record
                     .jailed_before_accessor()

--- a/contracts/staking/src/liveness.rs
+++ b/contracts/staking/src/liveness.rs
@@ -1,0 +1,198 @@
+use fluentbase_sdk::{Address, ContextReader, ExitCode, SharedAPI, U256};
+
+use crate::{
+    consts::*,
+    events,
+    storage::{
+        current_epoch, remove_active, staking_storage, STATUS_ACTIVE, STATUS_JAIL, STATUS_NOT_FOUND,
+    },
+    types::{AddressCommand, U64Command},
+    util::{
+        decode, ensure_initialized, ensure_mutable, ensure_non_payable, revert, revert_with,
+        set_selection_visible, touch_snapshot_at_or_before,
+    },
+};
+
+fn ensure_liveness<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let caller = sdk.context().contract_caller();
+    let expected = staking_storage()
+        .config_accessor()
+        .liveness_slashing_accessor()
+        .get_checked(sdk)?;
+    if expected.is_zero() || caller != expected {
+        return revert(sdk, ERR_ONLY_LIVENESS_SLASHING);
+    }
+    Ok(())
+}
+
+fn remove_jailed<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
+    let jailed = staking_storage().jailed_validators_accessor();
+    let len = jailed.len_checked(sdk)?;
+    for index in 0..len {
+        if jailed.at(index).get_checked(sdk)? != validator {
+            continue;
+        }
+        if index + 1 != len {
+            let last = jailed.at(len - 1).get_checked(sdk)?;
+            jailed.at(index).set_checked(sdk, last)?;
+        }
+        jailed.pop_checked(sdk)?;
+        break;
+    }
+    Ok(())
+}
+
+fn readmit<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    storage
+        .validators_accessor()
+        .entry(validator)
+        .status_accessor()
+        .set_checked(sdk, STATUS_ACTIVE)?;
+    storage
+        .active_validators_accessor()
+        .push_checked(sdk, validator)?;
+    remove_jailed(sdk, validator)?;
+    let epoch = current_epoch(sdk)?;
+    set_selection_visible(sdk, validator, true, epoch)?;
+    events::ValidatorReleased { validator, epoch }.emit(sdk)
+}
+
+pub fn release_validator_from_jail<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let validator = decode::<AddressCommand>(input)?.value;
+    let storage = staking_storage();
+    if storage
+        .tombstoned_accessor()
+        .entry(validator)
+        .get_checked(sdk)?
+    {
+        return revert_with(sdk, ERR_ALREADY_SLASHED_FOR_EQUIVOCATION, &validator);
+    }
+    let record = storage.validators_accessor().entry(validator);
+    if record.status_accessor().get_checked(sdk)? != STATUS_JAIL {
+        return revert_with(sdk, ERR_VALIDATOR_NOT_IN_JAIL, &validator);
+    }
+    let owner = record.owner_accessor().get_checked(sdk)?;
+    if sdk.context().contract_caller() != owner {
+        return revert_with(sdk, ERR_ONLY_VALIDATOR_OWNER, &owner);
+    }
+    if current_epoch(sdk)? < record.jailed_before_accessor().get_checked(sdk)? {
+        return revert_with(sdk, ERR_STILL_IN_JAIL, &validator);
+    }
+    readmit(sdk, validator)
+}
+
+pub fn readmit_expired_jails<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_liveness(sdk)?;
+    let supplied_epoch = decode::<U64Command>(input)?.value;
+    let storage = staking_storage();
+    let jailed = storage.jailed_validators_accessor();
+    let mut index = 0;
+    while index < jailed.len_checked(sdk)? {
+        let validator = jailed.at(index).get_checked(sdk)?;
+        let record = storage.validators_accessor().entry(validator);
+        if storage
+            .tombstoned_accessor()
+            .entry(validator)
+            .get_checked(sdk)?
+        {
+            remove_jailed(sdk, validator)?;
+        } else if record.status_accessor().get_checked(sdk)? == STATUS_JAIL
+            && supplied_epoch >= record.jailed_before_accessor().get_checked(sdk)?
+        {
+            readmit(sdk, validator)?;
+        } else {
+            index += 1;
+        }
+    }
+    Ok(())
+}
+
+fn quorum(n: u64) -> u64 {
+    if n == 0 {
+        return 0;
+    }
+    n - (n - 1) / 3
+}
+
+pub fn slash<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_liveness(sdk)?;
+    let validator = decode::<AddressCommand>(input)?.value;
+    let storage = staking_storage();
+    let record = storage.validators_accessor().entry(validator);
+    if record.status_accessor().get_checked(sdk)? == STATUS_NOT_FOUND {
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
+    }
+    let epoch = current_epoch(sdk)?;
+    let snapshot = touch_snapshot_at_or_before(sdk, validator, epoch)?;
+    let slashes = snapshot
+        .slashes_count_accessor()
+        .get_checked(sdk)?
+        .checked_add(1)
+        .ok_or(ExitCode::IntegerOverflow)?;
+    snapshot
+        .slashes_count_accessor()
+        .set_checked(sdk, slashes)?;
+
+    let threshold = storage
+        .config_accessor()
+        .felony_threshold_accessor()
+        .get_checked(sdk)?;
+    if slashes >= threshold {
+        let active_len = storage.active_validators_accessor().len_checked(sdk)?;
+        let cap = storage
+            .config_accessor()
+            .active_validators_length_accessor()
+            .get_checked(sdk)?;
+        let quorum_floor = quorum(core::cmp::min(active_len, cap));
+        if active_len == 0 || active_len - 1 < quorum_floor {
+            events::LivenessJailSkippedHaltGuard {
+                validator,
+                epoch,
+                active_set_size: U256::from(active_len),
+                quorum_floor: U256::from(quorum_floor),
+            }
+            .emit(sdk)?;
+        } else {
+            let jail_until = epoch
+                .checked_add(
+                    storage
+                        .config_accessor()
+                        .validator_jail_epoch_length_accessor()
+                        .get_checked(sdk)? as u64,
+                )
+                .ok_or(ExitCode::IntegerOverflow)?;
+            if record.status_accessor().get_checked(sdk)? != STATUS_JAIL {
+                record.status_accessor().set_checked(sdk, STATUS_JAIL)?;
+                record
+                    .jailed_before_accessor()
+                    .set_checked(sdk, jail_until)?;
+                remove_active(sdk, validator)?;
+                storage
+                    .jailed_validators_accessor()
+                    .push_checked(sdk, validator)?;
+                set_selection_visible(sdk, validator, false, epoch)?;
+            } else {
+                record
+                    .jailed_before_accessor()
+                    .set_checked(sdk, jail_until)?;
+            }
+            events::ValidatorJailed { validator, epoch }.emit(sdk)?;
+        }
+    }
+    events::ValidatorSlashed {
+        validator,
+        slashes,
+        epoch,
+    }
+    .emit(sdk)
+}

--- a/contracts/staking/src/math.rs
+++ b/contracts/staking/src/math.rs
@@ -1,15 +1,28 @@
 //! Pure arithmetic shared by staking state transitions.
 
-use fluentbase_sdk::U256;
+use fluentbase_sdk::{Uint, U256};
 
 use crate::consts::BALANCE_COMPACT_PRECISION;
 
-/// Convert an ABI balance into the compact protocol unit, rejecting dust.
-pub fn compact_balance(amount: U256) -> Option<U256> {
+pub type U96 = Uint<96, 2>;
+pub type U112 = Uint<112, 2>;
+
+/// Convert a full-precision BLEND balance into the compact `uint112` unit.
+pub fn compact_balance(amount: U256) -> Option<U112> {
     if amount % BALANCE_COMPACT_PRECISION != U256::ZERO {
         return None;
     }
-    Some(amount / BALANCE_COMPACT_PRECISION)
+    U112::checked_from_limbs_slice((amount / BALANCE_COMPACT_PRECISION).as_limbs())
+}
+
+/// Restore a compact staking balance to full-precision BLEND wei.
+pub fn expand_balance(amount: U112) -> U256 {
+    U256::from(amount) * BALANCE_COMPACT_PRECISION
+}
+
+/// Narrow an epoch reward to the Solidity `uint96` ledger width.
+pub fn narrow_reward(amount: U256) -> Option<U96> {
+    U96::checked_from_limbs_slice(amount.as_limbs())
 }
 
 /// Map a block to its activation-relative epoch, clamping pre-activation blocks.
@@ -31,9 +44,18 @@ mod tests {
     fn compact_balance_rejects_precision_dust() {
         assert_eq!(
             compact_balance(U256::from(10_000_000_000u64)),
-            Some(U256::ONE)
+            Some(U112::ONE)
         );
         assert_eq!(compact_balance(U256::from(10_000_000_001u64)), None);
+        let overflow = (U256::from(U112::MAX) + U256::ONE) * BALANCE_COMPACT_PRECISION;
+        assert_eq!(compact_balance(overflow), None);
+        assert_eq!(expand_balance(U112::MAX), overflow - BALANCE_COMPACT_PRECISION);
+    }
+
+    #[test]
+    fn reward_narrowing_rejects_uint96_overflow() {
+        assert_eq!(narrow_reward(U256::from(U96::MAX)), Some(U96::MAX));
+        assert_eq!(narrow_reward(U256::from(U96::MAX) + U256::ONE), None);
     }
 
     #[test]

--- a/contracts/staking/src/math.rs
+++ b/contracts/staking/src/math.rs
@@ -1,7 +1,10 @@
+//! Pure arithmetic shared by staking state transitions.
+
 use fluentbase_sdk::U256;
 
 use crate::consts::BALANCE_COMPACT_PRECISION;
 
+/// Convert an ABI balance into the compact protocol unit, rejecting dust.
 pub fn compact_balance(amount: U256) -> Option<U256> {
     if amount % BALANCE_COMPACT_PRECISION != U256::ZERO {
         return None;
@@ -9,6 +12,7 @@ pub fn compact_balance(amount: U256) -> Option<U256> {
     Some(amount / BALANCE_COMPACT_PRECISION)
 }
 
+/// Map a block to its activation-relative epoch, clamping pre-activation blocks.
 pub fn epoch_at_block(block_number: u64, activation_block: u64, interval: u64) -> Option<u64> {
     if interval == 0 {
         return None;

--- a/contracts/staking/src/math.rs
+++ b/contracts/staking/src/math.rs
@@ -1,0 +1,43 @@
+use fluentbase_sdk::U256;
+
+use crate::consts::BALANCE_COMPACT_PRECISION;
+
+pub fn compact_balance(amount: U256) -> Option<U256> {
+    if amount % BALANCE_COMPACT_PRECISION != U256::ZERO {
+        return None;
+    }
+    Some(amount / BALANCE_COMPACT_PRECISION)
+}
+
+pub fn epoch_at_block(block_number: u64, activation_block: u64, interval: u64) -> Option<u64> {
+    if interval == 0 {
+        return None;
+    }
+    if block_number < activation_block {
+        return Some(0);
+    }
+    Some((block_number - activation_block) / interval)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compact_balance_rejects_precision_dust() {
+        assert_eq!(
+            compact_balance(U256::from(10_000_000_000u64)),
+            Some(U256::ONE)
+        );
+        assert_eq!(compact_balance(U256::from(10_000_000_001u64)), None);
+    }
+
+    #[test]
+    fn epoch_is_rebased_and_clamped_before_activation() {
+        assert_eq!(epoch_at_block(99, 100, 20), Some(0));
+        assert_eq!(epoch_at_block(100, 100, 20), Some(0));
+        assert_eq!(epoch_at_block(139, 100, 20), Some(1));
+        assert_eq!(epoch_at_block(140, 100, 20), Some(2));
+        assert_eq!(epoch_at_block(140, 100, 0), None);
+    }
+}

--- a/contracts/staking/src/rewards.rs
+++ b/contracts/staking/src/rewards.rs
@@ -1,3 +1,5 @@
+//! Snapshot-based rewards, bounded claims, and finalized stipend settlement.
+
 use alloc::vec;
 use fluentbase_sdk::{
     bytes::BytesMut, codec::SolidityABI, Address, Bytes, ContextReader, ExitCode, SharedAPI, U256,
@@ -95,6 +97,7 @@ fn validator_owner_rewards<SDK: SharedAPI>(
         return Ok(U256::ZERO);
     }
     let mut epoch = record.claimed_at_accessor().get_checked(sdk)?;
+    // Bound historical work; callers can continue from the stored cursor.
     let before_epoch = core::cmp::min(
         before_epoch,
         epoch.saturating_add(MAX_EPOCHS_PER_CLAIM),
@@ -351,6 +354,8 @@ fn claim_validator_before<SDK: SharedAPI>(
         return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
     }
     let claimed_at = record.claimed_at_accessor().get_checked(sdk)?;
+    // Advancing the cursor before transfer is safe because a failed call
+    // reverts the whole contract transaction.
     let capped = core::cmp::min(
         before_epoch,
         claimed_at
@@ -622,6 +627,8 @@ fn settle_one<SDK: SharedAPI>(
                     passed[index as usize] = true;
                 }
             }
+            // During a partition, keep stake-weighted rewards available to
+            // participating and non-participating committee members alike.
             let partition = below > fault_tolerance(len as usize);
             let mut stakes = vec![U256::ZERO; len as usize];
             let mut total_stake = U256::ZERO;
@@ -670,6 +677,7 @@ fn settle_one<SDK: SharedAPI>(
         let recipient = sdk.context().contract_address();
         let sent =
             call_decode::<_, _, U256>(sdk, reserve, SIG_RESERVE_DISBURSE, &(recipient, assigned))?;
+        // Never credit accounting for BLEND the contract did not receive.
         if sent != assigned {
             return revert_with(sdk, ERR_RESERVE_SHORT_DISBURSEMENT, &(sent, assigned));
         }

--- a/contracts/staking/src/rewards.rs
+++ b/contracts/staking/src/rewards.rs
@@ -95,6 +95,10 @@ fn validator_owner_rewards<SDK: SharedAPI>(
         return Ok(U256::ZERO);
     }
     let mut epoch = record.claimed_at_accessor().get_checked(sdk)?;
+    let before_epoch = core::cmp::min(
+        before_epoch,
+        epoch.saturating_add(MAX_EPOCHS_PER_CLAIM),
+    );
     let mut rewards = U256::ZERO;
     while epoch < before_epoch {
         rewards = rewards
@@ -398,13 +402,19 @@ pub fn get_delegator_fee<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<
     ensure_non_payable(sdk)?;
     ensure_initialized(sdk)?;
     let command = decode::<ValidatorDelegatorCommand>(input)?;
+    let before_epoch = capped_delegator_claim_epoch(
+        sdk,
+        command.validator,
+        command.delegator,
+        current_epoch(sdk)?,
+    )?;
     write_abi(
         sdk,
         &delegator_claimable(
             sdk,
             command.validator,
             command.delegator,
-            current_epoch(sdk)?,
+            before_epoch,
         )?,
     )
 }
@@ -416,9 +426,15 @@ pub fn get_pending_delegator_fee<SDK: SharedAPI>(
     ensure_non_payable(sdk)?;
     ensure_initialized(sdk)?;
     let command = decode::<ValidatorDelegatorCommand>(input)?;
+    let before_epoch = capped_delegator_claim_epoch(
+        sdk,
+        command.validator,
+        command.delegator,
+        next_epoch(sdk)?,
+    )?;
     write_abi(
         sdk,
-        &delegator_claimable(sdk, command.validator, command.delegator, next_epoch(sdk)?)?,
+        &delegator_claimable(sdk, command.validator, command.delegator, before_epoch)?,
     )
 }
 
@@ -494,11 +510,17 @@ pub fn calc_available_for_redelegate_amount<SDK: SharedAPI>(
     ensure_non_payable(sdk)?;
     ensure_initialized(sdk)?;
     let command = decode::<ValidatorDelegatorCommand>(input)?;
-    let claimable = delegator_claimable(
+    let before_epoch = capped_delegator_claim_epoch(
         sdk,
         command.validator,
         command.delegator,
         current_epoch(sdk)?,
+    )?;
+    let claimable = delegator_claimable(
+        sdk,
+        command.validator,
+        command.delegator,
+        before_epoch,
     )?;
     write_abi(sdk, &available_for_redelegate(sdk, claimable)?)
 }
@@ -610,6 +632,12 @@ fn settle_one<SDK: SharedAPI>(
                         .tombstoned_accessor()
                         .entry(validator)
                         .get_checked(sdk)?
+                    || storage
+                        .validators_accessor()
+                        .entry(validator)
+                        .status_accessor()
+                        .get_checked(sdk)?
+                        == STATUS_NOT_FOUND
                 {
                     continue;
                 }
@@ -643,8 +671,7 @@ fn settle_one<SDK: SharedAPI>(
         let sent =
             call_decode::<_, _, U256>(sdk, reserve, SIG_RESERVE_DISBURSE, &(recipient, assigned))?;
         if sent != assigned {
-            assigned = U256::ZERO;
-            shares.fill(U256::ZERO);
+            return revert_with(sdk, ERR_RESERVE_SHORT_DISBURSEMENT, &(sent, assigned));
         }
     }
     if !assigned.is_zero() {
@@ -654,15 +681,6 @@ fn settle_one<SDK: SharedAPI>(
                 continue;
             }
             let validator = committee.at(index as u64).get_checked(sdk)?;
-            if storage
-                .validators_accessor()
-                .entry(validator)
-                .status_accessor()
-                .get_checked(sdk)?
-                == STATUS_NOT_FOUND
-            {
-                continue;
-            }
             let snapshot = touch_snapshot_at_or_before(sdk, validator, epoch)?;
             let next = snapshot
                 .total_blend_rewards_accessor()

--- a/contracts/staking/src/rewards.rs
+++ b/contracts/staking/src/rewards.rs
@@ -64,10 +64,11 @@ fn snapshot_payout<SDK: SharedAPI>(
         .validator_snapshots_accessor()
         .entry(validator)
         .entry(epoch);
-    if !snapshot.initialized_accessor().get_checked(sdk)? {
-        return Ok((U256::ZERO, U256::ZERO));
-    }
-    let total_reward = snapshot.total_blend_rewards_accessor().get_checked(sdk)?;
+    let total_reward = U256::from(
+        snapshot
+            .total_blend_rewards_accessor()
+            .get_checked(sdk)?,
+    );
     if total_reward.is_zero() {
         return Ok((U256::ZERO, U256::ZERO));
     }
@@ -154,9 +155,9 @@ fn delegator_claimable<SDK: SharedAPI>(
                 claimable = claimable
                     .checked_add(
                         delegator_pool
-                            .checked_mul(delegated)
+                            .checked_mul(U256::from(delegated))
                             .ok_or(ExitCode::IntegerOverflow)?
-                            / total,
+                            / U256::from(total),
                     )
                     .ok_or(ExitCode::IntegerOverflow)?;
             }
@@ -174,7 +175,9 @@ fn delegator_claimable<SDK: SharedAPI>(
             break;
         }
         claimable = claimable
-            .checked_add(operation.amount_accessor().get_checked(sdk)?)
+            .checked_add(crate::math::expand_balance(
+                operation.amount_accessor().get_checked(sdk)?,
+            ))
             .ok_or(ExitCode::IntegerOverflow)?;
         undelegate_gap += 1;
     }
@@ -269,9 +272,9 @@ fn consume_delegator_claim<SDK: SharedAPI>(
                 claimable = claimable
                     .checked_add(
                         delegator_pool
-                            .checked_mul(delegated)
+                            .checked_mul(U256::from(delegated))
                             .ok_or(ExitCode::IntegerOverflow)?
-                            / total,
+                            / U256::from(total),
                     )
                     .ok_or(ExitCode::IntegerOverflow)?;
             }
@@ -296,7 +299,9 @@ fn consume_delegator_claim<SDK: SharedAPI>(
             break;
         }
         claimable = claimable
-            .checked_add(operation.amount_accessor().get_checked(sdk)?)
+            .checked_add(crate::math::expand_balance(
+                operation.amount_accessor().get_checked(sdk)?,
+            ))
             .ok_or(ExitCode::IntegerOverflow)?;
         undelegate_gap += 1;
     }
@@ -553,12 +558,14 @@ pub fn get_epoch_rewards<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<
         let validator = committee.at(index).get_checked(sdk)?;
         total = total
             .checked_add(
-                staking_storage()
-                    .validator_snapshots_accessor()
-                    .entry(validator)
-                    .entry(epoch)
-                    .total_blend_rewards_accessor()
-                    .get_checked(sdk)?,
+                U256::from(
+                    staking_storage()
+                        .validator_snapshots_accessor()
+                        .entry(validator)
+                        .entry(epoch)
+                        .total_blend_rewards_accessor()
+                        .get_checked(sdk)?,
+                ),
             )
             .ok_or(ExitCode::IntegerOverflow)?;
     }
@@ -690,6 +697,7 @@ fn settle_one<SDK: SharedAPI>(
             }
             let validator = committee.at(index as u64).get_checked(sdk)?;
             let snapshot = touch_snapshot_at_or_before(sdk, validator, epoch)?;
+            let share = crate::math::narrow_reward(share).ok_or(ExitCode::IntegerOverflow)?;
             let next = snapshot
                 .total_blend_rewards_accessor()
                 .get_checked(sdk)?
@@ -699,7 +707,7 @@ fn settle_one<SDK: SharedAPI>(
                 .total_blend_rewards_accessor()
                 .set_checked(sdk, next)?;
             credited_this_epoch = credited_this_epoch
-                .checked_add(share)
+                .checked_add(U256::from(share))
                 .ok_or(ExitCode::IntegerOverflow)?;
         }
         let credited = storage.credited_blend_accessor().get_checked(sdk)?;

--- a/contracts/staking/src/rewards.rs
+++ b/contracts/staking/src/rewards.rs
@@ -1,0 +1,728 @@
+use alloc::vec;
+use fluentbase_sdk::{
+    bytes::BytesMut, codec::SolidityABI, Address, Bytes, ContextReader, ExitCode, SharedAPI, U256,
+};
+
+use crate::{
+    consts::*,
+    economics::delegate_to,
+    events,
+    storage::{current_epoch, staking_storage, STATUS_NOT_FOUND},
+    types::{AddressCommand, U64Command, ValidatorDelegatorCommand, ValidatorEpochCommand},
+    util::{
+        decode, ensure_initialized, ensure_mutable, ensure_non_payable, next_epoch, revert,
+        revert_with, safe_transfer, touch_snapshot_at_or_before, write_abi,
+    },
+};
+
+fn external_call<SDK, T>(
+    sdk: &mut SDK,
+    target: Address,
+    selector: u32,
+    params: &T,
+) -> Result<Bytes, ExitCode>
+where
+    SDK: SharedAPI,
+    T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let mut encoded = BytesMut::new();
+    SolidityABI::<T>::encode(params, &mut encoded, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    let mut input = selector.to_be_bytes().to_vec();
+    input.extend_from_slice(&encoded);
+    let result = sdk.call(target, U256::ZERO, &input, None);
+    if !result.status.is_ok() {
+        sdk.write(result.data);
+        return Err(result.status);
+    }
+    Ok(result.data)
+}
+
+fn call_decode<SDK, T, R>(
+    sdk: &mut SDK,
+    target: Address,
+    selector: u32,
+    params: &T,
+) -> Result<R, ExitCode>
+where
+    SDK: SharedAPI,
+    T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+    R: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let output = external_call(sdk, target, selector, params)?;
+    SolidityABI::<R>::decode(&output, 0).map_err(|_| ExitCode::MalformedBuiltinParams)
+}
+
+fn snapshot_payout<SDK: SharedAPI>(
+    sdk: &SDK,
+    validator: Address,
+    epoch: u64,
+) -> Result<(U256, U256), ExitCode> {
+    let snapshot = staking_storage()
+        .validator_snapshots_accessor()
+        .entry(validator)
+        .entry(epoch);
+    if !snapshot.initialized_accessor().get_checked(sdk)? {
+        return Ok((U256::ZERO, U256::ZERO));
+    }
+    let total_reward = snapshot.total_blend_rewards_accessor().get_checked(sdk)?;
+    if total_reward.is_zero() {
+        return Ok((U256::ZERO, U256::ZERO));
+    }
+    if snapshot
+        .total_delegated_accessor()
+        .get_checked(sdk)?
+        .is_zero()
+    {
+        return Ok((U256::ZERO, total_reward));
+    }
+    let owner_reward = total_reward
+        .checked_mul(U256::from(
+            snapshot.commission_rate_accessor().get_checked(sdk)?,
+        ))
+        .ok_or(ExitCode::IntegerOverflow)?
+        / U256::from(10_000);
+    Ok((total_reward - owner_reward, owner_reward))
+}
+
+fn validator_owner_rewards<SDK: SharedAPI>(
+    sdk: &SDK,
+    validator: Address,
+    before_epoch: u64,
+) -> Result<U256, ExitCode> {
+    let record = staking_storage().validators_accessor().entry(validator);
+    if record.status_accessor().get_checked(sdk)? == STATUS_NOT_FOUND {
+        return Ok(U256::ZERO);
+    }
+    let mut epoch = record.claimed_at_accessor().get_checked(sdk)?;
+    let mut rewards = U256::ZERO;
+    while epoch < before_epoch {
+        rewards = rewards
+            .checked_add(snapshot_payout(sdk, validator, epoch)?.1)
+            .ok_or(ExitCode::IntegerOverflow)?;
+        epoch = epoch.checked_add(1).ok_or(ExitCode::IntegerOverflow)?;
+    }
+    Ok(rewards)
+}
+
+fn delegator_claimable<SDK: SharedAPI>(
+    sdk: &SDK,
+    validator: Address,
+    delegator: Address,
+    before_epoch: u64,
+) -> Result<U256, ExitCode> {
+    let delegation = staking_storage()
+        .validator_delegations_accessor()
+        .entry(validator)
+        .entry(delegator);
+    let delegates = delegation.delegate_queue_accessor();
+    let delegate_len = delegates.len_checked(sdk)?;
+    let mut delegate_gap = delegation.delegate_gap_accessor().get_checked(sdk)?;
+    let mut claimable = U256::ZERO;
+
+    while delegate_gap < delegate_len {
+        let operation = delegates.at(delegate_gap);
+        let mut epoch = operation.epoch_accessor().get_checked(sdk)?;
+        if epoch >= before_epoch {
+            break;
+        }
+        let changed_at = if delegate_gap + 1 < delegate_len {
+            delegates
+                .at(delegate_gap + 1)
+                .epoch_accessor()
+                .get_checked(sdk)?
+        } else {
+            before_epoch
+        };
+        let end = core::cmp::min(before_epoch, changed_at);
+        let delegated = operation.amount_accessor().get_checked(sdk)?;
+        while epoch < end {
+            let (delegator_pool, _) = snapshot_payout(sdk, validator, epoch)?;
+            let snapshot = staking_storage()
+                .validator_snapshots_accessor()
+                .entry(validator)
+                .entry(epoch);
+            let total = snapshot.total_delegated_accessor().get_checked(sdk)?;
+            if !total.is_zero() {
+                claimable = claimable
+                    .checked_add(
+                        delegator_pool
+                            .checked_mul(delegated)
+                            .ok_or(ExitCode::IntegerOverflow)?
+                            / total,
+                    )
+                    .ok_or(ExitCode::IntegerOverflow)?;
+            }
+            epoch = epoch.checked_add(1).ok_or(ExitCode::IntegerOverflow)?;
+        }
+        delegate_gap += 1;
+    }
+
+    let undelegates = delegation.undelegate_queue_accessor();
+    let undelegate_len = undelegates.len_checked(sdk)?;
+    let mut undelegate_gap = delegation.undelegate_gap_accessor().get_checked(sdk)?;
+    while undelegate_gap < undelegate_len {
+        let operation = undelegates.at(undelegate_gap);
+        if operation.epoch_accessor().get_checked(sdk)? > before_epoch {
+            break;
+        }
+        claimable = claimable
+            .checked_add(operation.amount_accessor().get_checked(sdk)?)
+            .ok_or(ExitCode::IntegerOverflow)?;
+        undelegate_gap += 1;
+    }
+    Ok(claimable)
+}
+
+fn capped_delegator_claim_epoch<SDK: SharedAPI>(
+    sdk: &SDK,
+    validator: Address,
+    delegator: Address,
+    before_epoch: u64,
+) -> Result<u64, ExitCode> {
+    let delegation = staking_storage()
+        .validator_delegations_accessor()
+        .entry(validator)
+        .entry(delegator);
+    let delegates = delegation.delegate_queue_accessor();
+    let delegate_gap = delegation.delegate_gap_accessor().get_checked(sdk)?;
+    let first = if delegate_gap < delegates.len_checked(sdk)? {
+        Some(
+            delegates
+                .at(delegate_gap)
+                .epoch_accessor()
+                .get_checked(sdk)?,
+        )
+    } else {
+        let undelegates = delegation.undelegate_queue_accessor();
+        let undelegate_gap = delegation.undelegate_gap_accessor().get_checked(sdk)?;
+        if undelegate_gap < undelegates.len_checked(sdk)? {
+            Some(
+                undelegates
+                    .at(undelegate_gap)
+                    .epoch_accessor()
+                    .get_checked(sdk)?,
+            )
+        } else {
+            None
+        }
+    };
+    let Some(first) = first else {
+        return Ok(before_epoch);
+    };
+    Ok(core::cmp::min(
+        before_epoch,
+        first
+            .checked_add(MAX_EPOCHS_PER_CLAIM)
+            .ok_or(ExitCode::IntegerOverflow)?,
+    ))
+}
+
+fn consume_delegator_claim<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    delegator: Address,
+    before_epoch: u64,
+) -> Result<U256, ExitCode> {
+    let storage = staking_storage();
+    let delegation = storage
+        .validator_delegations_accessor()
+        .entry(validator)
+        .entry(delegator);
+    let delegates = delegation.delegate_queue_accessor();
+    let delegate_len = delegates.len_checked(sdk)?;
+    let mut delegate_gap = delegation.delegate_gap_accessor().get_checked(sdk)?;
+    let mut claimable = U256::ZERO;
+
+    while delegate_gap < delegate_len {
+        let operation = delegates.at(delegate_gap);
+        let mut epoch = operation.epoch_accessor().get_checked(sdk)?;
+        if epoch >= before_epoch {
+            break;
+        }
+        let has_next = delegate_gap + 1 < delegate_len;
+        let changed_at = if has_next {
+            delegates
+                .at(delegate_gap + 1)
+                .epoch_accessor()
+                .get_checked(sdk)?
+        } else {
+            before_epoch
+        };
+        let end = core::cmp::min(before_epoch, changed_at);
+        let delegated = operation.amount_accessor().get_checked(sdk)?;
+        while epoch < end {
+            let (delegator_pool, _) = snapshot_payout(sdk, validator, epoch)?;
+            let snapshot = storage
+                .validator_snapshots_accessor()
+                .entry(validator)
+                .entry(epoch);
+            let total = snapshot.total_delegated_accessor().get_checked(sdk)?;
+            if !total.is_zero() {
+                claimable = claimable
+                    .checked_add(
+                        delegator_pool
+                            .checked_mul(delegated)
+                            .ok_or(ExitCode::IntegerOverflow)?
+                            / total,
+                    )
+                    .ok_or(ExitCode::IntegerOverflow)?;
+            }
+            epoch = epoch.checked_add(1).ok_or(ExitCode::IntegerOverflow)?;
+        }
+        if !has_next || epoch < changed_at {
+            operation.epoch_accessor().set_checked(sdk, epoch)?;
+            break;
+        }
+        delegate_gap += 1;
+    }
+    delegation
+        .delegate_gap_accessor()
+        .set_checked(sdk, delegate_gap)?;
+
+    let undelegates = delegation.undelegate_queue_accessor();
+    let undelegate_len = undelegates.len_checked(sdk)?;
+    let mut undelegate_gap = delegation.undelegate_gap_accessor().get_checked(sdk)?;
+    while undelegate_gap < undelegate_len {
+        let operation = undelegates.at(undelegate_gap);
+        if operation.epoch_accessor().get_checked(sdk)? > before_epoch {
+            break;
+        }
+        claimable = claimable
+            .checked_add(operation.amount_accessor().get_checked(sdk)?)
+            .ok_or(ExitCode::IntegerOverflow)?;
+        undelegate_gap += 1;
+    }
+    delegation
+        .undelegate_gap_accessor()
+        .set_checked(sdk, undelegate_gap)?;
+    Ok(claimable)
+}
+
+fn available_for_redelegate<SDK: SharedAPI>(
+    sdk: &SDK,
+    claimable: U256,
+) -> Result<(U256, U256), ExitCode> {
+    let amount = claimable / BALANCE_COMPACT_PRECISION * BALANCE_COMPACT_PRECISION;
+    let minimum = staking_storage()
+        .config_accessor()
+        .min_staking_amount_accessor()
+        .get_checked(sdk)?;
+    if amount < minimum {
+        return Ok((U256::ZERO, claimable));
+    }
+    Ok((amount, claimable - amount))
+}
+
+pub fn get_validator_fee<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let validator = decode::<AddressCommand>(input)?.value;
+    write_abi(
+        sdk,
+        &validator_owner_rewards(sdk, validator, current_epoch(sdk)?)?,
+    )
+}
+
+pub fn get_pending_validator_fee<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let validator = decode::<AddressCommand>(input)?.value;
+    write_abi(
+        sdk,
+        &validator_owner_rewards(sdk, validator, next_epoch(sdk)?)?,
+    )
+}
+
+fn claim_validator_before<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    before_epoch: u64,
+) -> Result<(), ExitCode> {
+    let record = staking_storage().validators_accessor().entry(validator);
+    if record.status_accessor().get_checked(sdk)? == STATUS_NOT_FOUND {
+        return revert_with(sdk, ERR_VALIDATOR_NOT_FOUND, &validator);
+    }
+    let claimed_at = record.claimed_at_accessor().get_checked(sdk)?;
+    let capped = core::cmp::min(
+        before_epoch,
+        claimed_at
+            .checked_add(MAX_EPOCHS_PER_CLAIM)
+            .ok_or(ExitCode::IntegerOverflow)?,
+    );
+    let mut epoch = claimed_at;
+    let mut amount = U256::ZERO;
+    while epoch < capped {
+        amount = amount
+            .checked_add(snapshot_payout(sdk, validator, epoch)?.1)
+            .ok_or(ExitCode::IntegerOverflow)?;
+        epoch = epoch.checked_add(1).ok_or(ExitCode::IntegerOverflow)?;
+    }
+    let owner = record.owner_accessor().get_checked(sdk)?;
+    record.claimed_at_accessor().set_checked(sdk, epoch)?;
+    safe_transfer(sdk, owner, amount)?;
+    events::ValidatorOwnerClaimed {
+        validator,
+        amount,
+        epoch: capped,
+    }
+    .emit(sdk)
+}
+
+pub fn claim_validator_fee<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let validator = decode::<AddressCommand>(input)?.value;
+    claim_validator_before(sdk, validator, current_epoch(sdk)?)
+}
+
+pub fn claim_validator_fee_at_epoch<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command = decode::<ValidatorEpochCommand>(input)?;
+    if command.before_epoch > current_epoch(sdk)? {
+        return revert(sdk, ERR_INVALID_CLAIM_EPOCH);
+    }
+    claim_validator_before(sdk, command.validator, command.before_epoch)
+}
+
+pub fn get_delegator_fee<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command = decode::<ValidatorDelegatorCommand>(input)?;
+    write_abi(
+        sdk,
+        &delegator_claimable(
+            sdk,
+            command.validator,
+            command.delegator,
+            current_epoch(sdk)?,
+        )?,
+    )
+}
+
+pub fn get_pending_delegator_fee<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command = decode::<ValidatorDelegatorCommand>(input)?;
+    write_abi(
+        sdk,
+        &delegator_claimable(sdk, command.validator, command.delegator, next_epoch(sdk)?)?,
+    )
+}
+
+fn claim_delegator_before<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    delegator: Address,
+    before_epoch: u64,
+    redelegate: bool,
+) -> Result<(), ExitCode> {
+    let capped = capped_delegator_claim_epoch(sdk, validator, delegator, before_epoch)?;
+    let claimable = consume_delegator_claim(sdk, validator, delegator, capped)?;
+    if redelegate {
+        let (amount, dust) = available_for_redelegate(sdk, claimable)?;
+        if !amount.is_zero() {
+            delegate_to(sdk, delegator, validator, amount, false)?;
+        }
+        safe_transfer(sdk, delegator, dust)?;
+        events::Redelegated {
+            validator,
+            staker: delegator,
+            amount,
+            dust,
+            epoch: capped,
+        }
+        .emit(sdk)
+    } else {
+        safe_transfer(sdk, delegator, claimable)?;
+        events::Claimed {
+            validator,
+            staker: delegator,
+            amount: claimable,
+            epoch: capped,
+        }
+        .emit(sdk)
+    }
+}
+
+pub fn claim_delegator_fee<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let validator = decode::<AddressCommand>(input)?.value;
+    let delegator = sdk.context().contract_caller();
+    claim_delegator_before(sdk, validator, delegator, current_epoch(sdk)?, false)
+}
+
+pub fn claim_delegator_fee_at_epoch<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command = decode::<ValidatorEpochCommand>(input)?;
+    if command.before_epoch > current_epoch(sdk)? {
+        return revert(sdk, ERR_INVALID_CLAIM_EPOCH);
+    }
+    let delegator = sdk.context().contract_caller();
+    claim_delegator_before(
+        sdk,
+        command.validator,
+        delegator,
+        command.before_epoch,
+        false,
+    )
+}
+
+pub fn calc_available_for_redelegate_amount<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let command = decode::<ValidatorDelegatorCommand>(input)?;
+    let claimable = delegator_claimable(
+        sdk,
+        command.validator,
+        command.delegator,
+        current_epoch(sdk)?,
+    )?;
+    write_abi(sdk, &available_for_redelegate(sdk, claimable)?)
+}
+
+pub fn redelegate_delegator_fee<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    input: &[u8],
+) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    let validator = decode::<AddressCommand>(input)?.value;
+    let delegator = sdk.context().contract_caller();
+    claim_delegator_before(sdk, validator, delegator, current_epoch(sdk)?, true)
+}
+
+pub fn get_epoch_rewards<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_initialized(sdk)?;
+    let epoch = decode::<U64Command>(input)?.value;
+    let committee = staking_storage().epoch_committees_accessor().entry(epoch);
+    let len = committee.len_checked(sdk)?;
+    let mut total = U256::ZERO;
+    for index in 0..len {
+        let validator = committee.at(index).get_checked(sdk)?;
+        total = total
+            .checked_add(
+                staking_storage()
+                    .validator_snapshots_accessor()
+                    .entry(validator)
+                    .entry(epoch)
+                    .total_blend_rewards_accessor()
+                    .get_checked(sdk)?,
+            )
+            .ok_or(ExitCode::IntegerOverflow)?;
+    }
+    write_abi(sdk, &total)
+}
+
+fn fault_tolerance(n: usize) -> usize {
+    if n == 0 {
+        0
+    } else {
+        (n - 1) / 3
+    }
+}
+
+fn settle_one<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    epoch: u64,
+    liveness: Address,
+    reserve: Address,
+) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    let committee = storage.epoch_committees_accessor().entry(epoch);
+    let len = committee.len_checked(sdk)?;
+    let desired = storage
+        .config_accessor()
+        .blend_stipend_per_epoch_accessor()
+        .get_checked(sdk)?;
+    if desired.is_zero() {
+        events::EpochBlendRewardsCommitted {
+            epoch,
+            blend_amount: U256::ZERO,
+        }
+        .emit(sdk)?;
+        return Ok(());
+    }
+    let reserve_balance = call_decode::<_, _, U256>(sdk, reserve, SIG_RESERVE_BALANCE, &())?;
+    let pot = core::cmp::min(desired, reserve_balance);
+    let mut assigned = U256::ZERO;
+    let mut shares = vec![U256::ZERO; len as usize];
+
+    if !pot.is_zero() && len != 0 {
+        let (_, certs) =
+            call_decode::<_, _, (u32, u32)>(sdk, liveness, SIG_PARTICIPATION, &(epoch, 0u32))?;
+        if certs != 0 {
+            let floor = storage
+                .config_accessor()
+                .participation_floor_bps_accessor()
+                .get_checked(sdk)?;
+            let floor = if floor == 0 {
+                DEFAULT_PARTICIPATION_FLOOR_BPS
+            } else {
+                floor
+            };
+            let mut passed = vec![false; len as usize];
+            let mut below = 0usize;
+            for index in 0..len {
+                let (seen, _) = call_decode::<_, _, (u32, u32)>(
+                    sdk,
+                    liveness,
+                    SIG_PARTICIPATION,
+                    &(epoch, index as u32),
+                )?;
+                if U256::from(seen) * U256::from(10_000) < U256::from(certs) * U256::from(floor) {
+                    below += 1;
+                } else {
+                    passed[index as usize] = true;
+                }
+            }
+            let partition = below > fault_tolerance(len as usize);
+            let mut stakes = vec![U256::ZERO; len as usize];
+            let mut total_stake = U256::ZERO;
+            for index in 0..len {
+                let validator = committee.at(index).get_checked(sdk)?;
+                if (!partition && !passed[index as usize])
+                    || storage
+                        .tombstoned_accessor()
+                        .entry(validator)
+                        .get_checked(sdk)?
+                {
+                    continue;
+                }
+                let stake = crate::util::validator_total_at(sdk, validator, epoch)?;
+                if stake.is_zero() {
+                    continue;
+                }
+                stakes[index as usize] = stake;
+                total_stake = total_stake
+                    .checked_add(stake)
+                    .ok_or(ExitCode::IntegerOverflow)?;
+            }
+            if !total_stake.is_zero() {
+                for (index, stake) in stakes.into_iter().enumerate() {
+                    if stake.is_zero() {
+                        continue;
+                    }
+                    let share =
+                        pot.checked_mul(stake).ok_or(ExitCode::IntegerOverflow)? / total_stake;
+                    shares[index] = share;
+                    assigned = assigned
+                        .checked_add(share)
+                        .ok_or(ExitCode::IntegerOverflow)?;
+                }
+            }
+        }
+    }
+
+    if !assigned.is_zero() {
+        let recipient = sdk.context().contract_address();
+        let sent =
+            call_decode::<_, _, U256>(sdk, reserve, SIG_RESERVE_DISBURSE, &(recipient, assigned))?;
+        if sent != assigned {
+            assigned = U256::ZERO;
+            shares.fill(U256::ZERO);
+        }
+    }
+    if !assigned.is_zero() {
+        let mut credited_this_epoch = U256::ZERO;
+        for (index, share) in shares.into_iter().enumerate() {
+            if share.is_zero() {
+                continue;
+            }
+            let validator = committee.at(index as u64).get_checked(sdk)?;
+            if storage
+                .validators_accessor()
+                .entry(validator)
+                .status_accessor()
+                .get_checked(sdk)?
+                == STATUS_NOT_FOUND
+            {
+                continue;
+            }
+            let snapshot = touch_snapshot_at_or_before(sdk, validator, epoch)?;
+            let next = snapshot
+                .total_blend_rewards_accessor()
+                .get_checked(sdk)?
+                .checked_add(share)
+                .ok_or(ExitCode::IntegerOverflow)?;
+            snapshot
+                .total_blend_rewards_accessor()
+                .set_checked(sdk, next)?;
+            credited_this_epoch = credited_this_epoch
+                .checked_add(share)
+                .ok_or(ExitCode::IntegerOverflow)?;
+        }
+        let credited = storage.credited_blend_accessor().get_checked(sdk)?;
+        storage.credited_blend_accessor().set_checked(
+            sdk,
+            credited
+                .checked_add(credited_this_epoch)
+                .ok_or(ExitCode::IntegerOverflow)?,
+        )?;
+    } else {
+        events::StipendSkipped { epoch }.emit(sdk)?;
+    }
+    events::EpochBlendRewardsCommitted {
+        epoch,
+        blend_amount: assigned,
+    }
+    .emit(sdk)
+}
+
+pub fn settle_epoch_stipend<SDK: SharedAPI>(sdk: &mut SDK, input: &[u8]) -> Result<(), ExitCode> {
+    ensure_non_payable(sdk)?;
+    ensure_mutable(sdk)?;
+    ensure_initialized(sdk)?;
+    if sdk.context().contract_caller() != SYSTEM_CALLER {
+        return revert(sdk, ERR_ONLY_SYSTEM_CALL);
+    }
+    let requested = decode::<U64Command>(input)?.value;
+    let storage = staking_storage();
+    let config = storage.config_accessor();
+    let liveness = config.liveness_slashing_accessor().get_checked(sdk)?;
+    let reserve = config.blend_reserve_accessor().get_checked(sdk)?;
+    let finalized_p1 = call_decode::<_, _, u64>(sdk, liveness, SIG_LAST_FINALIZED_EPOCH_P1, &())?;
+    if finalized_p1 == 0 {
+        return Ok(());
+    }
+    let up_to = core::cmp::min(requested, finalized_p1 - 1);
+    let first = storage.last_rewarded_epoch_p1_accessor().get_checked(sdk)?;
+    if first != 0 && up_to.checked_add(1).ok_or(ExitCode::IntegerOverflow)? <= first {
+        return Ok(());
+    }
+    let mut epoch = first;
+    let mut settled = 0;
+    while epoch <= up_to && settled < MAX_SETTLE_CATCHUP {
+        settle_one(sdk, epoch, liveness, reserve)?;
+        storage
+            .last_rewarded_epoch_p1_accessor()
+            .set_checked(sdk, epoch.checked_add(1).ok_or(ExitCode::IntegerOverflow)?)?;
+        epoch = epoch.checked_add(1).ok_or(ExitCode::IntegerOverflow)?;
+        settled += 1;
+    }
+    Ok(())
+}

--- a/contracts/staking/src/storage.rs
+++ b/contracts/staking/src/storage.rs
@@ -1,3 +1,5 @@
+//! ERC-7201 storage layout, epoch calculation, and validator-set helpers.
+
 use fluentbase_sdk::{
     derive::Storage,
     storage::{

--- a/contracts/staking/src/storage.rs
+++ b/contracts/staking/src/storage.rs
@@ -4,7 +4,7 @@ use fluentbase_sdk::{
     derive::Storage,
     storage::{
         StorageAddress, StorageBool, StorageBytes, StorageBytes32, StorageMap, StorageU16,
-        StorageU256, StorageU32, StorageU64, StorageU8, StorageVec,
+        StorageU256, StorageU32, StorageU64, StorageU8, StorageUint112, StorageUint96, StorageVec,
     },
     Address, ContextReader, ExitCode, SharedAPI, B256,
 };
@@ -66,24 +66,27 @@ pub struct ValidatorStorage {
 /// Per-epoch validator accounting snapshot.
 #[derive(Storage)]
 pub struct ValidatorSnapshotStorage {
-    initialized: StorageBool,
-    total_delegated: StorageU256,
-    commission_rate: StorageU16,
+    /// Stake in `BALANCE_COMPACT_PRECISION` units.
+    total_delegated: StorageUint112,
     slashes_count: StorageU32,
-    total_blend_rewards: StorageU256,
+    commission_rate: StorageU16,
+    /// Per-epoch BLEND reward in token base units; never copied forward.
+    total_blend_rewards: StorageUint96,
 }
 
 /// Effective delegation balance beginning at `epoch`.
 #[derive(Storage)]
 pub struct DelegationOpStorage {
-    amount: StorageU256,
+    /// Stake in `BALANCE_COMPACT_PRECISION` units.
+    amount: StorageUint112,
     epoch: StorageU64,
 }
 
 /// Principal queued for release after the undelegation period.
 #[derive(Storage)]
 pub struct UndelegationOpStorage {
-    amount: StorageU256,
+    /// Stake in `BALANCE_COMPACT_PRECISION` units.
+    amount: StorageUint112,
     epoch: StorageU64,
 }
 

--- a/contracts/staking/src/storage.rs
+++ b/contracts/staking/src/storage.rs
@@ -23,15 +23,16 @@ pub struct ChainConfigStorage {
     governance: StorageAddress,
     active_validators_length: StorageU64,
     epoch_block_interval: StorageU64,
+    undelegate_period: StorageU64,
     dpos_activation_block: StorageU64,
     min_validator_stake_amount: StorageU256,
     min_staking_amount: StorageU256,
 }
 
-/// Fixed-size validator metadata and its latest accounting snapshot.
+/// Fixed-size validator metadata.
 ///
-/// Queue/snapshot history will be added as separate derived storage types in
-/// the delegation slice.
+/// Epoch-varying stake, commission, and slash counters live exclusively in
+/// `ValidatorSnapshotStorage`, avoiding duplicate sources of truth.
 #[derive(Storage)]
 pub struct ValidatorStorage {
     owner: StorageAddress,
@@ -39,9 +40,39 @@ pub struct ValidatorStorage {
     changed_at: StorageU64,
     jailed_before: StorageU64,
     claimed_at: StorageU64,
+}
+
+/// Per-epoch validator accounting snapshot.
+#[derive(Storage)]
+pub struct ValidatorSnapshotStorage {
+    initialized: StorageBool,
+    total_delegated: StorageU256,
     commission_rate: StorageU16,
     slashes_count: StorageU32,
-    total_delegated: StorageU256,
+}
+
+/// Effective delegation balance beginning at `epoch`.
+#[derive(Storage)]
+pub struct DelegationOpStorage {
+    amount: StorageU256,
+    epoch: StorageU64,
+}
+
+/// Principal queued for release after the undelegation period.
+#[derive(Storage)]
+pub struct UndelegationOpStorage {
+    amount: StorageU256,
+    epoch: StorageU64,
+}
+
+/// Delegation history for one validator/delegator pair.
+#[derive(Storage)]
+#[allow(dead_code)]
+pub struct ValidatorDelegationStorage {
+    delegate_queue: StorageVec<DelegationOpStorage>,
+    delegate_gap: StorageU64,
+    undelegate_queue: StorageVec<UndelegationOpStorage>,
+    undelegate_gap: StorageU64,
 }
 
 /// Single ERC-7201 namespaced storage root for staking.
@@ -56,6 +87,8 @@ pub struct StakingStorage {
     validators: StorageMap<Address, ValidatorStorage>,
     owner_validators: StorageMap<Address, StorageAddress>,
     active_validators: StorageVec<StorageAddress>,
+    validator_snapshots: StorageMap<Address, StorageMap<u64, ValidatorSnapshotStorage>>,
+    validator_delegations: StorageMap<Address, StorageMap<Address, ValidatorDelegationStorage>>,
 }
 
 pub fn staking_storage() -> StakingStorage {
@@ -63,12 +96,18 @@ pub fn staking_storage() -> StakingStorage {
 }
 
 pub fn current_epoch<SDK: SharedAPI>(sdk: &SDK) -> Result<u64, ExitCode> {
+    current_epoch_at_block(sdk, sdk.context().block_number())
+}
+
+pub fn current_epoch_at_block<SDK: SharedAPI>(
+    sdk: &SDK,
+    block_number: u64,
+) -> Result<u64, ExitCode> {
     let storage = staking_storage();
     let config = storage.config_accessor();
     let activation = config.dpos_activation_block_accessor().get_checked(sdk)?;
     let interval = config.epoch_block_interval_accessor().get_checked(sdk)?;
-    math::epoch_at_block(sdk.context().block_number(), activation, interval)
-        .ok_or(ExitCode::IntegerDivisionByZero)
+    math::epoch_at_block(block_number, activation, interval).ok_or(ExitCode::IntegerDivisionByZero)
 }
 
 pub fn remove_active<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {

--- a/contracts/staking/src/storage.rs
+++ b/contracts/staking/src/storage.rs
@@ -54,6 +54,11 @@ pub struct ValidatorStorage {
     changed_at: StorageU64,
     jailed_before: StorageU64,
     claimed_at: StorageU64,
+    /// First initialized snapshot epoch plus one (`0` means no snapshot).
+    ///
+    /// Appended to preserve the existing storage layout while bounding
+    /// historical snapshot lookups.
+    first_snapshot_epoch_p1: StorageU64,
 }
 
 /// Per-epoch validator accounting snapshot.
@@ -134,6 +139,10 @@ pub struct StakingStorage {
     tombstoned: StorageMap<Address, StorageBool>,
     credited_blend: StorageU256,
     last_rewarded_epoch_p1: StorageU64,
+    /// Resumable cursor for bounded jailed-validator sweeps.
+    ///
+    /// Appended to preserve the existing ERC-7201 layout.
+    jailed_scan_cursor: StorageU64,
 }
 
 pub fn staking_storage() -> StakingStorage {

--- a/contracts/staking/src/storage.rs
+++ b/contracts/staking/src/storage.rs
@@ -1,59 +1,78 @@
 use fluentbase_sdk::{
+    derive::Storage,
     storage::{
-        StorageAddress, StorageBool, StorageDescriptor, StorageMap, StorageU16, StorageU256,
-        StorageU32, StorageU64, StorageU8, StorageVec,
+        StorageAddress, StorageBool, StorageMap, StorageU16, StorageU256, StorageU32, StorageU64,
+        StorageU8, StorageVec,
     },
-    Address, ContextReader, StorageAPI, U256,
+    Address, ContextReader, ExitCode, SharedAPI,
 };
 
-use crate::consts::*;
+use crate::{consts::STAKING_STORAGE_SLOT, math};
 
 pub const STATUS_NOT_FOUND: u8 = 0;
 pub const STATUS_ACTIVE: u8 = 1;
 pub const STATUS_PENDING: u8 = 2;
 
-pub type AddressMap = StorageMap<Address, StorageAddress>;
-pub type U8Map = StorageMap<Address, StorageU8>;
-pub type U16Map = StorageMap<Address, StorageU16>;
-pub type U32Map = StorageMap<Address, StorageU32>;
-pub type U64Map = StorageMap<Address, StorageU64>;
-pub type U256Map = StorageMap<Address, StorageU256>;
-
-pub fn initialized<SDK: StorageAPI>(sdk: &SDK) -> Result<bool, fluentbase_sdk::ExitCode> {
-    StorageBool::new(INITIALIZED_SLOT, 31).get_checked(sdk)
+/// Configuration formerly read from the external Solidity `ChainConfig`.
+///
+/// The rWasm staking contract owns this state so consensus-critical reads do
+/// not require a second contract call.
+#[derive(Storage)]
+pub struct ChainConfigStorage {
+    staking_token: StorageAddress,
+    governance: StorageAddress,
+    active_validators_length: StorageU64,
+    epoch_block_interval: StorageU64,
+    dpos_activation_block: StorageU64,
+    min_validator_stake_amount: StorageU256,
+    min_staking_amount: StorageU256,
 }
 
-pub fn owner<SDK: StorageAPI>(sdk: &SDK) -> Result<Address, fluentbase_sdk::ExitCode> {
-    StorageAddress::new(OWNER_SLOT, 12).get_checked(sdk)
+/// Fixed-size validator metadata and its latest accounting snapshot.
+///
+/// Queue/snapshot history will be added as separate derived storage types in
+/// the delegation slice.
+#[derive(Storage)]
+pub struct ValidatorStorage {
+    owner: StorageAddress,
+    status: StorageU8,
+    changed_at: StorageU64,
+    jailed_before: StorageU64,
+    claimed_at: StorageU64,
+    commission_rate: StorageU16,
+    slashes_count: StorageU32,
+    total_delegated: StorageU256,
 }
 
-pub fn status<SDK: StorageAPI>(
-    sdk: &SDK,
-    validator: Address,
-) -> Result<u8, fluentbase_sdk::ExitCode> {
-    U8Map::new(VALIDATOR_STATUS_SLOT)
-        .entry(validator)
-        .get_checked(sdk)
+/// Single ERC-7201 namespaced storage root for staking.
+///
+/// Deriving the layout keeps packing and nested map/vector locations
+/// deterministic while avoiding a slot constant and map type for every field.
+#[derive(Storage)]
+pub struct StakingStorage {
+    initialized: StorageBool,
+    owner: StorageAddress,
+    config: ChainConfigStorage,
+    validators: StorageMap<Address, ValidatorStorage>,
+    owner_validators: StorageMap<Address, StorageAddress>,
+    active_validators: StorageVec<StorageAddress>,
 }
 
-pub fn current_epoch<SDK: fluentbase_sdk::SystemAPI>(
-    sdk: &SDK,
-) -> Result<u64, fluentbase_sdk::ExitCode> {
-    let activation = StorageU64::new(ACTIVATION_BLOCK_SLOT, 24).get_checked(sdk)?;
-    let interval = StorageU64::new(EPOCH_INTERVAL_SLOT, 24).get_checked(sdk)?;
-    crate::math::epoch_at_block(sdk.context().block_number(), activation, interval)
-        .ok_or(fluentbase_sdk::ExitCode::IntegerDivisionByZero)
+pub fn staking_storage() -> StakingStorage {
+    StakingStorage::new(STAKING_STORAGE_SLOT, 0)
 }
 
-pub fn active_validators() -> StorageVec<StorageAddress> {
-    StorageVec::new(ACTIVE_VALIDATORS_SLOT)
+pub fn current_epoch<SDK: SharedAPI>(sdk: &SDK) -> Result<u64, ExitCode> {
+    let storage = staking_storage();
+    let config = storage.config_accessor();
+    let activation = config.dpos_activation_block_accessor().get_checked(sdk)?;
+    let interval = config.epoch_block_interval_accessor().get_checked(sdk)?;
+    math::epoch_at_block(sdk.context().block_number(), activation, interval)
+        .ok_or(ExitCode::IntegerDivisionByZero)
 }
 
-pub fn remove_active<SDK: StorageAPI>(
-    sdk: &mut SDK,
-    validator: Address,
-) -> Result<(), fluentbase_sdk::ExitCode> {
-    let active = active_validators();
+pub fn remove_active<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
+    let active = staking_storage().active_validators_accessor();
     let len = active.len_checked(sdk)?;
     for index in 0..len {
         if active.at(index).get_checked(sdk)? != validator {
@@ -67,13 +86,4 @@ pub fn remove_active<SDK: StorageAPI>(
         break;
     }
     Ok(())
-}
-
-pub fn total_delegated<SDK: StorageAPI>(
-    sdk: &SDK,
-    validator: Address,
-) -> Result<U256, fluentbase_sdk::ExitCode> {
-    U256Map::new(VALIDATOR_TOTAL_DELEGATED_SLOT)
-        .entry(validator)
-        .get_checked(sdk)
 }

--- a/contracts/staking/src/storage.rs
+++ b/contracts/staking/src/storage.rs
@@ -1,0 +1,79 @@
+use fluentbase_sdk::{
+    storage::{
+        StorageAddress, StorageBool, StorageDescriptor, StorageMap, StorageU16, StorageU256,
+        StorageU32, StorageU64, StorageU8, StorageVec,
+    },
+    Address, ContextReader, StorageAPI, U256,
+};
+
+use crate::consts::*;
+
+pub const STATUS_NOT_FOUND: u8 = 0;
+pub const STATUS_ACTIVE: u8 = 1;
+pub const STATUS_PENDING: u8 = 2;
+
+pub type AddressMap = StorageMap<Address, StorageAddress>;
+pub type U8Map = StorageMap<Address, StorageU8>;
+pub type U16Map = StorageMap<Address, StorageU16>;
+pub type U32Map = StorageMap<Address, StorageU32>;
+pub type U64Map = StorageMap<Address, StorageU64>;
+pub type U256Map = StorageMap<Address, StorageU256>;
+
+pub fn initialized<SDK: StorageAPI>(sdk: &SDK) -> Result<bool, fluentbase_sdk::ExitCode> {
+    StorageBool::new(INITIALIZED_SLOT, 31).get_checked(sdk)
+}
+
+pub fn owner<SDK: StorageAPI>(sdk: &SDK) -> Result<Address, fluentbase_sdk::ExitCode> {
+    StorageAddress::new(OWNER_SLOT, 12).get_checked(sdk)
+}
+
+pub fn status<SDK: StorageAPI>(
+    sdk: &SDK,
+    validator: Address,
+) -> Result<u8, fluentbase_sdk::ExitCode> {
+    U8Map::new(VALIDATOR_STATUS_SLOT)
+        .entry(validator)
+        .get_checked(sdk)
+}
+
+pub fn current_epoch<SDK: fluentbase_sdk::SystemAPI>(
+    sdk: &SDK,
+) -> Result<u64, fluentbase_sdk::ExitCode> {
+    let activation = StorageU64::new(ACTIVATION_BLOCK_SLOT, 24).get_checked(sdk)?;
+    let interval = StorageU64::new(EPOCH_INTERVAL_SLOT, 24).get_checked(sdk)?;
+    crate::math::epoch_at_block(sdk.context().block_number(), activation, interval)
+        .ok_or(fluentbase_sdk::ExitCode::IntegerDivisionByZero)
+}
+
+pub fn active_validators() -> StorageVec<StorageAddress> {
+    StorageVec::new(ACTIVE_VALIDATORS_SLOT)
+}
+
+pub fn remove_active<SDK: StorageAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+) -> Result<(), fluentbase_sdk::ExitCode> {
+    let active = active_validators();
+    let len = active.len_checked(sdk)?;
+    for index in 0..len {
+        if active.at(index).get_checked(sdk)? != validator {
+            continue;
+        }
+        if index + 1 != len {
+            let last = active.at(len - 1).get_checked(sdk)?;
+            active.at(index).set_checked(sdk, last)?;
+        }
+        active.pop_checked(sdk)?;
+        break;
+    }
+    Ok(())
+}
+
+pub fn total_delegated<SDK: StorageAPI>(
+    sdk: &SDK,
+    validator: Address,
+) -> Result<U256, fluentbase_sdk::ExitCode> {
+    U256Map::new(VALIDATOR_TOTAL_DELEGATED_SLOT)
+        .entry(validator)
+        .get_checked(sdk)
+}

--- a/contracts/staking/src/storage.rs
+++ b/contracts/staking/src/storage.rs
@@ -1,10 +1,10 @@
 use fluentbase_sdk::{
     derive::Storage,
     storage::{
-        StorageAddress, StorageBool, StorageMap, StorageU16, StorageU256, StorageU32, StorageU64,
-        StorageU8, StorageVec,
+        StorageAddress, StorageBool, StorageBytes, StorageBytes32, StorageMap, StorageU16,
+        StorageU256, StorageU32, StorageU64, StorageU8, StorageVec,
     },
-    Address, ContextReader, ExitCode, SharedAPI,
+    Address, ContextReader, ExitCode, SharedAPI, B256,
 };
 
 use crate::{consts::STAKING_STORAGE_SLOT, math};
@@ -12,6 +12,7 @@ use crate::{consts::STAKING_STORAGE_SLOT, math};
 pub const STATUS_NOT_FOUND: u8 = 0;
 pub const STATUS_ACTIVE: u8 = 1;
 pub const STATUS_PENDING: u8 = 2;
+pub const STATUS_JAIL: u8 = 3;
 
 /// Configuration formerly read from the external Solidity `ChainConfig`.
 ///
@@ -27,6 +28,19 @@ pub struct ChainConfigStorage {
     dpos_activation_block: StorageU64,
     min_validator_stake_amount: StorageU256,
     min_staking_amount: StorageU256,
+    felony_threshold: StorageU32,
+    validator_jail_epoch_length: StorageU32,
+    slash_reporter_reward_bps: StorageU32,
+    slash_fund_address: StorageAddress,
+    participation_floor_bps: StorageU32,
+    participation_jail_disabled: StorageBool,
+    blend_stipend_per_epoch: StorageU256,
+    bls_verifier: StorageAddress,
+    evidence_decoder: StorageAddress,
+    min_undelegate_blocks: StorageU256,
+    liveness_slashing: StorageAddress,
+    blend_reserve: StorageAddress,
+    configured: StorageBool,
 }
 
 /// Fixed-size validator metadata.
@@ -49,6 +63,7 @@ pub struct ValidatorSnapshotStorage {
     total_delegated: StorageU256,
     commission_rate: StorageU16,
     slashes_count: StorageU32,
+    total_blend_rewards: StorageU256,
 }
 
 /// Effective delegation balance beginning at `epoch`.
@@ -75,6 +90,24 @@ pub struct ValidatorDelegationStorage {
     undelegate_gap: StorageU64,
 }
 
+/// Epoch-stamped selection visibility. Status changes become visible from the
+/// following epoch so an in-flight committee derivation cannot drift.
+#[derive(Storage)]
+pub struct SelectionMembershipStorage {
+    visible: StorageBool,
+    prev_visible: StorageBool,
+    effective_from: StorageU64,
+    rostered: StorageBool,
+}
+
+/// One validator's immutable v1 consensus identity.
+#[derive(Storage)]
+pub struct ConsensusKeysStorage {
+    bls_pubkey: StorageBytes,
+    peer_pubkey: StorageBytes32,
+    activation_epoch: StorageU64,
+}
+
 /// Single ERC-7201 namespaced storage root for staking.
 ///
 /// Deriving the layout keeps packing and nested map/vector locations
@@ -87,8 +120,20 @@ pub struct StakingStorage {
     validators: StorageMap<Address, ValidatorStorage>,
     owner_validators: StorageMap<Address, StorageAddress>,
     active_validators: StorageVec<StorageAddress>,
+    jailed_validators: StorageVec<StorageAddress>,
+    selection_roster: StorageVec<StorageAddress>,
+    selection_membership: StorageMap<Address, SelectionMembershipStorage>,
     validator_snapshots: StorageMap<Address, StorageMap<u64, ValidatorSnapshotStorage>>,
     validator_delegations: StorageMap<Address, StorageMap<Address, ValidatorDelegationStorage>>,
+    consensus_keys: StorageMap<Address, ConsensusKeysStorage>,
+    peer_pubkey_owner: StorageMap<B256, StorageAddress>,
+    epoch_committees: StorageMap<u64, StorageVec<StorageAddress>>,
+    dkg_qual: StorageMap<u64, StorageBool>,
+    last_committed_epoch_p1: StorageU64,
+    pruned_up_to_p1: StorageU64,
+    tombstoned: StorageMap<Address, StorageBool>,
+    credited_blend: StorageU256,
+    last_rewarded_epoch_p1: StorageU64,
 }
 
 pub fn staking_storage() -> StakingStorage {

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -1,7 +1,10 @@
 use super::*;
+use crate::storage::{staking_storage, STATUS_ACTIVE};
+use crate::types::{AddressCommand, ConfigureCommand, InitializeCommand};
 use fluentbase_sdk::{
-    codec::SolidityABI, derive::derive_keccak256_id, Address, Bytes, ContractContextV1, ExitCode,
-    PRECOMPILE_STAKING,
+    bytes::BytesMut, codec::SolidityABI, derive::derive_keccak256_id, is_engine_metered_precompile,
+    is_execute_using_system_runtime, Address, Bytes, ContractContextV1, ExitCode,
+    GENESIS_GOVERNANCE, GENESIS_STAKING, U256,
 };
 use fluentbase_testing::TestingContextImpl;
 
@@ -29,8 +32,8 @@ impl Harness {
         let gas_limit = 1_000_000;
         let sdk = TestingContextImpl::default()
             .with_contract_context(ContractContextV1 {
-                address: PRECOMPILE_STAKING,
-                bytecode_address: PRECOMPILE_STAKING,
+                address: GENESIS_STAKING,
+                bytecode_address: GENESIS_STAKING,
                 gas_limit,
                 ..Default::default()
             })
@@ -93,6 +96,20 @@ fn implemented_selectors_match_pinned_solidity_abi() {
     assert_eq!(SIG_CURRENT_EPOCH, derive_keccak256_id!("currentEpoch()"));
     assert_eq!(SIG_NEXT_EPOCH, derive_keccak256_id!("nextEpoch()"));
     assert_eq!(SIG_OWNER, derive_keccak256_id!("owner()"));
+    assert_eq!(SIG_GET_STAKING, derive_keccak256_id!("getStaking()"));
+    assert_eq!(SIG_GET_GOVERNANCE, derive_keccak256_id!("getGovernance()"));
+    assert_eq!(
+        SIG_GET_CHAIN_CONFIG,
+        derive_keccak256_id!("getChainConfig()")
+    );
+    assert_eq!(
+        SIG_GET_STAKING_TOKEN,
+        derive_keccak256_id!("getStakingToken()")
+    );
+    assert_eq!(
+        SIG_CONFIGURE,
+        derive_keccak256_id!("configure(address,uint64,uint64,uint256,uint256)")
+    );
     assert_eq!(
         SIG_IS_VALIDATOR,
         derive_keccak256_id!("isValidator(address)")
@@ -209,13 +226,13 @@ fn epoch_number_is_rebased_to_initialization_block() {
 
 #[test]
 fn governance_lifecycle_updates_active_registry() {
-    let governance = Address::with_last_byte(0xa0);
+    let owner = Address::with_last_byte(0xa0);
     let outsider = Address::with_last_byte(0xb0);
     let validator = Address::with_last_byte(0x01);
     let mut harness = Harness::new(1_000);
-    harness.set_caller(governance);
+    harness.set_caller(owner);
     assert_eq!(
-        harness.initialize(governance, Vec::new(), Vec::new(), 0),
+        harness.initialize(owner, Vec::new(), Vec::new(), 0),
         ExitCode::Ok
     );
 
@@ -226,7 +243,7 @@ fn governance_lifecycle_updates_active_registry() {
     ));
     assert_eq!(exit, ExitCode::Panic);
 
-    harness.set_caller(governance);
+    harness.set_caller(GENESIS_GOVERNANCE);
     assert_eq!(
         harness
             .call(encode_call(
@@ -266,6 +283,65 @@ fn governance_lifecycle_updates_active_registry() {
             .0,
         ExitCode::Ok
     );
+}
+
+#[test]
+fn staking_is_a_genesis_rwasm_contract_not_a_system_precompile() {
+    assert!(!is_execute_using_system_runtime(&GENESIS_STAKING));
+    assert!(!is_engine_metered_precompile(&GENESIS_STAKING));
+}
+
+#[test]
+fn stores_reserved_governance_and_chain_configuration() {
+    let owner = Address::with_last_byte(0xa0);
+    let staking_token = Address::with_last_byte(0xb1);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(owner, Vec::new(), Vec::new(), 0),
+        ExitCode::Ok
+    );
+
+    let (_, output) = harness.call(encode_empty_call(SIG_GET_GOVERNANCE));
+    assert_eq!(decode_output::<Address>(&output), GENESIS_GOVERNANCE);
+
+    let (_, output) = harness.call(encode_empty_call(SIG_GET_STAKING));
+    assert_eq!(decode_output::<Address>(&output), GENESIS_STAKING);
+    let (_, output) = harness.call(encode_empty_call(SIG_GET_CHAIN_CONFIG));
+    assert_eq!(decode_output::<Address>(&output), GENESIS_STAKING);
+
+    let configure = ConfigureCommand {
+        staking_token,
+        active_validators_length: 50,
+        epoch_block_interval: 100,
+        min_validator_stake_amount: U256::from(1_000),
+        min_staking_amount: U256::from(10),
+    };
+    assert_eq!(
+        harness.call(encode_call(SIG_CONFIGURE, &configure)).0,
+        ExitCode::Ok
+    );
+    let config = staking_storage().config_accessor();
+    assert_eq!(
+        config
+            .active_validators_length_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        50
+    );
+    assert_eq!(
+        config
+            .epoch_block_interval_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        100
+    );
+    let (_, output) = harness.call(encode_empty_call(SIG_GET_STAKING_TOKEN));
+    assert_eq!(decode_output::<Address>(&output), staking_token);
+
+    harness.set_block_number(1_100);
+    let (_, output) = harness.call(encode_empty_call(SIG_CURRENT_EPOCH));
+    assert_eq!(decode_output::<u64>(&output), 1);
 }
 
 #[test]

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -1,12 +1,13 @@
 use super::*;
-use crate::storage::{staking_storage, STATUS_ACTIVE};
+use crate::storage::{staking_storage, STATUS_ACTIVE, STATUS_JAIL, STATUS_PENDING};
 use crate::types::{
-    AddressCommand, ConfigureCommand, InitializeCommand, ValidatorBlockCommand,
-    ValidatorDelegatorCommand,
+    AddressCommand, BoolCommand, ConfigureCommand, ConfigureDependenciesCommand,
+    EpochSignerCommand, TwoAddressesCommand, U256Command, U32Command, U64Command,
+    ValidatorBlockCommand, ValidatorDelegatorCommand, ValidatorEpochCommand,
 };
 use fluentbase_sdk::{
     bytes::BytesMut, codec::SolidityABI, derive::derive_keccak256_id, is_engine_metered_precompile,
-    is_execute_using_system_runtime, Address, Bytes, ContractContextV1, ExitCode,
+    is_execute_using_system_runtime, Address, Bytes, ContractContextV1, ExitCode, B256,
     GENESIS_GOVERNANCE, GENESIS_STAKING, U256,
 };
 use fluentbase_testing::TestingContextImpl;
@@ -17,6 +18,17 @@ where
 {
     let mut params = BytesMut::new();
     SolidityABI::<T>::encode(value, &mut params, 0).unwrap();
+    let mut input = selector.to_be_bytes().to_vec();
+    input.extend_from_slice(&params);
+    input
+}
+
+fn encode_args_call<T>(selector: u32, value: &T) -> Vec<u8>
+where
+    T: fluentbase_sdk::codec::FunctionArgs<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let mut params = BytesMut::new();
+    SolidityABI::<T>::encode_function_args(value, &mut params).unwrap();
     let mut input = selector.to_be_bytes().to_vec();
     input.extend_from_slice(&params);
     input
@@ -73,13 +85,11 @@ impl Harness {
         stakes: Vec<U256>,
         commission_rate: u16,
     ) -> ExitCode {
-        let command = InitializeCommand {
-            initial_owner: owner,
-            validators,
-            initial_stakes: stakes,
-            commission_rate,
-        };
-        self.call(encode_call(SIG_INITIALIZE, &command)).0
+        self.call(encode_args_call(
+            SIG_INITIALIZE,
+            &(owner, validators, stakes, commission_rate),
+        ))
+        .0
     }
 }
 
@@ -88,6 +98,64 @@ where
     T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
 {
     SolidityABI::<T>::decode(&output, 0).unwrap()
+}
+
+fn decode_returns<T>(output: &[u8]) -> T
+where
+    T: fluentbase_sdk::codec::FunctionArgs<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    SolidityABI::<T>::decode_function_args(&output).unwrap()
+}
+
+fn assert_revert_selector(result: (ExitCode, Vec<u8>), selector: u32) {
+    assert_eq!(result.0, ExitCode::Panic);
+    assert_eq!(&result.1[..4], &selector.to_be_bytes());
+}
+
+#[test]
+fn parameterized_custom_errors_use_solidity_abi() {
+    let owner = Address::with_last_byte(0xa0);
+    let outsider = Address::with_last_byte(0xb0);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(owner, Vec::new(), Vec::new(), 0),
+        ExitCode::Ok
+    );
+
+    harness.set_caller(outsider);
+    let (_, output) = harness.call(encode_call(
+        SIG_CONFIGURE,
+        &ConfigureCommand {
+            staking_token: Address::with_last_byte(0xc0),
+            active_validators_length: 21,
+            epoch_block_interval: 200,
+            felony_threshold: 150,
+            validator_jail_epoch_length: 7,
+            undelegate_period: 7,
+            min_validator_stake_amount: DEFAULT_MIN_VALIDATOR_STAKE,
+            min_staking_amount: DEFAULT_MIN_STAKING_AMOUNT,
+            dpos_activation_block: 1_000,
+            bls_verifier: Address::ZERO,
+            evidence_decoder: Address::ZERO,
+            min_undelegate_blocks: U256::ZERO,
+        },
+    ));
+    assert_eq!(&output[..4], &ERR_ONLY_OWNER.to_be_bytes());
+    assert_eq!(decode_output::<Address>(&output[4..]), outsider);
+
+    harness.set_caller(GENESIS_GOVERNANCE);
+    let (_, output) = harness.call(encode_call(
+        SIG_SET_BLS_VERIFIER,
+        &AddressCommand {
+            value: Address::ZERO,
+        },
+    ));
+    assert_eq!(&output[..4], &ERR_ZERO_VALUE.to_be_bytes());
+    assert_eq!(
+        decode_output::<alloc::string::String>(&output[4..]),
+        "blsVerifier"
+    );
 }
 
 #[test]
@@ -111,7 +179,33 @@ fn implemented_selectors_match_pinned_solidity_abi() {
     );
     assert_eq!(
         SIG_CONFIGURE,
-        derive_keccak256_id!("configure(address,uint64,uint64,uint256,uint256)")
+        derive_keccak256_id!(
+            "configure(address,uint32,uint32,uint32,uint32,uint32,uint256,uint256,uint64,address,address,uint256)"
+        )
+    );
+    assert_eq!(
+        SIG_DEFAULT_PARTICIPATION_FLOOR_BPS,
+        derive_keccak256_id!("DEFAULT_PARTICIPATION_FLOOR_BPS()")
+    );
+    assert_eq!(
+        SIG_DEFAULT_SLASH_REPORTER_BPS,
+        derive_keccak256_id!("DEFAULT_SLASH_REPORTER_BPS()")
+    );
+    assert_eq!(
+        SIG_MAX_ACTIVE_VALIDATORS,
+        derive_keccak256_id!("MAX_ACTIVE_VALIDATORS()")
+    );
+    assert_eq!(
+        SIG_MAX_BLEND_STIPEND_PER_EPOCH,
+        derive_keccak256_id!("MAX_BLEND_STIPEND_PER_EPOCH()")
+    );
+    assert_eq!(
+        SIG_MAX_PARTICIPATION_FLOOR_BPS,
+        derive_keccak256_id!("MAX_PARTICIPATION_FLOOR_BPS()")
+    );
+    assert_eq!(
+        SIG_MAX_SLASH_REPORTER_BPS,
+        derive_keccak256_id!("MAX_SLASH_REPORTER_BPS()")
     );
     assert_eq!(
         SIG_GET_VALIDATOR_DELEGATION,
@@ -173,6 +267,123 @@ fn implemented_selectors_match_pinned_solidity_abi() {
     assert_eq!(
         SIG_CHANGE_VALIDATOR_OWNER,
         derive_keccak256_id!("changeValidatorOwner(address,address)")
+    );
+    assert_eq!(
+        SIG_CONFIGURE_DEPENDENCIES,
+        derive_keccak256_id!("configureDependencies(address,address)")
+    );
+    assert_eq!(
+        SIG_SET_ACTIVE_VALIDATORS_LENGTH,
+        derive_keccak256_id!("setActiveValidatorsLength(uint32)")
+    );
+    assert_eq!(
+        SIG_SET_EPOCH_BLOCK_INTERVAL,
+        derive_keccak256_id!("setEpochBlockInterval(uint32)")
+    );
+    assert_eq!(
+        SIG_SET_DPOS_ACTIVATION_BLOCK,
+        derive_keccak256_id!("setDposActivationBlock(uint64)")
+    );
+    assert_eq!(
+        SIG_SET_FELONY_THRESHOLD,
+        derive_keccak256_id!("setFelonyThreshold(uint32)")
+    );
+    assert_eq!(
+        SIG_SET_VALIDATOR_JAIL_EPOCH_LENGTH,
+        derive_keccak256_id!("setValidatorJailEpochLength(uint32)")
+    );
+    assert_eq!(
+        SIG_SET_SLASH_REPORTER_REWARD_BPS,
+        derive_keccak256_id!("setSlashReporterRewardBps(uint32)")
+    );
+    assert_eq!(
+        SIG_SET_SLASH_FUND_ADDRESS,
+        derive_keccak256_id!("setSlashFundAddress(address)")
+    );
+    assert_eq!(
+        SIG_SET_PARTICIPATION_FLOOR_BPS,
+        derive_keccak256_id!("setParticipationFloorBps(uint32)")
+    );
+    assert_eq!(
+        SIG_SET_PARTICIPATION_JAIL_DISABLED,
+        derive_keccak256_id!("setParticipationJailDisabled(bool)")
+    );
+    assert_eq!(
+        SIG_SET_BLEND_STIPEND_PER_EPOCH,
+        derive_keccak256_id!("setBlendStipendPerEpoch(uint256)")
+    );
+    assert_eq!(
+        SIG_SET_UNDELEGATE_PERIOD,
+        derive_keccak256_id!("setUndelegatePeriod(uint32)")
+    );
+    assert_eq!(
+        SIG_SET_MIN_VALIDATOR_STAKE_AMOUNT,
+        derive_keccak256_id!("setMinValidatorStakeAmount(uint256)")
+    );
+    assert_eq!(
+        SIG_SET_MIN_STAKING_AMOUNT,
+        derive_keccak256_id!("setMinStakingAmount(uint256)")
+    );
+    assert_eq!(
+        SIG_SET_BLS_VERIFIER,
+        derive_keccak256_id!("setBlsVerifier(address)")
+    );
+    assert_eq!(
+        SIG_SET_EVIDENCE_DECODER,
+        derive_keccak256_id!("setEvidenceDecoder(address)")
+    );
+    assert_eq!(
+        SIG_GET_VALIDATOR_FEE,
+        derive_keccak256_id!("getValidatorFee(address)")
+    );
+    assert_eq!(
+        SIG_GET_PENDING_VALIDATOR_FEE,
+        derive_keccak256_id!("getPendingValidatorFee(address)")
+    );
+    assert_eq!(
+        SIG_CLAIM_VALIDATOR_FEE_AT_EPOCH,
+        derive_keccak256_id!("claimValidatorFeeAtEpoch(address,uint64)")
+    );
+    assert_eq!(
+        SIG_GET_DELEGATOR_FEE,
+        derive_keccak256_id!("getDelegatorFee(address,address)")
+    );
+    assert_eq!(
+        SIG_CLAIM_DELEGATOR_FEE_AT_EPOCH,
+        derive_keccak256_id!("claimDelegatorFeeAtEpoch(address,uint64)")
+    );
+    assert_eq!(
+        SIG_CALC_AVAILABLE_FOR_REDELEGATE_AMOUNT,
+        derive_keccak256_id!("calcAvailableForRedelegateAmount(address,address)")
+    );
+    assert_eq!(
+        SIG_SETTLE_EPOCH_STIPEND,
+        derive_keccak256_id!("settleEpochStipend(uint64)")
+    );
+    assert_eq!(
+        SIG_SET_CONSENSUS_KEYS,
+        derive_keccak256_id!("setConsensusKeys(address,bytes,bytes,bytes32)")
+    );
+    assert_eq!(
+        SIG_GET_VALIDATORS_WITH_KEYS_AT,
+        derive_keccak256_id!("getValidatorsWithKeysAt(uint64)")
+    );
+    assert_eq!(
+        SIG_COMMIT_EPOCH_COMMITTEE,
+        derive_keccak256_id!("commitEpochCommittee(address[])")
+    );
+    assert_eq!(
+        SIG_GET_EPOCH_COMMITTEE_WITH_STAKES,
+        derive_keccak256_id!("getEpochCommitteeWithStakes(uint64)")
+    );
+    assert_eq!(
+        SIG_RELEASE_VALIDATOR_FROM_JAIL,
+        derive_keccak256_id!("releaseValidatorFromJail(address)")
+    );
+    assert_eq!(SIG_SLASH, derive_keccak256_id!("slash(address)"));
+    assert_eq!(
+        SIG_SLASH_EQUIVOCATION_NOTARIZE,
+        derive_keccak256_id!("slashEquivocationNotarize(bytes,bytes,bytes,bytes)")
     );
 }
 
@@ -315,14 +526,68 @@ fn staking_is_a_genesis_rwasm_contract_not_a_system_precompile() {
 }
 
 #[test]
+fn embedded_chain_config_exposes_solidity_public_constants() {
+    let mut harness = Harness::new(0);
+    for (selector, expected) in [
+        (
+            SIG_DEFAULT_PARTICIPATION_FLOOR_BPS,
+            DEFAULT_PARTICIPATION_FLOOR_BPS,
+        ),
+        (
+            SIG_DEFAULT_SLASH_REPORTER_BPS,
+            DEFAULT_SLASH_REPORTER_REWARD_BPS,
+        ),
+        (
+            SIG_MAX_ACTIVE_VALIDATORS,
+            MAX_ACTIVE_VALIDATORS_LENGTH as u32,
+        ),
+        (SIG_MAX_PARTICIPATION_FLOOR_BPS, MAX_PARTICIPATION_FLOOR_BPS),
+        (SIG_MAX_SLASH_REPORTER_BPS, MAX_SLASH_REPORTER_REWARD_BPS),
+    ] {
+        let (_, output) = harness.call(encode_empty_call(selector));
+        assert_eq!(decode_output::<u32>(&output), expected);
+    }
+    let (_, output) = harness.call(encode_empty_call(SIG_MAX_BLEND_STIPEND_PER_EPOCH));
+    assert_eq!(decode_output::<U256>(&output), MAX_BLEND_STIPEND_PER_EPOCH);
+}
+
+#[test]
 fn stores_reserved_governance_and_chain_configuration() {
     let owner = Address::with_last_byte(0xa0);
     let staking_token = Address::with_last_byte(0xb1);
     let mut harness = Harness::new(1_000);
     harness.set_caller(owner);
+
+    let mut configure = ConfigureCommand {
+        staking_token,
+        active_validators_length: 50,
+        epoch_block_interval: 100,
+        felony_threshold: 150,
+        validator_jail_epoch_length: 7,
+        undelegate_period: 7,
+        min_validator_stake_amount: BALANCE_COMPACT_PRECISION,
+        min_staking_amount: BALANCE_COMPACT_PRECISION,
+        dpos_activation_block: 1_000,
+        bls_verifier: Address::with_last_byte(0xb2),
+        evidence_decoder: Address::with_last_byte(0xb3),
+        min_undelegate_blocks: U256::from(701),
+    };
+    assert_revert_selector(
+        harness.call(encode_call(SIG_CONFIGURE, &configure)),
+        ERR_UNDELEGATE_WINDOW_TOO_SHORT,
+    );
+    configure.min_undelegate_blocks = U256::from(700);
+    assert_eq!(
+        harness.call(encode_call(SIG_CONFIGURE, &configure)).0,
+        ExitCode::Ok
+    );
     assert_eq!(
         harness.initialize(owner, Vec::new(), Vec::new(), 0),
         ExitCode::Ok
+    );
+    assert_revert_selector(
+        harness.call(encode_call(SIG_CONFIGURE, &configure)),
+        ERR_ALREADY_CONFIGURED,
     );
 
     let (_, output) = harness.call(encode_empty_call(SIG_GET_GOVERNANCE));
@@ -333,17 +598,6 @@ fn stores_reserved_governance_and_chain_configuration() {
     let (_, output) = harness.call(encode_empty_call(SIG_GET_CHAIN_CONFIG));
     assert_eq!(decode_output::<Address>(&output), GENESIS_STAKING);
 
-    let configure = ConfigureCommand {
-        staking_token,
-        active_validators_length: 50,
-        epoch_block_interval: 100,
-        min_validator_stake_amount: BALANCE_COMPACT_PRECISION,
-        min_staking_amount: BALANCE_COMPACT_PRECISION,
-    };
-    assert_eq!(
-        harness.call(encode_call(SIG_CONFIGURE, &configure)).0,
-        ExitCode::Ok
-    );
     let config = staking_storage().config_accessor();
     assert_eq!(
         config
@@ -359,12 +613,133 @@ fn stores_reserved_governance_and_chain_configuration() {
             .unwrap(),
         100
     );
+    assert_eq!(
+        config
+            .min_undelegate_blocks_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        U256::from(700)
+    );
     let (_, output) = harness.call(encode_empty_call(SIG_GET_STAKING_TOKEN));
     assert_eq!(decode_output::<Address>(&output), staking_token);
 
     harness.set_block_number(1_100);
     let (_, output) = harness.call(encode_empty_call(SIG_CURRENT_EPOCH));
     assert_eq!(decode_output::<u64>(&output), 1);
+}
+
+#[test]
+fn governance_updates_embedded_chain_configuration() {
+    let owner = Address::with_last_byte(0xa0);
+    let outsider = Address::with_last_byte(0xb0);
+    let slash_fund = Address::with_last_byte(0xc1);
+    let bls_verifier = Address::with_last_byte(0xc2);
+    let evidence_decoder = Address::with_last_byte(0xc3);
+    let liveness_slashing = Address::with_last_byte(0xc4);
+    let blend_reserve = Address::with_last_byte(0xc5);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(owner, Vec::new(), Vec::new(), 0),
+        ExitCode::Ok
+    );
+
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_CONFIGURE_DEPENDENCIES,
+                &ConfigureDependenciesCommand {
+                    liveness_slashing,
+                    blend_reserve,
+                },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+
+    harness.set_caller(outsider);
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_SET_FELONY_THRESHOLD,
+                &U32Command { value: 3 },
+            ))
+            .0,
+        ExitCode::Panic
+    );
+
+    harness.set_caller(GENESIS_GOVERNANCE);
+    for (selector, value) in [
+        (SIG_SET_FELONY_THRESHOLD, 3),
+        (SIG_SET_VALIDATOR_JAIL_EPOCH_LENGTH, 4),
+        (SIG_SET_SLASH_REPORTER_REWARD_BPS, 2_500),
+        (SIG_SET_PARTICIPATION_FLOOR_BPS, 1_000),
+        (SIG_SET_ACTIVE_VALIDATORS_LENGTH, 31),
+        (SIG_SET_UNDELEGATE_PERIOD, 9),
+    ] {
+        assert_eq!(
+            harness.call(encode_call(selector, &U32Command { value })).0,
+            ExitCode::Ok
+        );
+    }
+    for (selector, value) in [
+        (SIG_SET_SLASH_FUND_ADDRESS, slash_fund),
+        (SIG_SET_BLS_VERIFIER, bls_verifier),
+        (SIG_SET_EVIDENCE_DECODER, evidence_decoder),
+    ] {
+        assert_eq!(
+            harness
+                .call(encode_call(selector, &AddressCommand { value }))
+                .0,
+            ExitCode::Ok
+        );
+    }
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_SET_PARTICIPATION_JAIL_DISABLED,
+                &BoolCommand { value: true },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_SET_BLEND_STIPEND_PER_EPOCH,
+                &U256Command {
+                    value: U256::from(42),
+                },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+
+    for (selector, expected) in [
+        (SIG_GET_FELONY_THRESHOLD, 3),
+        (SIG_GET_VALIDATOR_JAIL_EPOCH_LENGTH, 4),
+        (SIG_GET_SLASH_REPORTER_REWARD_BPS, 2_500),
+        (SIG_GET_PARTICIPATION_FLOOR_BPS, 1_000),
+        (SIG_GET_ACTIVE_VALIDATORS_LENGTH, 31),
+        (SIG_GET_UNDELEGATE_PERIOD, 9),
+    ] {
+        let (exit, output) = harness.call(encode_empty_call(selector));
+        assert_eq!(exit, ExitCode::Ok);
+        assert_eq!(decode_output::<u32>(&output), expected);
+    }
+    for (selector, expected) in [
+        (SIG_GET_SLASH_FUND_ADDRESS, slash_fund),
+        (SIG_GET_BLS_VERIFIER, bls_verifier),
+        (SIG_GET_EVIDENCE_DECODER, evidence_decoder),
+    ] {
+        let (exit, output) = harness.call(encode_empty_call(selector));
+        assert_eq!(exit, ExitCode::Ok);
+        assert_eq!(decode_output::<Address>(&output), expected);
+    }
+    let (_, output) = harness.call(encode_empty_call(SIG_GET_PARTICIPATION_JAIL_DISABLED));
+    assert!(decode_output::<bool>(&output));
+    let (_, output) = harness.call(encode_empty_call(SIG_GET_BLEND_STIPEND_PER_EPOCH));
+    assert_eq!(decode_output::<U256>(&output), U256::from(42));
 }
 
 #[test]
@@ -408,8 +783,15 @@ fn delegation_and_undelegation_follow_epoch_snapshots() {
                     staking_token: token,
                     active_validators_length: 21,
                     epoch_block_interval: 200,
+                    felony_threshold: 150,
+                    validator_jail_epoch_length: 7,
+                    undelegate_period: 7,
                     min_validator_stake_amount: one_token,
                     min_staking_amount: one_token,
+                    dpos_activation_block: 1_000,
+                    bls_verifier: Address::ZERO,
+                    evidence_decoder: Address::ZERO,
+                    min_undelegate_blocks: U256::ZERO,
                 },
             ))
             .0,
@@ -484,5 +866,781 @@ fn erc20_transfer_from_calldata_is_standard_abi() {
     assert_eq!(
         SolidityABI::<(Address, Address, U256)>::decode(&&input[4..], 0).unwrap(),
         (from, to, amount)
+    );
+}
+
+#[test]
+fn reward_views_split_blend_between_owner_and_delegators() {
+    let owner = Address::with_last_byte(0xa0);
+    let delegator = Address::with_last_byte(0xb0);
+    let validator = Address::with_last_byte(0x01);
+    let ten_tokens = DEFAULT_MIN_STAKING_AMOUNT * U256::from(10);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(owner, vec![validator], vec![ten_tokens], 1_000),
+        ExitCode::Ok
+    );
+    economics::delegate_to(&mut harness.sdk, delegator, validator, ten_tokens, false).unwrap();
+    let snapshot = staking_storage()
+        .validator_snapshots_accessor()
+        .entry(validator)
+        .entry(2);
+    snapshot
+        .total_blend_rewards_accessor()
+        .set_checked(&mut harness.sdk, ten_tokens)
+        .unwrap();
+
+    harness.set_block_number(1_600);
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_VALIDATOR_FEE,
+        &AddressCommand { value: validator },
+    ));
+    assert_eq!(decode_output::<U256>(&output), DEFAULT_MIN_STAKING_AMOUNT);
+
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_DELEGATOR_FEE,
+        &ValidatorDelegatorCommand {
+            validator,
+            delegator,
+        },
+    ));
+    assert_eq!(
+        decode_output::<U256>(&output),
+        U256::from(9) * DEFAULT_MIN_STAKING_AMOUNT / U256::from(2)
+    );
+
+    let (_, output) = harness.call(encode_call(
+        SIG_CALC_AVAILABLE_FOR_REDELEGATE_AMOUNT,
+        &ValidatorDelegatorCommand {
+            validator,
+            delegator,
+        },
+    ));
+    assert_eq!(
+        decode_output::<(U256, U256)>(&output),
+        (
+            U256::from(9) * DEFAULT_MIN_STAKING_AMOUNT / U256::from(2),
+            U256::ZERO
+        )
+    );
+}
+
+#[test]
+fn committee_commit_is_system_gated_and_returns_epoch_stakes() {
+    let owner = Address::with_last_byte(0xa0);
+    let validator_a = Address::with_last_byte(0x01);
+    let validator_b = Address::with_last_byte(0x02);
+    let stake_a = U256::from(10) * BALANCE_COMPACT_PRECISION;
+    let stake_b = U256::from(20) * BALANCE_COMPACT_PRECISION;
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(
+            owner,
+            vec![validator_a, validator_b],
+            vec![stake_a, stake_b],
+            500,
+        ),
+        ExitCode::Ok
+    );
+
+    for (validator, last_byte) in [(validator_a, 1u8), (validator_b, 2u8)] {
+        let keys = staking_storage().consensus_keys_accessor().entry(validator);
+        keys.bls_pubkey_accessor()
+            .store(&mut harness.sdk, &[last_byte; BLS_PUBKEY_LENGTH])
+            .unwrap();
+        keys.peer_pubkey_accessor()
+            .set_checked(&mut harness.sdk, B256::with_last_byte(last_byte))
+            .unwrap();
+        keys.activation_epoch_accessor()
+            .set_checked(&mut harness.sdk, 0)
+            .unwrap();
+    }
+
+    let committee = (vec![validator_a, validator_b],);
+    assert_eq!(
+        harness
+            .call(encode_args_call(SIG_COMMIT_EPOCH_COMMITTEE, &committee))
+            .0,
+        ExitCode::Panic
+    );
+    harness.set_caller(SYSTEM_CALLER);
+    assert_eq!(
+        harness
+            .call(encode_args_call(SIG_COMMIT_EPOCH_COMMITTEE, &committee))
+            .0,
+        ExitCode::Ok
+    );
+
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_EPOCH_COMMITTEE,
+        &U64Command { value: 0 },
+    ));
+    assert_eq!(
+        decode_output::<Vec<Address>>(&output),
+        vec![validator_a, validator_b]
+    );
+    let (_, output) = harness.call(encode_call(
+        SIG_RESOLVE_SIGNER,
+        &EpochSignerCommand {
+            epoch: 0,
+            signer_idx: 1,
+        },
+    ));
+    assert_eq!(decode_output::<Address>(&output), validator_b);
+    let (_, output) = harness.call(encode_empty_call(SIG_NEXT_EPOCH_TO_COMMIT));
+    assert_eq!(decode_output::<u64>(&output), 1);
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_EPOCH_COMMITTEE_WITH_STAKES,
+        &U64Command { value: 0 },
+    ));
+    let (validators, _, stakes): (Vec<Address>, Vec<crate::types::ConsensusKeys>, Vec<U256>) =
+        decode_returns(&output);
+    assert_eq!(validators, vec![validator_a, validator_b]);
+    assert_eq!(stakes, vec![stake_a, stake_b]);
+
+    let logs = harness.sdk.take_logs();
+    let (_, topics) = logs
+        .iter()
+        .find(|(_, topics)| {
+            topics.first() == Some(&B256::new(events::EpochCommitteeCommitted::SELECTOR))
+        })
+        .expect("committee event");
+    assert_eq!(topics.len(), 2);
+    let (data, _) = logs
+        .iter()
+        .find(|(_, topics)| {
+            topics.first() == Some(&B256::new(events::EpochCommitteeCommitted::SELECTOR))
+        })
+        .expect("committee event");
+    let (event_committee,): (Vec<Address>,) = decode_returns(data);
+    assert_eq!(event_committee, vec![validator_a, validator_b]);
+}
+
+#[test]
+fn equal_stake_top_k_preserves_solidity_roster_order() {
+    let owner = Address::with_last_byte(0xa0);
+    let first = Address::with_last_byte(0xf0);
+    let second = Address::with_last_byte(0x01);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(
+            owner,
+            vec![first, second],
+            vec![DEFAULT_MIN_VALIDATOR_STAKE, DEFAULT_MIN_VALIDATOR_STAKE],
+            0,
+        ),
+        ExitCode::Ok
+    );
+    staking_storage()
+        .config_accessor()
+        .active_validators_length_accessor()
+        .set_checked(&mut harness.sdk, 1)
+        .unwrap();
+
+    let (_, output) = harness.call(encode_empty_call(SIG_GET_VALIDATORS));
+    assert_eq!(decode_output::<Vec<Address>>(&output), vec![first]);
+}
+
+#[test]
+fn committee_pruning_keeps_dkg_history() {
+    let owner = Address::with_last_byte(0xa0);
+    let validator = Address::with_last_byte(0x01);
+    let activation_block = 1_000;
+    let mut harness = Harness::new(activation_block);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(owner, vec![validator], vec![DEFAULT_MIN_VALIDATOR_STAKE], 0,),
+        ExitCode::Ok
+    );
+    harness.set_block_number(
+        activation_block
+            + DEFAULT_EPOCH_BLOCK_INTERVAL
+                * (DEFAULT_UNDELEGATE_PERIOD + EPOCH_COMMITTEE_RETENTION_MARGIN + 2),
+    );
+    let keys = staking_storage().consensus_keys_accessor().entry(validator);
+    keys.bls_pubkey_accessor()
+        .store(&mut harness.sdk, &[1; BLS_PUBKEY_LENGTH])
+        .unwrap();
+    keys.peer_pubkey_accessor()
+        .set_checked(&mut harness.sdk, B256::with_last_byte(1))
+        .unwrap();
+    staking_storage()
+        .dkg_qual_accessor()
+        .entry(1)
+        .set_checked(&mut harness.sdk, true)
+        .unwrap();
+
+    harness.set_caller(SYSTEM_CALLER);
+    assert_eq!(
+        harness
+            .call(encode_args_call(
+                SIG_COMMIT_EPOCH_COMMITTEE,
+                &(vec![validator],),
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    assert!(staking_storage()
+        .dkg_qual_accessor()
+        .entry(1)
+        .get_checked(&harness.sdk)
+        .unwrap());
+}
+
+#[test]
+fn liveness_slash_jails_and_readmits_without_breaking_quorum() {
+    let owner = Address::with_last_byte(0xa0);
+    let liveness = Address::with_last_byte(0xb0);
+    let reserve = Address::with_last_byte(0xb1);
+    let validators = (1..=4)
+        .map(Address::with_last_byte)
+        .collect::<Vec<Address>>();
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(
+            owner,
+            validators.clone(),
+            vec![BALANCE_COMPACT_PRECISION; validators.len()],
+            500,
+        ),
+        ExitCode::Ok
+    );
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_CONFIGURE_DEPENDENCIES,
+                &ConfigureDependenciesCommand {
+                    liveness_slashing: liveness,
+                    blend_reserve: reserve,
+                },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+
+    harness.set_caller(liveness);
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_SLASH,
+                &AddressCommand {
+                    value: validators[0],
+                },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    assert_eq!(
+        staking_storage()
+            .validators_accessor()
+            .entry(validators[0])
+            .status_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        crate::storage::STATUS_JAIL
+    );
+
+    harness.set_block_number(1_200);
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_READMIT_EXPIRED_JAILS,
+                &U64Command { value: 1 },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    assert_eq!(
+        staking_storage()
+            .validators_accessor()
+            .entry(validators[0])
+            .status_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        STATUS_ACTIVE
+    );
+}
+
+#[test]
+fn chain_config_guards_match_solidity_boundaries() {
+    let owner = Address::with_last_byte(0xa0);
+    let mut harness = Harness::new(0);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(owner, Vec::new(), Vec::new(), 0),
+        ExitCode::Ok
+    );
+    harness.set_caller(GENESIS_GOVERNANCE);
+
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_ACTIVE_VALIDATORS_LENGTH,
+            &U32Command { value: 52 },
+        )),
+        ERR_MAX_ACTIVE_VALIDATORS_EXCEEDED,
+    );
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_SLASH_REPORTER_REWARD_BPS,
+            &U32Command { value: 0 },
+        )),
+        ERR_ZERO_VALUE,
+    );
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_PARTICIPATION_FLOOR_BPS,
+            &U32Command { value: 2_001 },
+        )),
+        ERR_PARTICIPATION_FLOOR_BPS_TOO_HIGH,
+    );
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_BLEND_STIPEND_PER_EPOCH,
+            &U256Command {
+                value: MAX_BLEND_STIPEND_PER_EPOCH + U256::from(1),
+            },
+        )),
+        ERR_BLEND_STIPEND_PER_EPOCH_TOO_HIGH,
+    );
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_DPOS_ACTIVATION_BLOCK,
+            &U64Command { value: 401 },
+        )),
+        ERR_UNALIGNED_ACTIVATION_BLOCK,
+    );
+
+    staking_storage()
+        .config_accessor()
+        .min_undelegate_blocks_accessor()
+        .set_checked(&mut harness.sdk, U256::from(1_000))
+        .unwrap();
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_UNDELEGATE_PERIOD,
+            &U32Command { value: 4 },
+        )),
+        ERR_UNDELEGATE_WINDOW_TOO_SHORT,
+    );
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_SET_DPOS_ACTIVATION_BLOCK,
+                &U64Command { value: 1_200 },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_SET_EPOCH_BLOCK_INTERVAL,
+                &U32Command { value: 300 },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    harness.set_block_number(1_200);
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_EPOCH_BLOCK_INTERVAL,
+            &U32Command { value: 200 },
+        )),
+        ERR_DPOS_ALREADY_ACTIVE,
+    );
+}
+
+#[test]
+fn lifecycle_transitions_preserve_next_epoch_snapshot_frontier() {
+    let contract_owner = Address::with_last_byte(0xa0);
+    let validator = Address::with_last_byte(0x01);
+    let new_owner = Address::with_last_byte(0x02);
+    let stake = DEFAULT_MIN_VALIDATOR_STAKE;
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(contract_owner);
+    assert_eq!(
+        harness.initialize(contract_owner, vec![validator], vec![stake], 500),
+        ExitCode::Ok
+    );
+
+    harness.set_caller(GENESIS_GOVERNANCE);
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_DISABLE_VALIDATOR,
+                &AddressCommand { value: validator },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    let record = staking_storage().validators_accessor().entry(validator);
+    assert_eq!(
+        record.status_accessor().get_checked(&harness.sdk).unwrap(),
+        STATUS_PENDING
+    );
+    assert_eq!(
+        record
+            .changed_at_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        staking_storage()
+            .validator_snapshots_accessor()
+            .entry(validator)
+            .entry(1)
+            .total_delegated_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        stake
+    );
+
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_ACTIVATE_VALIDATOR,
+                &AddressCommand { value: validator },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    harness.set_caller(validator);
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_CHANGE_VALIDATOR_OWNER,
+                &TwoAddressesCommand {
+                    validator,
+                    value: new_owner,
+                },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    assert_eq!(
+        record
+            .changed_at_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        staking_storage()
+            .owner_validators_accessor()
+            .entry(new_owner)
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        validator
+    );
+}
+
+#[test]
+fn validator_owner_cannot_drop_below_minimum_while_delegators_remain() {
+    let owner = Address::with_last_byte(0xa0);
+    let delegator = Address::with_last_byte(0xb0);
+    let validator = Address::with_last_byte(0x01);
+    let stake = DEFAULT_MIN_VALIDATOR_STAKE * U256::from(10);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(owner, vec![validator], vec![stake], 500),
+        ExitCode::Ok
+    );
+    economics::delegate_to(
+        &mut harness.sdk,
+        delegator,
+        validator,
+        DEFAULT_MIN_STAKING_AMOUNT * U256::from(2),
+        false,
+    )
+    .unwrap();
+
+    let before = harness.sdk.dump_storage();
+    assert_revert_selector(
+        (
+            economics::undelegate_from(&mut harness.sdk, validator, validator, stake).unwrap_err(),
+            harness.sdk.take_output(),
+        ),
+        ERR_OWNER_SELF_STAKE_BELOW_MINIMUM,
+    );
+    harness.sdk.restore_storage(before);
+}
+
+#[test]
+fn reward_claims_are_bounded_to_one_thousand_epochs() {
+    let owner = Address::with_last_byte(0xa0);
+    let validator = Address::with_last_byte(0x01);
+    let mut harness = Harness::new(0);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(
+            owner,
+            vec![validator],
+            vec![DEFAULT_MIN_VALIDATOR_STAKE],
+            500,
+        ),
+        ExitCode::Ok
+    );
+    harness.set_block_number(DEFAULT_EPOCH_BLOCK_INTERVAL * (MAX_EPOCHS_PER_CLAIM + 1));
+    harness.set_caller(validator);
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_CLAIM_DELEGATOR_FEE,
+                &AddressCommand { value: validator },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    assert_eq!(
+        staking_storage()
+            .validator_delegations_accessor()
+            .entry(validator)
+            .entry(validator)
+            .delegate_queue_accessor()
+            .at(0)
+            .epoch_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        MAX_EPOCHS_PER_CLAIM
+    );
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_CLAIM_VALIDATOR_FEE,
+                &AddressCommand { value: validator },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    assert_eq!(
+        staking_storage()
+            .validators_accessor()
+            .entry(validator)
+            .claimed_at_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        MAX_EPOCHS_PER_CLAIM
+    );
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_CLAIM_VALIDATOR_FEE_AT_EPOCH,
+            &ValidatorEpochCommand {
+                validator,
+                before_epoch: MAX_EPOCHS_PER_CLAIM + 2,
+            },
+        )),
+        ERR_INVALID_CLAIM_EPOCH,
+    );
+}
+
+#[test]
+fn liveness_halt_guard_and_equivocation_tombstone_are_enforced() {
+    let owner = Address::with_last_byte(0xa0);
+    let liveness = Address::with_last_byte(0xb0);
+    let validators = (1..=4)
+        .map(Address::with_last_byte)
+        .collect::<Vec<Address>>();
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(
+            owner,
+            validators.clone(),
+            vec![DEFAULT_MIN_VALIDATOR_STAKE; validators.len()],
+            500,
+        ),
+        ExitCode::Ok
+    );
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_CONFIGURE_DEPENDENCIES,
+                &ConfigureDependenciesCommand {
+                    liveness_slashing: liveness,
+                    blend_reserve: Address::with_last_byte(0xc0),
+                },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    harness.set_caller(liveness);
+    for validator in &validators[..2] {
+        assert_eq!(
+            harness
+                .call(encode_call(
+                    SIG_SLASH,
+                    &AddressCommand { value: *validator },
+                ))
+                .0,
+            ExitCode::Ok
+        );
+    }
+    assert_eq!(
+        staking_storage()
+            .validators_accessor()
+            .entry(validators[0])
+            .status_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        STATUS_JAIL
+    );
+    assert_eq!(
+        staking_storage()
+            .validators_accessor()
+            .entry(validators[1])
+            .status_accessor()
+            .get_checked(&harness.sdk)
+            .unwrap(),
+        STATUS_ACTIVE,
+        "the second jail would drop the active set below Simplex quorum"
+    );
+
+    staking_storage()
+        .tombstoned_accessor()
+        .entry(validators[0])
+        .set_checked(&mut harness.sdk, true)
+        .unwrap();
+    harness.set_caller(validators[0]);
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_RELEASE_VALIDATOR_FROM_JAIL,
+            &AddressCommand {
+                value: validators[0],
+            },
+        )),
+        ERR_ALREADY_SLASHED_FOR_EQUIVOCATION,
+    );
+}
+
+#[test]
+fn committee_validation_is_canonical_and_membership_changes_mint_dkg_bit() {
+    let owner = Address::with_last_byte(0xa0);
+    let validator_a = Address::with_last_byte(0x01);
+    let validator_b = Address::with_last_byte(0x02);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(
+            owner,
+            vec![validator_a, validator_b],
+            vec![DEFAULT_MIN_VALIDATOR_STAKE, DEFAULT_MIN_VALIDATOR_STAKE,],
+            500,
+        ),
+        ExitCode::Ok
+    );
+    for (validator, last_byte) in [(validator_a, 1u8), (validator_b, 2u8)] {
+        let keys = staking_storage().consensus_keys_accessor().entry(validator);
+        keys.bls_pubkey_accessor()
+            .store(&mut harness.sdk, &[last_byte; BLS_PUBKEY_LENGTH])
+            .unwrap();
+        keys.peer_pubkey_accessor()
+            .set_checked(&mut harness.sdk, B256::with_last_byte(last_byte))
+            .unwrap();
+    }
+
+    harness.set_caller(SYSTEM_CALLER);
+    assert_revert_selector(
+        harness.call(encode_args_call(
+            SIG_COMMIT_EPOCH_COMMITTEE,
+            &(vec![validator_b, validator_a],),
+        )),
+        ERR_COMMITTEE_NOT_STRICTLY_ASCENDING,
+    );
+    assert_revert_selector(
+        harness.call(encode_args_call(
+            SIG_COMMIT_EPOCH_COMMITTEE,
+            &(vec![validator_a],),
+        )),
+        ERR_COMMITTEE_LENGTH_MISMATCH,
+    );
+    let both = (vec![validator_a, validator_b],);
+    assert_eq!(
+        harness
+            .call(encode_args_call(SIG_COMMIT_EPOCH_COMMITTEE, &both))
+            .0,
+        ExitCode::Ok
+    );
+
+    harness.set_caller(GENESIS_GOVERNANCE);
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_DISABLE_VALIDATOR,
+                &AddressCommand { value: validator_b },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    harness.set_caller(SYSTEM_CALLER);
+    for _ in 0..2 {
+        assert_eq!(
+            harness
+                .call(encode_args_call(SIG_COMMIT_EPOCH_COMMITTEE, &both))
+                .0,
+            ExitCode::Ok
+        );
+    }
+    harness.set_block_number(1_200);
+    assert_eq!(
+        harness
+            .call(encode_args_call(
+                SIG_COMMIT_EPOCH_COMMITTEE,
+                &(vec![validator_a],),
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    let (_, output) = harness.call(encode_call(SIG_GET_DKG_QUAL, &U64Command { value: 3 }));
+    assert!(decode_output::<bool>(&output));
+}
+
+#[test]
+fn external_dependency_flows_fail_closed_before_calls() {
+    let owner = Address::with_last_byte(0xa0);
+    let validator = Address::with_last_byte(0x01);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(
+            owner,
+            vec![validator],
+            vec![DEFAULT_MIN_VALIDATOR_STAKE],
+            500,
+        ),
+        ExitCode::Ok
+    );
+
+    harness.set_caller(validator);
+    assert_revert_selector(
+        harness.call(encode_args_call(
+            SIG_SET_CONSENSUS_KEYS,
+            &(validator, Vec::<u8>::new(), Vec::<u8>::new(), B256::ZERO),
+        )),
+        ERR_INVALID_CONSENSUS_KEY_ENCODING,
+    );
+    assert_revert_selector(
+        harness.call(encode_args_call(
+            SIG_SLASH_EQUIVOCATION_NOTARIZE,
+            &(
+                Vec::<u8>::new(),
+                Vec::<u8>::new(),
+                Vec::<u8>::new(),
+                Vec::<u8>::new(),
+            ),
+        )),
+        ERR_EVIDENCE_DECODER_NOT_CONFIGURED,
+    );
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SETTLE_EPOCH_STIPEND,
+            &U64Command { value: 0 },
+        )),
+        ERR_ONLY_SYSTEM_CALL,
     );
 }

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::storage::{staking_storage, STATUS_ACTIVE, STATUS_JAIL, STATUS_PENDING};
 use crate::types::{
     AddressCommand, BoolCommand, ConfigureCommand, ConfigureDependenciesCommand,
-    EpochSignerCommand, TwoAddressesCommand, U256Command, U32Command, U64Command,
-    ValidatorBlockCommand, ValidatorDelegatorCommand, ValidatorEpochCommand,
+    EpochSignerCommand, RegisterValidatorCommand, TwoAddressesCommand, U256Command, U32Command,
+    U64Command, ValidatorBlockCommand, ValidatorDelegatorCommand, ValidatorEpochCommand,
 };
 use fluentbase_sdk::{
     bytes::BytesMut, codec::SolidityABI, derive::derive_keccak256_id, is_engine_metered_precompile,
@@ -85,11 +85,15 @@ impl Harness {
         stakes: Vec<U256>,
         commission_rate: u16,
     ) -> ExitCode {
-        self.call(encode_args_call(
+        self.set_caller(GENESIS_GOVERNANCE);
+        let exit = self
+            .call(encode_args_call(
             SIG_INITIALIZE,
             &(owner, validators, stakes, commission_rate),
         ))
-        .0
+            .0;
+        self.set_caller(owner);
+        exit
     }
 }
 
@@ -109,6 +113,11 @@ where
 
 fn assert_revert_selector(result: (ExitCode, Vec<u8>), selector: u32) {
     assert_eq!(result.0, ExitCode::Panic);
+    assert!(
+        result.1.len() >= SIG_LEN_BYTES,
+        "revert payload is missing the four-byte selector: {:?}",
+        result.1
+    );
     assert_eq!(&result.1[..4], &selector.to_be_bytes());
 }
 
@@ -388,6 +397,75 @@ fn implemented_selectors_match_pinned_solidity_abi() {
 }
 
 #[test]
+fn derived_selectors_match_independent_hex_pins() {
+    for (actual, pinned) in [
+        (SIG_INITIALIZE, 0x01f6bb50),
+        (SIG_CURRENT_EPOCH, 0x76671808),
+        (SIG_NEXT_EPOCH, 0xaea0e78b),
+        (SIG_OWNER, 0x8da5cb5b),
+        (SIG_GET_STAKING, 0x7b1391a6),
+        (SIG_GET_GOVERNANCE, 0x289b3c0d),
+        (SIG_GET_CHAIN_CONFIG, 0x606c0c94),
+        (SIG_GET_STAKING_TOKEN, 0x9f9106d1),
+        (SIG_CONFIGURE, 0xc4bb1bdd),
+        (SIG_DEFAULT_PARTICIPATION_FLOOR_BPS, 0x2c1d88e8),
+        (SIG_DEFAULT_SLASH_REPORTER_BPS, 0x6cc69027),
+        (SIG_MAX_ACTIVE_VALIDATORS, 0x5d887462),
+        (SIG_MAX_BLEND_STIPEND_PER_EPOCH, 0x2bc2fec4),
+        (SIG_MAX_PARTICIPATION_FLOOR_BPS, 0x9dbdf12b),
+        (SIG_MAX_SLASH_REPORTER_BPS, 0x0a3a6183),
+        (SIG_GET_VALIDATOR_DELEGATION, 0xd951e186),
+        (SIG_GET_VALIDATOR_DELEGATED_STAKE_AT, 0xe8810ea7),
+        (SIG_REGISTER_VALIDATOR, 0xdd0fb5df),
+        (SIG_DELEGATE, 0x026e402b),
+        (SIG_UNDELEGATE, 0x4d99dd16),
+        (SIG_IS_VALIDATOR, 0xfacd743b),
+        (SIG_IS_VALIDATOR_ACTIVE, 0x42ad55ac),
+        (SIG_GET_VALIDATOR_STATUS, 0xa310624f),
+        (SIG_GET_VALIDATOR_BY_OWNER, 0x30108c22),
+        (SIG_GET_VALIDATORS, 0xb7ab4db5),
+        (SIG_ADD_VALIDATOR, 0x4d238c8e),
+        (SIG_REMOVE_VALIDATOR, 0x40a141ff),
+        (SIG_ACTIVATE_VALIDATOR, 0xb46e5520),
+        (SIG_DISABLE_VALIDATOR, 0x1fe97684),
+        (SIG_CHANGE_VALIDATOR_COMMISSION_RATE, 0x14f8649f),
+        (SIG_CHANGE_VALIDATOR_OWNER, 0x0052c9e1),
+        (SIG_CONFIGURE_DEPENDENCIES, 0xd2bcdd7b),
+        (SIG_SET_ACTIVE_VALIDATORS_LENGTH, 0xc227a412),
+        (SIG_SET_EPOCH_BLOCK_INTERVAL, 0xaf70fa2c),
+        (SIG_SET_DPOS_ACTIVATION_BLOCK, 0xf517ca6a),
+        (SIG_SET_FELONY_THRESHOLD, 0xfcd6cb3e),
+        (SIG_SET_VALIDATOR_JAIL_EPOCH_LENGTH, 0xc8652bd5),
+        (SIG_SET_SLASH_REPORTER_REWARD_BPS, 0x58702003),
+        (SIG_SET_SLASH_FUND_ADDRESS, 0xa79e7263),
+        (SIG_SET_PARTICIPATION_FLOOR_BPS, 0xd0a01007),
+        (SIG_SET_PARTICIPATION_JAIL_DISABLED, 0x8664f2e7),
+        (SIG_SET_BLEND_STIPEND_PER_EPOCH, 0x2c91b879),
+        (SIG_SET_UNDELEGATE_PERIOD, 0x41d8a080),
+        (SIG_SET_MIN_VALIDATOR_STAKE_AMOUNT, 0xe1a2e863),
+        (SIG_SET_MIN_STAKING_AMOUNT, 0x612d669e),
+        (SIG_SET_BLS_VERIFIER, 0x466ae541),
+        (SIG_SET_EVIDENCE_DECODER, 0x00857c90),
+        (SIG_GET_VALIDATOR_FEE, 0x457179fd),
+        (SIG_GET_PENDING_VALIDATOR_FEE, 0xc6fb9065),
+        (SIG_CLAIM_VALIDATOR_FEE_AT_EPOCH, 0xadf2a79c),
+        (SIG_GET_DELEGATOR_FEE, 0x52b7bea2),
+        (SIG_CLAIM_DELEGATOR_FEE_AT_EPOCH, 0xfe38ebef),
+        (SIG_CALC_AVAILABLE_FOR_REDELEGATE_AMOUNT, 0x5ef9e8c6),
+        (SIG_SETTLE_EPOCH_STIPEND, 0xa631344a),
+        (SIG_SET_CONSENSUS_KEYS, 0x225cba85),
+        (SIG_GET_VALIDATORS_WITH_KEYS_AT, 0x7cfba9f3),
+        (SIG_COMMIT_EPOCH_COMMITTEE, 0x87401d8a),
+        (SIG_GET_EPOCH_COMMITTEE_WITH_STAKES, 0xa4d160c1),
+        (SIG_RELEASE_VALIDATOR_FROM_JAIL, 0x73a3dda6),
+        (SIG_SLASH, 0xc96be4cb),
+        (SIG_SLASH_EQUIVOCATION_NOTARIZE, 0xe28d2f63),
+    ] {
+        assert_eq!(actual, pinned);
+    }
+}
+
+#[test]
 fn initializes_registry_and_preserves_solidity_read_abi() {
     let governance = Address::with_last_byte(0xa0);
     let validator_a = Address::with_last_byte(0x01);
@@ -556,7 +634,7 @@ fn stores_reserved_governance_and_chain_configuration() {
     let owner = Address::with_last_byte(0xa0);
     let staking_token = Address::with_last_byte(0xb1);
     let mut harness = Harness::new(1_000);
-    harness.set_caller(owner);
+    harness.set_caller(GENESIS_GOVERNANCE);
 
     let mut configure = ConfigureCommand {
         staking_token,
@@ -644,6 +722,7 @@ fn governance_updates_embedded_chain_configuration() {
         ExitCode::Ok
     );
 
+    harness.set_caller(GENESIS_GOVERNANCE);
     assert_eq!(
         harness
             .call(encode_call(
@@ -755,6 +834,90 @@ fn initializer_rejects_mismatched_arrays_without_persisting_owner() {
 
     let (_, output) = harness.call(encode_empty_call(SIG_OWNER));
     assert_eq!(decode_output::<Address>(&output), Address::ZERO);
+}
+
+#[test]
+fn genesis_bootstrap_rejects_untrusted_first_callers() {
+    let owner = Address::with_last_byte(0xa0);
+    let outsider = Address::with_last_byte(0xb0);
+    let mut harness = Harness::new(0);
+    harness.set_caller(outsider);
+
+    assert_revert_selector(
+        harness.call(encode_args_call(
+            SIG_INITIALIZE,
+            &(owner, Vec::<Address>::new(), Vec::<U256>::new(), 0u16),
+        )),
+        ERR_ONLY_OWNER,
+    );
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_CONFIGURE,
+            &ConfigureCommand {
+                staking_token: Address::with_last_byte(0xc0),
+                active_validators_length: 21,
+                epoch_block_interval: 200,
+                felony_threshold: 150,
+                validator_jail_epoch_length: 7,
+                undelegate_period: 7,
+                min_validator_stake_amount: DEFAULT_MIN_VALIDATOR_STAKE,
+                min_staking_amount: DEFAULT_MIN_STAKING_AMOUNT,
+                dpos_activation_block: 0,
+                bls_verifier: Address::ZERO,
+                evidence_decoder: Address::ZERO,
+                min_undelegate_blocks: U256::ZERO,
+            },
+        )),
+        ERR_ONLY_OWNER,
+    );
+
+    let (_, output) = harness.call(encode_empty_call(SIG_OWNER));
+    assert_eq!(decode_output::<Address>(&output), Address::ZERO);
+}
+
+#[test]
+fn initialize_and_registration_reject_bad_commission_and_duplicate_validator() {
+    let owner = Address::with_last_byte(0xa0);
+    let validator = Address::with_last_byte(0x01);
+    let mut harness = Harness::new(0);
+    harness.set_caller(GENESIS_GOVERNANCE);
+    assert_revert_selector(
+        harness.call(encode_args_call(
+            SIG_INITIALIZE,
+            &(
+                owner,
+                vec![validator],
+                vec![DEFAULT_MIN_VALIDATOR_STAKE],
+                COMMISSION_RATE_MAX + 1,
+            ),
+        )),
+        ERR_BAD_COMMISSION_RATE,
+    );
+    assert_eq!(
+        harness.initialize(
+            owner,
+            vec![validator],
+            vec![DEFAULT_MIN_VALIDATOR_STAKE],
+            COMMISSION_RATE_MAX,
+        ),
+        ExitCode::Ok
+    );
+
+    let input = encode_call(
+        SIG_REGISTER_VALIDATOR,
+        &RegisterValidatorCommand {
+            validator,
+            commission_rate: 0,
+            initial_stake: DEFAULT_MIN_VALIDATOR_STAKE,
+        },
+    );
+    assert_revert_selector(
+        (
+            economics::register_validator(&mut harness.sdk, &input[SIG_LEN_BYTES..]).unwrap_err(),
+            harness.sdk.take_output(),
+        ),
+        ERR_VALIDATOR_ALREADY_EXISTS,
+    );
 }
 
 #[test]
@@ -1109,6 +1272,7 @@ fn liveness_slash_jails_and_readmits_without_breaking_quorum() {
         ),
         ExitCode::Ok
     );
+    harness.set_caller(GENESIS_GOVERNANCE);
     assert_eq!(
         harness
             .call(encode_call(
@@ -1174,6 +1338,11 @@ fn chain_config_guards_match_solidity_boundaries() {
         harness.initialize(owner, Vec::new(), Vec::new(), 0),
         ExitCode::Ok
     );
+    staking_storage()
+        .config_accessor()
+        .dpos_activation_block_accessor()
+        .set_checked(&mut harness.sdk, 400)
+        .unwrap();
     harness.set_caller(GENESIS_GOVERNANCE);
 
     assert_revert_selector(
@@ -1249,6 +1418,31 @@ fn chain_config_guards_match_solidity_boundaries() {
         harness.call(encode_call(
             SIG_SET_EPOCH_BLOCK_INTERVAL,
             &U32Command { value: 200 },
+        )),
+        ERR_DPOS_ALREADY_ACTIVE,
+    );
+}
+
+#[test]
+fn dpos_activation_at_block_zero_is_already_locked() {
+    let owner = Address::with_last_byte(0xa0);
+    let mut harness = Harness::new(0);
+    assert_eq!(
+        harness.initialize(owner, Vec::new(), Vec::new(), 0),
+        ExitCode::Ok
+    );
+    harness.set_caller(GENESIS_GOVERNANCE);
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_EPOCH_BLOCK_INTERVAL,
+            &U32Command { value: 100 },
+        )),
+        ERR_DPOS_ALREADY_ACTIVE,
+    );
+    assert_revert_selector(
+        harness.call(encode_call(
+            SIG_SET_DPOS_ACTIVATION_BLOCK,
+            &U64Command { value: 200 },
         )),
         ERR_DPOS_ALREADY_ACTIVE,
     );
@@ -1372,6 +1566,36 @@ fn validator_owner_cannot_drop_below_minimum_while_delegators_remain() {
 }
 
 #[test]
+fn sole_validator_owner_cannot_leave_subminimum_dust() {
+    let owner = Address::with_last_byte(0xa0);
+    let validator = Address::with_last_byte(0x01);
+    let stake = DEFAULT_MIN_VALIDATOR_STAKE * U256::from(10);
+    let mut harness = Harness::new(1_000);
+    assert_eq!(
+        harness.initialize(owner, vec![validator], vec![stake], 500),
+        ExitCode::Ok
+    );
+
+    let dust = DEFAULT_MIN_VALIDATOR_STAKE / U256::from(2);
+    let before = harness.sdk.dump_storage();
+    assert_revert_selector(
+        (
+            economics::undelegate_from(
+                &mut harness.sdk,
+                validator,
+                validator,
+                stake - dust,
+            )
+            .unwrap_err(),
+            harness.sdk.take_output(),
+        ),
+        ERR_OWNER_SELF_STAKE_BELOW_MINIMUM,
+    );
+    harness.sdk.restore_storage(before);
+    economics::undelegate_from(&mut harness.sdk, validator, validator, stake).unwrap();
+}
+
+#[test]
 fn reward_claims_are_bounded_to_one_thousand_epochs() {
     let owner = Address::with_last_byte(0xa0);
     let validator = Address::with_last_byte(0x01);
@@ -1457,6 +1681,7 @@ fn liveness_halt_guard_and_equivocation_tombstone_are_enforced() {
         ),
         ExitCode::Ok
     );
+    harness.set_caller(GENESIS_GOVERNANCE);
     assert_eq!(
         harness
             .call(encode_call(

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use crate::storage::{staking_storage, STATUS_ACTIVE};
-use crate::types::{AddressCommand, ConfigureCommand, InitializeCommand};
+use crate::types::{
+    AddressCommand, ConfigureCommand, InitializeCommand, ValidatorBlockCommand,
+    ValidatorDelegatorCommand,
+};
 use fluentbase_sdk::{
     bytes::BytesMut, codec::SolidityABI, derive::derive_keccak256_id, is_engine_metered_precompile,
     is_execute_using_system_runtime, Address, Bytes, ContractContextV1, ExitCode,
@@ -109,6 +112,26 @@ fn implemented_selectors_match_pinned_solidity_abi() {
     assert_eq!(
         SIG_CONFIGURE,
         derive_keccak256_id!("configure(address,uint64,uint64,uint256,uint256)")
+    );
+    assert_eq!(
+        SIG_GET_VALIDATOR_DELEGATION,
+        derive_keccak256_id!("getValidatorDelegation(address,address)")
+    );
+    assert_eq!(
+        SIG_GET_VALIDATOR_DELEGATED_STAKE_AT,
+        derive_keccak256_id!("getValidatorDelegatedStakeAt(address,uint256)")
+    );
+    assert_eq!(
+        SIG_REGISTER_VALIDATOR,
+        derive_keccak256_id!("registerValidator(address,uint16,uint256)")
+    );
+    assert_eq!(
+        SIG_DELEGATE,
+        derive_keccak256_id!("delegate(address,uint256)")
+    );
+    assert_eq!(
+        SIG_UNDELEGATE,
+        derive_keccak256_id!("undelegate(address,uint256)")
     );
     assert_eq!(
         SIG_IS_VALIDATOR,
@@ -314,8 +337,8 @@ fn stores_reserved_governance_and_chain_configuration() {
         staking_token,
         active_validators_length: 50,
         epoch_block_interval: 100,
-        min_validator_stake_amount: U256::from(1_000),
-        min_staking_amount: U256::from(10),
+        min_validator_stake_amount: BALANCE_COMPACT_PRECISION,
+        min_staking_amount: BALANCE_COMPACT_PRECISION,
     };
     assert_eq!(
         harness.call(encode_call(SIG_CONFIGURE, &configure)).0,
@@ -357,4 +380,109 @@ fn initializer_rejects_mismatched_arrays_without_persisting_owner() {
 
     let (_, output) = harness.call(encode_empty_call(SIG_OWNER));
     assert_eq!(decode_output::<Address>(&output), Address::ZERO);
+}
+
+#[test]
+fn delegation_and_undelegation_follow_epoch_snapshots() {
+    let owner = Address::with_last_byte(0xa0);
+    let delegator = Address::with_last_byte(0xb0);
+    let validator = Address::with_last_byte(0x01);
+    let token = Address::with_last_byte(0xc0);
+    let one_token = U256::from(1_000_000_000_000_000_000u64);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(owner);
+    assert_eq!(
+        harness.initialize(
+            owner,
+            vec![validator],
+            vec![one_token * U256::from(10)],
+            500,
+        ),
+        ExitCode::Ok
+    );
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_CONFIGURE,
+                &ConfigureCommand {
+                    staking_token: token,
+                    active_validators_length: 21,
+                    epoch_block_interval: 200,
+                    min_validator_stake_amount: one_token,
+                    min_staking_amount: one_token,
+                },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+
+    economics::delegate_to(
+        &mut harness.sdk,
+        delegator,
+        validator,
+        one_token * U256::from(2),
+        false,
+    )
+    .unwrap();
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_VALIDATOR_DELEGATION,
+        &ValidatorDelegatorCommand {
+            validator,
+            delegator,
+        },
+    ));
+    assert_eq!(
+        decode_output::<(U256, u64)>(&output),
+        (one_token * U256::from(2), 2)
+    );
+
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_VALIDATOR_DELEGATED_STAKE_AT,
+        &ValidatorBlockCommand {
+            validator,
+            block_number: U256::from(1_399),
+        },
+    ));
+    assert_eq!(decode_output::<U256>(&output), one_token * U256::from(10));
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_VALIDATOR_DELEGATED_STAKE_AT,
+        &ValidatorBlockCommand {
+            validator,
+            block_number: U256::from(1_400),
+        },
+    ));
+    assert_eq!(decode_output::<U256>(&output), one_token * U256::from(12));
+
+    harness.set_block_number(1_400);
+    economics::undelegate_from(&mut harness.sdk, delegator, validator, one_token).unwrap();
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_VALIDATOR_DELEGATION,
+        &ValidatorDelegatorCommand {
+            validator,
+            delegator,
+        },
+    ));
+    assert_eq!(decode_output::<(U256, u64)>(&output), (one_token, 3));
+
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_VALIDATOR_DELEGATED_STAKE_AT,
+        &ValidatorBlockCommand {
+            validator,
+            block_number: U256::from(1_600),
+        },
+    ));
+    assert_eq!(decode_output::<U256>(&output), one_token * U256::from(11));
+}
+
+#[test]
+fn erc20_transfer_from_calldata_is_standard_abi() {
+    let from = Address::with_last_byte(0x11);
+    let to = Address::with_last_byte(0x22);
+    let amount = U256::from(123);
+    let input = util::erc20_transfer_from_input(from, to, amount).unwrap();
+    assert_eq!(&input[..4], &SIG_ERC20_TRANSFER_FROM.to_be_bytes());
+    assert_eq!(
+        SolidityABI::<(Address, Address, U256)>::decode(&&input[4..], 0).unwrap(),
+        (from, to, amount)
+    );
 }

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -1,0 +1,284 @@
+use super::*;
+use fluentbase_sdk::{
+    codec::SolidityABI, derive::derive_keccak256_id, Address, Bytes, ContractContextV1, ExitCode,
+    PRECOMPILE_STAKING,
+};
+use fluentbase_testing::TestingContextImpl;
+
+fn encode_call<T>(selector: u32, value: &T) -> Vec<u8>
+where
+    T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let mut params = BytesMut::new();
+    SolidityABI::<T>::encode(value, &mut params, 0).unwrap();
+    let mut input = selector.to_be_bytes().to_vec();
+    input.extend_from_slice(&params);
+    input
+}
+
+fn encode_empty_call(selector: u32) -> Vec<u8> {
+    selector.to_be_bytes().to_vec()
+}
+
+struct Harness {
+    sdk: TestingContextImpl,
+}
+
+impl Harness {
+    fn new(block_number: u64) -> Self {
+        let gas_limit = 1_000_000;
+        let sdk = TestingContextImpl::default()
+            .with_contract_context(ContractContextV1 {
+                address: PRECOMPILE_STAKING,
+                bytecode_address: PRECOMPILE_STAKING,
+                gas_limit,
+                ..Default::default()
+            })
+            .with_block_number(block_number)
+            .with_gas_limit(gas_limit);
+        Self { sdk }
+    }
+
+    fn set_caller(&self, caller: Address) {
+        self.sdk.context_mut().caller = caller;
+    }
+
+    fn set_block_number(&mut self, block_number: u64) {
+        self.sdk = core::mem::take(&mut self.sdk).with_block_number(block_number);
+    }
+
+    fn call<I: Into<Bytes>>(&mut self, input: I) -> (ExitCode, Vec<u8>) {
+        self.sdk = core::mem::take(&mut self.sdk).with_input(input);
+        let storage_before = self.sdk.dump_storage();
+        let exit = match main_entry(&mut self.sdk) {
+            Ok(()) => ExitCode::Ok,
+            Err(exit) => exit,
+        };
+        if !exit.is_ok() {
+            self.sdk.restore_storage(storage_before);
+        }
+        (exit, self.sdk.take_output())
+    }
+
+    fn initialize(
+        &mut self,
+        owner: Address,
+        validators: Vec<Address>,
+        stakes: Vec<U256>,
+        commission_rate: u16,
+    ) -> ExitCode {
+        let command = InitializeCommand {
+            initial_owner: owner,
+            validators,
+            initial_stakes: stakes,
+            commission_rate,
+        };
+        self.call(encode_call(SIG_INITIALIZE, &command)).0
+    }
+}
+
+fn decode_output<T>(output: &[u8]) -> T
+where
+    T: fluentbase_sdk::codec::Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    SolidityABI::<T>::decode(&output, 0).unwrap()
+}
+
+#[test]
+fn implemented_selectors_match_pinned_solidity_abi() {
+    assert_eq!(
+        SIG_INITIALIZE,
+        derive_keccak256_id!("initialize(address,address[],uint256[],uint16)")
+    );
+    assert_eq!(SIG_CURRENT_EPOCH, derive_keccak256_id!("currentEpoch()"));
+    assert_eq!(SIG_NEXT_EPOCH, derive_keccak256_id!("nextEpoch()"));
+    assert_eq!(SIG_OWNER, derive_keccak256_id!("owner()"));
+    assert_eq!(
+        SIG_IS_VALIDATOR,
+        derive_keccak256_id!("isValidator(address)")
+    );
+    assert_eq!(
+        SIG_IS_VALIDATOR_ACTIVE,
+        derive_keccak256_id!("isValidatorActive(address)")
+    );
+    assert_eq!(
+        SIG_GET_VALIDATOR_STATUS,
+        derive_keccak256_id!("getValidatorStatus(address)")
+    );
+    assert_eq!(
+        SIG_GET_VALIDATOR_BY_OWNER,
+        derive_keccak256_id!("getValidatorByOwner(address)")
+    );
+    assert_eq!(SIG_GET_VALIDATORS, derive_keccak256_id!("getValidators()"));
+    assert_eq!(
+        SIG_ADD_VALIDATOR,
+        derive_keccak256_id!("addValidator(address)")
+    );
+    assert_eq!(
+        SIG_REMOVE_VALIDATOR,
+        derive_keccak256_id!("removeValidator(address)")
+    );
+    assert_eq!(
+        SIG_ACTIVATE_VALIDATOR,
+        derive_keccak256_id!("activateValidator(address)")
+    );
+    assert_eq!(
+        SIG_DISABLE_VALIDATOR,
+        derive_keccak256_id!("disableValidator(address)")
+    );
+    assert_eq!(
+        SIG_CHANGE_VALIDATOR_COMMISSION_RATE,
+        derive_keccak256_id!("changeValidatorCommissionRate(address,uint16)")
+    );
+    assert_eq!(
+        SIG_CHANGE_VALIDATOR_OWNER,
+        derive_keccak256_id!("changeValidatorOwner(address,address)")
+    );
+}
+
+#[test]
+fn initializes_registry_and_preserves_solidity_read_abi() {
+    let governance = Address::with_last_byte(0xa0);
+    let validator_a = Address::with_last_byte(0x01);
+    let validator_b = Address::with_last_byte(0x02);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(governance);
+
+    assert_eq!(
+        harness.initialize(
+            governance,
+            vec![validator_a, validator_b],
+            vec![
+                U256::from(10) * BALANCE_COMPACT_PRECISION,
+                U256::from(20) * BALANCE_COMPACT_PRECISION,
+            ],
+            500,
+        ),
+        ExitCode::Ok
+    );
+
+    let (exit, output) = harness.call(encode_empty_call(SIG_OWNER));
+    assert_eq!(exit, ExitCode::Ok);
+    assert_eq!(decode_output::<Address>(&output), governance);
+
+    let (_, output) = harness.call(encode_empty_call(SIG_GET_VALIDATORS));
+    assert_eq!(
+        decode_output::<Vec<Address>>(&output),
+        vec![validator_b, validator_a],
+        "top validators are ordered by stake descending"
+    );
+
+    let (_, output) = harness.call(encode_call(
+        SIG_GET_VALIDATOR_STATUS,
+        &AddressCommand { value: validator_a },
+    ));
+    let status: (Address, u8, U256, u32, u64, u64, u64, u16) = decode_output(&output);
+    assert_eq!(
+        status,
+        (
+            validator_a,
+            STATUS_ACTIVE,
+            U256::from(10) * BALANCE_COMPACT_PRECISION,
+            0,
+            0,
+            0,
+            0,
+            500,
+        )
+    );
+}
+
+#[test]
+fn epoch_number_is_rebased_to_initialization_block() {
+    let governance = Address::with_last_byte(0xa0);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(governance);
+    assert_eq!(
+        harness.initialize(governance, Vec::new(), Vec::new(), 0),
+        ExitCode::Ok
+    );
+
+    harness.set_block_number(1_399);
+    let (_, output) = harness.call(encode_empty_call(SIG_CURRENT_EPOCH));
+    assert_eq!(decode_output::<u64>(&output), 1);
+
+    harness.set_block_number(1_400);
+    let (_, output) = harness.call(encode_empty_call(SIG_NEXT_EPOCH));
+    assert_eq!(decode_output::<u64>(&output), 3);
+}
+
+#[test]
+fn governance_lifecycle_updates_active_registry() {
+    let governance = Address::with_last_byte(0xa0);
+    let outsider = Address::with_last_byte(0xb0);
+    let validator = Address::with_last_byte(0x01);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(governance);
+    assert_eq!(
+        harness.initialize(governance, Vec::new(), Vec::new(), 0),
+        ExitCode::Ok
+    );
+
+    harness.set_caller(outsider);
+    let (exit, _) = harness.call(encode_call(
+        SIG_ADD_VALIDATOR,
+        &AddressCommand { value: validator },
+    ));
+    assert_eq!(exit, ExitCode::Panic);
+
+    harness.set_caller(governance);
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_ADD_VALIDATOR,
+                &AddressCommand { value: validator },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    let (_, output) = harness.call(encode_call(
+        SIG_IS_VALIDATOR_ACTIVE,
+        &AddressCommand { value: validator },
+    ));
+    assert!(decode_output::<bool>(&output));
+
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_DISABLE_VALIDATOR,
+                &AddressCommand { value: validator },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+    let (_, output) = harness.call(encode_call(
+        SIG_IS_VALIDATOR_ACTIVE,
+        &AddressCommand { value: validator },
+    ));
+    assert!(!decode_output::<bool>(&output));
+
+    assert_eq!(
+        harness
+            .call(encode_call(
+                SIG_ACTIVATE_VALIDATOR,
+                &AddressCommand { value: validator },
+            ))
+            .0,
+        ExitCode::Ok
+    );
+}
+
+#[test]
+fn initializer_rejects_mismatched_arrays_without_persisting_owner() {
+    let governance = Address::with_last_byte(0xa0);
+    let mut harness = Harness::new(1_000);
+    harness.set_caller(governance);
+
+    assert_eq!(
+        harness.initialize(governance, vec![Address::with_last_byte(1)], Vec::new(), 0,),
+        ExitCode::Panic
+    );
+
+    let (_, output) = harness.call(encode_empty_call(SIG_OWNER));
+    assert_eq!(decode_output::<Address>(&output), Address::ZERO);
+}

--- a/contracts/staking/src/tests.rs
+++ b/contracts/staking/src/tests.rs
@@ -1,5 +1,8 @@
 use super::*;
-use crate::storage::{staking_storage, STATUS_ACTIVE, STATUS_JAIL, STATUS_PENDING};
+use crate::storage::{
+    staking_storage, DelegationOpStorage, UndelegationOpStorage, ValidatorSnapshotStorage,
+    STATUS_ACTIVE, STATUS_JAIL, STATUS_PENDING,
+};
 use crate::types::{
     AddressCommand, BoolCommand, ConfigureCommand, ConfigureDependenciesCommand,
     EpochSignerCommand, RegisterValidatorCommand, TwoAddressesCommand, U256Command, U32Command,
@@ -7,8 +10,9 @@ use crate::types::{
 };
 use fluentbase_sdk::{
     bytes::BytesMut, codec::SolidityABI, derive::derive_keccak256_id, is_engine_metered_precompile,
-    is_execute_using_system_runtime, Address, Bytes, ContractContextV1, ExitCode, B256,
-    GENESIS_GOVERNANCE, GENESIS_STAKING, U256,
+    is_execute_using_system_runtime,
+    storage::{StorageDescriptor, StorageLayout},
+    Address, Bytes, ContractContextV1, ExitCode, B256, GENESIS_GOVERNANCE, GENESIS_STAKING, U256,
 };
 use fluentbase_testing::TestingContextImpl;
 
@@ -36,6 +40,27 @@ where
 
 fn encode_empty_call(selector: u32) -> Vec<u8> {
     selector.to_be_bytes().to_vec()
+}
+
+#[test]
+fn compact_storage_matches_solidity_struct_layouts() {
+    assert_eq!(ValidatorSnapshotStorage::SLOTS, 1);
+    assert_eq!(
+        <ValidatorSnapshotStorage as StorageLayout>::BYTES,
+        32
+    );
+    assert_eq!(DelegationOpStorage::SLOTS, 1);
+    assert_eq!(<DelegationOpStorage as StorageLayout>::BYTES, 22);
+    assert_eq!(UndelegationOpStorage::SLOTS, 1);
+    assert_eq!(<UndelegationOpStorage as StorageLayout>::BYTES, 22);
+
+    let slot = U256::from(7);
+    let snapshot = ValidatorSnapshotStorage::new(slot, 0);
+    assert_eq!(snapshot.total_delegated_accessor().slot(), slot);
+    assert_eq!(snapshot.total_delegated_accessor().offset(), 18);
+    assert_eq!(snapshot.slashes_count_accessor().offset(), 14);
+    assert_eq!(snapshot.commission_rate_accessor().offset(), 12);
+    assert_eq!(snapshot.total_blend_rewards_accessor().offset(), 0);
 }
 
 struct Harness {
@@ -1051,7 +1076,10 @@ fn reward_views_split_blend_between_owner_and_delegators() {
         .entry(2);
     snapshot
         .total_blend_rewards_accessor()
-        .set_checked(&mut harness.sdk, ten_tokens)
+        .set_checked(
+            &mut harness.sdk,
+            math::narrow_reward(ten_tokens).expect("reward fits uint96"),
+        )
         .unwrap();
 
     harness.set_block_number(1_600);
@@ -1491,7 +1519,7 @@ fn lifecycle_transitions_preserve_next_epoch_snapshot_frontier() {
             .total_delegated_accessor()
             .get_checked(&harness.sdk)
             .unwrap(),
-        stake
+        math::compact_balance(stake).unwrap()
     );
 
     assert_eq!(

--- a/contracts/staking/src/types.rs
+++ b/contracts/staking/src/types.rs
@@ -27,6 +27,31 @@ pub struct TwoAddressesCommand {
 }
 
 #[derive(Default, Debug, Codec)]
+pub struct ValidatorDelegatorCommand {
+    pub validator: Address,
+    pub delegator: Address,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct AddressAmountCommand {
+    pub validator: Address,
+    pub amount: U256,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct ValidatorBlockCommand {
+    pub validator: Address,
+    pub block_number: U256,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct RegisterValidatorCommand {
+    pub validator: Address,
+    pub commission_rate: u16,
+    pub initial_stake: U256,
+}
+
+#[derive(Default, Debug, Codec)]
 pub struct ConfigureCommand {
     pub staking_token: Address,
     pub active_validators_length: u64,

--- a/contracts/staking/src/types.rs
+++ b/contracts/staking/src/types.rs
@@ -1,5 +1,5 @@
 use alloc::vec::Vec;
-use fluentbase_sdk::{codec::Codec, Address, U256};
+use fluentbase_sdk::{codec::Codec, Address, B256, U256};
 
 #[derive(Default, Debug, Codec)]
 pub struct InitializeCommand {
@@ -45,6 +45,12 @@ pub struct ValidatorBlockCommand {
 }
 
 #[derive(Default, Debug, Codec)]
+pub struct ValidatorEpochCommand {
+    pub validator: Address,
+    pub before_epoch: u64,
+}
+
+#[derive(Default, Debug, Codec)]
 pub struct RegisterValidatorCommand {
     pub validator: Address,
     pub commission_rate: u16,
@@ -54,8 +60,82 @@ pub struct RegisterValidatorCommand {
 #[derive(Default, Debug, Codec)]
 pub struct ConfigureCommand {
     pub staking_token: Address,
-    pub active_validators_length: u64,
-    pub epoch_block_interval: u64,
+    pub active_validators_length: u32,
+    pub epoch_block_interval: u32,
+    pub felony_threshold: u32,
+    pub validator_jail_epoch_length: u32,
+    pub undelegate_period: u32,
     pub min_validator_stake_amount: U256,
     pub min_staking_amount: U256,
+    pub dpos_activation_block: u64,
+    pub bls_verifier: Address,
+    pub evidence_decoder: Address,
+    pub min_undelegate_blocks: U256,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct ConfigureDependenciesCommand {
+    pub liveness_slashing: Address,
+    pub blend_reserve: Address,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct U32Command {
+    pub value: u32,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct U64Command {
+    pub value: u64,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct U256Command {
+    pub value: U256,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct BoolCommand {
+    pub value: bool,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, Codec)]
+pub struct ConsensusKeys {
+    pub bls_pubkey: Vec<u8>,
+    pub peer_pubkey: B256,
+    pub activation_epoch: u64,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct SetConsensusKeysCommand {
+    pub validator: Address,
+    pub bls_pubkey_uncompressed: Vec<u8>,
+    pub bls_pop_uncompressed: Vec<u8>,
+    pub peer_pubkey: B256,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct EpochSignerCommand {
+    pub epoch: u64,
+    pub signer_idx: u32,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct EquivocationCommand {
+    pub evidence: Vec<u8>,
+    pub pk_uncompressed: Vec<u8>,
+    pub sig1_uncompressed: Vec<u8>,
+    pub sig2_uncompressed: Vec<u8>,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct DecodedEvidence {
+    pub epoch: u64,
+    pub signer_idx: u32,
+    pub kind1: u8,
+    pub msg1: Vec<u8>,
+    pub sig1: Vec<u8>,
+    pub kind2: u8,
+    pub msg2: Vec<u8>,
+    pub sig2: Vec<u8>,
 }

--- a/contracts/staking/src/types.rs
+++ b/contracts/staking/src/types.rs
@@ -1,3 +1,5 @@
+//! Internal representations of Solidity ABI commands and dependency results.
+
 use alloc::vec::Vec;
 use fluentbase_sdk::{codec::Codec, Address, B256, U256};
 

--- a/contracts/staking/src/types.rs
+++ b/contracts/staking/src/types.rs
@@ -1,0 +1,36 @@
+use alloc::vec::Vec;
+use fluentbase_sdk::{codec::Codec, Address, U256};
+
+#[derive(Default, Debug, Codec)]
+pub struct InitializeCommand {
+    pub initial_owner: Address,
+    pub validators: Vec<Address>,
+    pub initial_stakes: Vec<U256>,
+    pub commission_rate: u16,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct AddressCommand {
+    pub value: Address,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct AddressU16Command {
+    pub validator: Address,
+    pub value: u16,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct TwoAddressesCommand {
+    pub validator: Address,
+    pub value: Address,
+}
+
+#[derive(Default, Debug, Codec)]
+pub struct ConfigureCommand {
+    pub staking_token: Address,
+    pub active_validators_length: u64,
+    pub epoch_block_interval: u64,
+    pub min_validator_stake_amount: U256,
+    pub min_staking_amount: U256,
+}

--- a/contracts/staking/src/util.rs
+++ b/contracts/staking/src/util.rs
@@ -1,0 +1,195 @@
+use alloc::vec::Vec;
+use fluentbase_sdk::{
+    bytes::BytesMut,
+    codec::{Encoder, SolidityABI},
+    evm::write_evm_exit_message,
+    Address, ContextReader, ExitCode, SharedAPI, U256,
+};
+
+use crate::{
+    consts::*,
+    events, math,
+    storage::{current_epoch, staking_storage, STATUS_ACTIVE, STATUS_NOT_FOUND},
+    types::AddressCommand,
+};
+
+pub fn revert<SDK: SharedAPI>(sdk: &mut SDK, code: u32) -> Result<(), ExitCode> {
+    write_evm_exit_message(code, |slice| sdk.write(slice));
+    Err(ExitCode::Panic)
+}
+
+pub fn ensure_non_payable<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    if !sdk.context().contract_value().is_zero() {
+        return Err(ExitCode::Panic);
+    }
+    Ok(())
+}
+
+pub fn ensure_mutable<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    if sdk.context().contract_is_static() {
+        return Err(ExitCode::StateChangeDuringStaticCall);
+    }
+    Ok(())
+}
+
+pub fn ensure_initialized<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    if !staking_storage().initialized_accessor().get_checked(sdk)? {
+        return revert(sdk, ERR_NOT_INITIALIZED);
+    }
+    Ok(())
+}
+
+pub fn ensure_governance<SDK: SharedAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
+    ensure_initialized(sdk)?;
+    let governance = staking_storage()
+        .config_accessor()
+        .governance_accessor()
+        .get_checked(sdk)?;
+    if sdk.context().contract_caller() != governance {
+        return revert(sdk, ERR_ONLY_GOVERNANCE);
+    }
+    Ok(())
+}
+
+pub fn decode<T>(input: &[u8]) -> Result<T, ExitCode>
+where
+    T: Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    SolidityABI::<T>::decode(&input, 0).map_err(|_| ExitCode::MalformedBuiltinParams)
+}
+
+pub fn write_abi<SDK, T>(sdk: &mut SDK, value: &T) -> Result<(), ExitCode>
+where
+    SDK: SharedAPI,
+    T: Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let mut output = BytesMut::new();
+    SolidityABI::<T>::encode(value, &mut output, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    sdk.write(output.freeze());
+    Ok(())
+}
+
+pub fn address_arg(input: &[u8]) -> Result<Address, ExitCode> {
+    Ok(decode::<AddressCommand>(input)?.value)
+}
+
+pub fn validator_status<SDK: SharedAPI>(sdk: &SDK, validator: Address) -> Result<u8, ExitCode> {
+    staking_storage()
+        .validators_accessor()
+        .entry(validator)
+        .status_accessor()
+        .get_checked(sdk)
+}
+
+pub fn total_delegated<SDK: SharedAPI>(sdk: &SDK, validator: Address) -> Result<U256, ExitCode> {
+    staking_storage()
+        .validators_accessor()
+        .entry(validator)
+        .total_delegated_accessor()
+        .get_checked(sdk)
+}
+
+pub fn set_validator<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    validator_owner: Address,
+    validator_status: u8,
+    commission_rate: u16,
+    stake: U256,
+    changed_at: u64,
+) -> Result<(), ExitCode> {
+    if validator.is_zero() {
+        return revert(sdk, ERR_ZERO_VALIDATOR);
+    }
+    if validator_owner.is_zero() {
+        return revert(sdk, ERR_ZERO_OWNER);
+    }
+    if commission_rate > COMMISSION_RATE_MAX {
+        return revert(sdk, ERR_BAD_COMMISSION_RATE);
+    }
+    if math::compact_balance(stake).is_none() {
+        return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
+    }
+
+    let storage = staking_storage();
+    let record = storage.validators_accessor().entry(validator);
+    if record.status_accessor().get_checked(sdk)? != STATUS_NOT_FOUND {
+        return revert(sdk, ERR_VALIDATOR_ALREADY_EXISTS);
+    }
+    if !storage
+        .owner_validators_accessor()
+        .entry(validator_owner)
+        .get_checked(sdk)?
+        .is_zero()
+    {
+        return revert(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE);
+    }
+
+    record.owner_accessor().set_checked(sdk, validator_owner)?;
+    record
+        .status_accessor()
+        .set_checked(sdk, validator_status)?;
+    record.total_delegated_accessor().set_checked(sdk, stake)?;
+    record.changed_at_accessor().set_checked(sdk, changed_at)?;
+    record
+        .commission_rate_accessor()
+        .set_checked(sdk, commission_rate)?;
+    storage
+        .owner_validators_accessor()
+        .entry(validator_owner)
+        .set_checked(sdk, validator)?;
+
+    if validator_status == STATUS_ACTIVE {
+        storage
+            .active_validators_accessor()
+            .push_checked(sdk, validator)?;
+    }
+    events::ValidatorAdded {
+        validator,
+        owner: validator_owner,
+        status: validator_status,
+        commission_rate,
+    }
+    .emit(sdk)?;
+    Ok(())
+}
+
+pub fn selected_validators<SDK: SharedAPI>(sdk: &SDK) -> Result<Vec<Address>, ExitCode> {
+    let storage = staking_storage();
+    let active = storage.active_validators_accessor();
+    let active_len = active.len_checked(sdk)?;
+    let mut ranked = Vec::with_capacity(active_len as usize);
+    for index in 0..active_len {
+        let validator = active.at(index).get_checked(sdk)?;
+        if validator_status(sdk, validator)? == STATUS_ACTIVE {
+            ranked.push((validator, total_delegated(sdk, validator)?));
+        }
+    }
+    ranked.sort_unstable_by(|(a_address, a_stake), (b_address, b_stake)| {
+        b_stake.cmp(a_stake).then_with(|| a_address.cmp(b_address))
+    });
+    let cap = storage
+        .config_accessor()
+        .active_validators_length_accessor()
+        .get_checked(sdk)? as usize;
+    ranked.truncate(cap);
+    Ok(ranked.into_iter().map(|(validator, _)| validator).collect())
+}
+
+pub fn emit_modified<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
+    let record = staking_storage().validators_accessor().entry(validator);
+    events::ValidatorModified {
+        validator,
+        owner: record.owner_accessor().get_checked(sdk)?,
+        status: record.status_accessor().get_checked(sdk)?,
+        commission_rate: record.commission_rate_accessor().get_checked(sdk)?,
+    }
+    .emit(sdk)
+}
+
+pub fn next_epoch<SDK: SharedAPI>(sdk: &SDK) -> Result<u64, ExitCode> {
+    current_epoch(sdk)?
+        .checked_add(1)
+        .ok_or(ExitCode::IntegerOverflow)
+}

--- a/contracts/staking/src/util.rs
+++ b/contracts/staking/src/util.rs
@@ -1,8 +1,8 @@
 use alloc::vec::Vec;
 use fluentbase_sdk::{
+    byteorder::BE,
     bytes::BytesMut,
-    codec::{Encoder, SolidityABI},
-    evm::write_evm_exit_message,
+    codec::{Encoder, FunctionArgs, SolidityABI},
     Address, ContextReader, ExitCode, SharedAPI, U256,
 };
 
@@ -16,7 +16,21 @@ use crate::{
 };
 
 pub fn revert<SDK: SharedAPI>(sdk: &mut SDK, code: u32) -> Result<(), ExitCode> {
-    write_evm_exit_message(code, |slice| sdk.write(slice));
+    sdk.write(code.to_be_bytes());
+    Err(ExitCode::Panic)
+}
+
+pub fn revert_with<SDK, T>(sdk: &mut SDK, code: u32, value: &T) -> Result<(), ExitCode>
+where
+    SDK: SharedAPI,
+    T: Encoder<fluentbase_sdk::byteorder::BE, 32, true, false>,
+{
+    let mut params = BytesMut::new();
+    SolidityABI::<T>::encode(value, &mut params, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    let mut output = code.to_be_bytes().to_vec();
+    output.extend_from_slice(&params);
+    sdk.write(output);
     Err(ExitCode::Panic)
 }
 
@@ -60,6 +74,17 @@ where
     SolidityABI::<T>::decode(&input, 0).map_err(|_| ExitCode::MalformedBuiltinParams)
 }
 
+/// Decode a Solidity function's parameter tuple.
+///
+/// Dynamic function arguments omit the outer tuple offset used when a
+/// dynamic Rust struct is encoded as a standalone ABI value.
+pub fn decode_args<T>(input: &[u8]) -> Result<T, ExitCode>
+where
+    T: FunctionArgs<BE, 32, true, false>,
+{
+    SolidityABI::<T>::decode_function_args(&input).map_err(|_| ExitCode::MalformedBuiltinParams)
+}
+
 pub fn write_abi<SDK, T>(sdk: &mut SDK, value: &T) -> Result<(), ExitCode>
 where
     SDK: SharedAPI,
@@ -67,6 +92,19 @@ where
 {
     let mut output = BytesMut::new();
     SolidityABI::<T>::encode(value, &mut output, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    sdk.write(output.freeze());
+    Ok(())
+}
+
+/// Encode a Solidity function's return tuple without an outer tuple offset.
+pub fn write_returns<SDK, T>(sdk: &mut SDK, value: &T) -> Result<(), ExitCode>
+where
+    SDK: SharedAPI,
+    T: FunctionArgs<BE, 32, true, false>,
+{
+    let mut output = BytesMut::new();
+    SolidityABI::<T>::encode_function_args(value, &mut output)
         .map_err(|_| ExitCode::MalformedBuiltinParams)?;
     sdk.write(output.freeze());
     Ok(())
@@ -104,7 +142,7 @@ pub fn set_validator<SDK: SharedAPI>(
         return revert(sdk, ERR_ZERO_OWNER);
     }
     if commission_rate > COMMISSION_RATE_MAX {
-        return revert(sdk, ERR_BAD_COMMISSION_RATE);
+        return revert_with(sdk, ERR_BAD_COMMISSION_RATE, &commission_rate);
     }
     if math::compact_balance(stake).is_none() {
         return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
@@ -113,7 +151,7 @@ pub fn set_validator<SDK: SharedAPI>(
     let storage = staking_storage();
     let record = storage.validators_accessor().entry(validator);
     if record.status_accessor().get_checked(sdk)? != STATUS_NOT_FOUND {
-        return revert(sdk, ERR_VALIDATOR_ALREADY_EXISTS);
+        return revert_with(sdk, ERR_VALIDATOR_ALREADY_EXISTS, &validator);
     }
     if !storage
         .owner_validators_accessor()
@@ -121,7 +159,7 @@ pub fn set_validator<SDK: SharedAPI>(
         .get_checked(sdk)?
         .is_zero()
     {
-        return revert(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE);
+        return revert_with(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE, &validator);
     }
 
     record.owner_accessor().set_checked(sdk, validator_owner)?;
@@ -150,8 +188,13 @@ pub fn set_validator<SDK: SharedAPI>(
         .validator_delegations_accessor()
         .entry(validator)
         .entry(validator_owner);
-    if delegation.delegate_queue_accessor().len_checked(sdk)? != 0 {
-        return revert(sdk, ERR_DELEGATION_QUEUE_NOT_EMPTY);
+    let delegation_queue_length = delegation.delegate_queue_accessor().len_checked(sdk)?;
+    if delegation_queue_length != 0 {
+        return revert_with(
+            sdk,
+            ERR_DELEGATION_QUEUE_NOT_EMPTY,
+            &U256::from(delegation_queue_length),
+        );
     }
     let initial = delegation.delegate_queue_accessor().grow_checked(sdk)?;
     initial.amount_accessor().set_checked(sdk, stake)?;
@@ -162,6 +205,12 @@ pub fn set_validator<SDK: SharedAPI>(
             .active_validators_accessor()
             .push_checked(sdk, validator)?;
     }
+    seed_selection_membership(
+        sdk,
+        validator,
+        validator_status == STATUS_ACTIVE,
+        changed_at,
+    )?;
     events::ValidatorAdded {
         validator,
         owner: validator_owner,
@@ -172,27 +221,169 @@ pub fn set_validator<SDK: SharedAPI>(
     Ok(())
 }
 
+pub fn seed_selection_membership<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    visible: bool,
+    since_epoch: u64,
+) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    if visible {
+        storage
+            .selection_roster_accessor()
+            .push_checked(sdk, validator)?;
+    }
+    let membership = storage.selection_membership_accessor().entry(validator);
+    membership.visible_accessor().set_checked(sdk, visible)?;
+    membership.prev_visible_accessor().set_checked(sdk, false)?;
+    membership
+        .effective_from_accessor()
+        .set_checked(sdk, since_epoch)?;
+    membership.rostered_accessor().set_checked(sdk, visible)
+}
+
+pub fn ensure_rostered<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    let membership = storage.selection_membership_accessor().entry(validator);
+    if !membership.rostered_accessor().get_checked(sdk)? {
+        storage
+            .selection_roster_accessor()
+            .push_checked(sdk, validator)?;
+        membership.rostered_accessor().set_checked(sdk, true)?;
+    }
+    Ok(())
+}
+
+pub fn set_selection_visible<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    visible: bool,
+    at_epoch: u64,
+) -> Result<(), ExitCode> {
+    let membership = staking_storage()
+        .selection_membership_accessor()
+        .entry(validator);
+    let effective = at_epoch.checked_add(1).ok_or(ExitCode::IntegerOverflow)?;
+    if membership.effective_from_accessor().get_checked(sdk)? == effective {
+        membership.visible_accessor().set_checked(sdk, visible)?;
+    } else {
+        let previous = membership.visible_accessor().get_checked(sdk)?;
+        membership
+            .prev_visible_accessor()
+            .set_checked(sdk, previous)?;
+        membership.visible_accessor().set_checked(sdk, visible)?;
+        membership
+            .effective_from_accessor()
+            .set_checked(sdk, effective)?;
+    }
+    Ok(())
+}
+
+pub fn selection_visible_at<SDK: SharedAPI>(
+    sdk: &SDK,
+    validator: Address,
+    epoch: u64,
+) -> Result<bool, ExitCode> {
+    let membership = staking_storage()
+        .selection_membership_accessor()
+        .entry(validator);
+    if epoch >= membership.effective_from_accessor().get_checked(sdk)? {
+        membership.visible_accessor().get_checked(sdk)
+    } else {
+        membership.prev_visible_accessor().get_checked(sdk)
+    }
+}
+
+pub fn remove_selection_member<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+) -> Result<(), ExitCode> {
+    let storage = staking_storage();
+    let roster = storage.selection_roster_accessor();
+    let len = roster.len_checked(sdk)?;
+    for index in 0..len {
+        if roster.at(index).get_checked(sdk)? != validator {
+            continue;
+        }
+        if index + 1 != len {
+            let last = roster.at(len - 1).get_checked(sdk)?;
+            roster.at(index).set_checked(sdk, last)?;
+        }
+        roster.pop_checked(sdk)?;
+        break;
+    }
+    let membership = storage.selection_membership_accessor().entry(validator);
+    membership.visible_accessor().set_checked(sdk, false)?;
+    membership.prev_visible_accessor().set_checked(sdk, false)?;
+    membership.effective_from_accessor().set_checked(sdk, 0)?;
+    membership.rostered_accessor().set_checked(sdk, false)
+}
+
+pub fn selected_validators_at<SDK: SharedAPI>(
+    sdk: &SDK,
+    epoch: u64,
+) -> Result<Vec<Address>, ExitCode> {
+    let storage = staking_storage();
+    let roster = storage.selection_roster_accessor();
+    let len = roster.len_checked(sdk)?;
+    let mut candidates = Vec::with_capacity(len as usize);
+    for index in 0..len {
+        let validator = roster.at(index).get_checked(sdk)?;
+        if selection_visible_at(sdk, validator, epoch)? {
+            candidates.push(validator);
+        }
+    }
+    let cap = storage
+        .config_accessor()
+        .active_validators_length_accessor()
+        .get_checked(sdk)? as usize;
+    top_k_by_stake_at(sdk, candidates, epoch, cap)
+}
+
 pub fn selected_validators<SDK: SharedAPI>(sdk: &SDK) -> Result<Vec<Address>, ExitCode> {
     let storage = staking_storage();
     let active = storage.active_validators_accessor();
     let active_len = active.len_checked(sdk)?;
     let epoch = current_epoch(sdk)?;
-    let mut ranked = Vec::with_capacity(active_len as usize);
+    let mut candidates = Vec::with_capacity(active_len as usize);
     for index in 0..active_len {
         let validator = active.at(index).get_checked(sdk)?;
         if validator_status(sdk, validator)? == STATUS_ACTIVE {
-            ranked.push((validator, validator_total_at(sdk, validator, epoch)?));
+            candidates.push(validator);
         }
     }
-    ranked.sort_unstable_by(|(a_address, a_stake), (b_address, b_stake)| {
-        b_stake.cmp(a_stake).then_with(|| a_address.cmp(b_address))
-    });
     let cap = storage
         .config_accessor()
         .active_validators_length_accessor()
         .get_checked(sdk)? as usize;
-    ranked.truncate(cap);
-    Ok(ranked.into_iter().map(|(validator, _)| validator).collect())
+    top_k_by_stake_at(sdk, candidates, epoch, cap)
+}
+
+/// Match Solidity's partial selection sort exactly.
+///
+/// Equal-stake candidates retain roster order; an address tie-breaker would
+/// choose a different committee at the top-k boundary.
+fn top_k_by_stake_at<SDK: SharedAPI>(
+    sdk: &SDK,
+    mut candidates: Vec<Address>,
+    epoch: u64,
+    cap: usize,
+) -> Result<Vec<Address>, ExitCode> {
+    let k = core::cmp::min(cap, candidates.len());
+    for index in 0..k {
+        let mut next = index;
+        let mut max_stake = validator_total_at(sdk, candidates[next], epoch)?;
+        for (candidate, validator) in candidates.iter().enumerate().skip(index + 1) {
+            let stake = validator_total_at(sdk, *validator, epoch)?;
+            if stake > max_stake {
+                next = candidate;
+                max_stake = stake;
+            }
+        }
+        candidates.swap(index, next);
+    }
+    candidates.truncate(k);
+    Ok(candidates)
 }
 
 pub fn emit_modified<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
@@ -248,6 +439,45 @@ pub fn touch_validator_snapshot<SDK: SharedAPI>(
     Ok(snapshot)
 }
 
+pub fn touch_snapshot_at_or_before<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    epoch: u64,
+) -> Result<ValidatorSnapshotStorage, ExitCode> {
+    let storage = staking_storage();
+    let snapshots = storage.validator_snapshots_accessor().entry(validator);
+    let snapshot = snapshots.entry(epoch);
+    if snapshot.initialized_accessor().get_checked(sdk)? {
+        return Ok(snapshot);
+    }
+    let record = storage.validators_accessor().entry(validator);
+    let mut lookup = core::cmp::min(epoch, record.changed_at_accessor().get_checked(sdk)?);
+    loop {
+        let base = snapshots.entry(lookup);
+        if base.initialized_accessor().get_checked(sdk)? {
+            snapshot.initialized_accessor().set_checked(sdk, true)?;
+            snapshot
+                .total_delegated_accessor()
+                .set_checked(sdk, base.total_delegated_accessor().get_checked(sdk)?)?;
+            snapshot
+                .commission_rate_accessor()
+                .set_checked(sdk, base.commission_rate_accessor().get_checked(sdk)?)?;
+            snapshot
+                .slashes_count_accessor()
+                .set_checked(sdk, base.slashes_count_accessor().get_checked(sdk)?)?;
+            if epoch > record.changed_at_accessor().get_checked(sdk)? {
+                record.changed_at_accessor().set_checked(sdk, epoch)?;
+            }
+            return Ok(snapshot);
+        }
+        if lookup == 0 {
+            snapshot.initialized_accessor().set_checked(sdk, true)?;
+            return Ok(snapshot);
+        }
+        lookup -= 1;
+    }
+}
+
 pub fn validator_total_at<SDK: SharedAPI>(
     sdk: &SDK,
     validator: Address,
@@ -286,6 +516,15 @@ pub fn erc20_transfer_from_input(
     Ok(input)
 }
 
+pub fn erc20_transfer_input(to: Address, amount: U256) -> Result<Vec<u8>, ExitCode> {
+    let mut params = BytesMut::new();
+    SolidityABI::<(Address, U256)>::encode(&(to, amount), &mut params, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    let mut input = SIG_ERC20_TRANSFER.to_be_bytes().to_vec();
+    input.extend_from_slice(&params);
+    Ok(input)
+}
+
 pub fn safe_transfer_from<SDK: SharedAPI>(
     sdk: &mut SDK,
     from: Address,
@@ -300,6 +539,36 @@ pub fn safe_transfer_from<SDK: SharedAPI>(
     }
     let recipient = sdk.context().contract_address();
     let input = erc20_transfer_from_input(from, recipient, amount)?;
+    let result = sdk.call(token, U256::ZERO, &input, None);
+    if !result.status.is_ok() {
+        sdk.write(result.data);
+        return Err(result.status);
+    }
+    if !result.data.is_empty()
+        && !SolidityABI::<bool>::decode(&result.data, 0)
+            .map_err(|_| ExitCode::MalformedBuiltinParams)?
+    {
+        return revert(sdk, ERR_STAKING_TOKEN_CALL_FAILED);
+    }
+    Ok(())
+}
+
+pub fn safe_transfer<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    recipient: Address,
+    amount: U256,
+) -> Result<(), ExitCode> {
+    if amount.is_zero() {
+        return Ok(());
+    }
+    let token = staking_storage()
+        .config_accessor()
+        .staking_token_accessor()
+        .get_checked(sdk)?;
+    if token.is_zero() {
+        return revert(sdk, ERR_ZERO_STAKING_TOKEN);
+    }
+    let input = erc20_transfer_input(recipient, amount)?;
     let result = sdk.call(token, U256::ZERO, &input, None);
     if !result.status.is_ok() {
         sdk.write(result.data);

--- a/contracts/staking/src/util.rs
+++ b/contracts/staking/src/util.rs
@@ -146,9 +146,9 @@ pub fn set_validator<SDK: SharedAPI>(
     if commission_rate > COMMISSION_RATE_MAX {
         return revert_with(sdk, ERR_BAD_COMMISSION_RATE, &commission_rate);
     }
-    if math::compact_balance(stake).is_none() {
+    let Some(compact_stake) = math::compact_balance(stake) else {
         return revert(sdk, ERR_WRONG_AMOUNT_PRECISION);
-    }
+    };
 
     let storage = staking_storage();
     let record = storage.validators_accessor().entry(validator);
@@ -190,10 +190,9 @@ pub fn set_validator<SDK: SharedAPI>(
         .validator_snapshots_accessor()
         .entry(validator)
         .entry(changed_at);
-    snapshot.initialized_accessor().set_checked(sdk, true)?;
     snapshot
         .total_delegated_accessor()
-        .set_checked(sdk, stake)?;
+        .set_checked(sdk, compact_stake)?;
     snapshot
         .commission_rate_accessor()
         .set_checked(sdk, commission_rate)?;
@@ -211,7 +210,9 @@ pub fn set_validator<SDK: SharedAPI>(
         );
     }
     let initial = delegation.delegate_queue_accessor().grow_checked(sdk)?;
-    initial.amount_accessor().set_checked(sdk, stake)?;
+    initial
+        .amount_accessor()
+        .set_checked(sdk, compact_stake)?;
     initial.epoch_accessor().set_checked(sdk, changed_at)?;
 
     if validator_status == STATUS_ACTIVE {
@@ -436,23 +437,23 @@ pub fn touch_validator_snapshot<SDK: SharedAPI>(
     let storage = staking_storage();
     let snapshots = storage.validator_snapshots_accessor().entry(validator);
     let snapshot = snapshots.entry(epoch);
-    if snapshot.initialized_accessor().get_checked(sdk)? {
+    if !snapshot
+        .total_delegated_accessor()
+        .get_checked(sdk)?
+        .is_zero()
+    {
         return Ok(snapshot);
     }
 
     let record = storage.validators_accessor().entry(validator);
     let changed_at = record.changed_at_accessor().get_checked(sdk)?;
     let previous = snapshots.entry(changed_at);
-    snapshot.initialized_accessor().set_checked(sdk, true)?;
     snapshot
         .total_delegated_accessor()
         .set_checked(sdk, previous.total_delegated_accessor().get_checked(sdk)?)?;
     snapshot
         .commission_rate_accessor()
         .set_checked(sdk, previous.commission_rate_accessor().get_checked(sdk)?)?;
-    snapshot
-        .slashes_count_accessor()
-        .set_checked(sdk, previous.slashes_count_accessor().get_checked(sdk)?)?;
     if epoch > changed_at {
         record.changed_at_accessor().set_checked(sdk, epoch)?;
     }
@@ -467,7 +468,11 @@ pub fn touch_snapshot_at_or_before<SDK: SharedAPI>(
     let storage = staking_storage();
     let snapshots = storage.validator_snapshots_accessor().entry(validator);
     let snapshot = snapshots.entry(epoch);
-    if snapshot.initialized_accessor().get_checked(sdk)? {
+    if !snapshot
+        .total_delegated_accessor()
+        .get_checked(sdk)?
+        .is_zero()
+    {
         return Ok(snapshot);
     }
     let record = storage.validators_accessor().entry(validator);
@@ -475,31 +480,36 @@ pub fn touch_snapshot_at_or_before<SDK: SharedAPI>(
         .first_snapshot_epoch_p1_accessor()
         .get_checked(sdk)?;
     if first_p1 == 0 || epoch < first_p1 - 1 {
-        snapshot.initialized_accessor().set_checked(sdk, true)?;
         return Ok(snapshot);
     }
     let floor = first_p1 - 1;
     let mut lookup = core::cmp::min(epoch, record.changed_at_accessor().get_checked(sdk)?);
     loop {
         let base = snapshots.entry(lookup);
-        if base.initialized_accessor().get_checked(sdk)? {
-            snapshot.initialized_accessor().set_checked(sdk, true)?;
+        if lookup == record.changed_at_accessor().get_checked(sdk)?
+            || !base
+                .total_delegated_accessor()
+                .get_checked(sdk)?
+                .is_zero()
+            || !base
+                .total_blend_rewards_accessor()
+                .get_checked(sdk)?
+                .is_zero()
+            || base.commission_rate_accessor().get_checked(sdk)? != 0
+            || base.slashes_count_accessor().get_checked(sdk)? != 0
+        {
             snapshot
                 .total_delegated_accessor()
                 .set_checked(sdk, base.total_delegated_accessor().get_checked(sdk)?)?;
             snapshot
                 .commission_rate_accessor()
                 .set_checked(sdk, base.commission_rate_accessor().get_checked(sdk)?)?;
-            snapshot
-                .slashes_count_accessor()
-                .set_checked(sdk, base.slashes_count_accessor().get_checked(sdk)?)?;
             if epoch > record.changed_at_accessor().get_checked(sdk)? {
                 record.changed_at_accessor().set_checked(sdk, epoch)?;
             }
             return Ok(snapshot);
         }
         if lookup == floor {
-            snapshot.initialized_accessor().set_checked(sdk, true)?;
             return Ok(snapshot);
         }
         lookup -= 1;
@@ -525,11 +535,21 @@ pub fn validator_total_at<SDK: SharedAPI>(
     }
     let floor = first_p1 - 1;
     let mut lookup = core::cmp::min(epoch, record.changed_at_accessor().get_checked(sdk)?);
+    let changed_at = record.changed_at_accessor().get_checked(sdk)?;
     let snapshots = storage.validator_snapshots_accessor().entry(validator);
     loop {
         let snapshot = snapshots.entry(lookup);
-        if snapshot.initialized_accessor().get_checked(sdk)? {
-            return snapshot.total_delegated_accessor().get_checked(sdk);
+        let compact = snapshot.total_delegated_accessor().get_checked(sdk)?;
+        if lookup == changed_at
+            || !compact.is_zero()
+            || !snapshot
+                .total_blend_rewards_accessor()
+                .get_checked(sdk)?
+                .is_zero()
+            || snapshot.commission_rate_accessor().get_checked(sdk)? != 0
+            || snapshot.slashes_count_accessor().get_checked(sdk)? != 0
+        {
+            return Ok(math::expand_balance(compact));
         }
         if lookup == floor {
             return Ok(U256::ZERO);

--- a/contracts/staking/src/util.rs
+++ b/contracts/staking/src/util.rs
@@ -1,3 +1,5 @@
+//! Shared ABI, validator-selection, snapshot, and ERC-20 helpers.
+
 use alloc::vec::Vec;
 use fluentbase_sdk::{
     byteorder::BE,

--- a/contracts/staking/src/util.rs
+++ b/contracts/staking/src/util.rs
@@ -9,7 +9,9 @@ use fluentbase_sdk::{
 use crate::{
     consts::*,
     events, math,
-    storage::{current_epoch, staking_storage, STATUS_ACTIVE, STATUS_NOT_FOUND},
+    storage::{
+        current_epoch, staking_storage, ValidatorSnapshotStorage, STATUS_ACTIVE, STATUS_NOT_FOUND,
+    },
     types::AddressCommand,
 };
 
@@ -83,11 +85,7 @@ pub fn validator_status<SDK: SharedAPI>(sdk: &SDK, validator: Address) -> Result
 }
 
 pub fn total_delegated<SDK: SharedAPI>(sdk: &SDK, validator: Address) -> Result<U256, ExitCode> {
-    staking_storage()
-        .validators_accessor()
-        .entry(validator)
-        .total_delegated_accessor()
-        .get_checked(sdk)
+    validator_total_at(sdk, validator, current_epoch(sdk)?)
 }
 
 pub fn set_validator<SDK: SharedAPI>(
@@ -130,15 +128,34 @@ pub fn set_validator<SDK: SharedAPI>(
     record
         .status_accessor()
         .set_checked(sdk, validator_status)?;
-    record.total_delegated_accessor().set_checked(sdk, stake)?;
     record.changed_at_accessor().set_checked(sdk, changed_at)?;
-    record
-        .commission_rate_accessor()
-        .set_checked(sdk, commission_rate)?;
     storage
         .owner_validators_accessor()
         .entry(validator_owner)
         .set_checked(sdk, validator)?;
+
+    let snapshot = storage
+        .validator_snapshots_accessor()
+        .entry(validator)
+        .entry(changed_at);
+    snapshot.initialized_accessor().set_checked(sdk, true)?;
+    snapshot
+        .total_delegated_accessor()
+        .set_checked(sdk, stake)?;
+    snapshot
+        .commission_rate_accessor()
+        .set_checked(sdk, commission_rate)?;
+
+    let delegation = storage
+        .validator_delegations_accessor()
+        .entry(validator)
+        .entry(validator_owner);
+    if delegation.delegate_queue_accessor().len_checked(sdk)? != 0 {
+        return revert(sdk, ERR_DELEGATION_QUEUE_NOT_EMPTY);
+    }
+    let initial = delegation.delegate_queue_accessor().grow_checked(sdk)?;
+    initial.amount_accessor().set_checked(sdk, stake)?;
+    initial.epoch_accessor().set_checked(sdk, changed_at)?;
 
     if validator_status == STATUS_ACTIVE {
         storage
@@ -159,11 +176,12 @@ pub fn selected_validators<SDK: SharedAPI>(sdk: &SDK) -> Result<Vec<Address>, Ex
     let storage = staking_storage();
     let active = storage.active_validators_accessor();
     let active_len = active.len_checked(sdk)?;
+    let epoch = current_epoch(sdk)?;
     let mut ranked = Vec::with_capacity(active_len as usize);
     for index in 0..active_len {
         let validator = active.at(index).get_checked(sdk)?;
         if validator_status(sdk, validator)? == STATUS_ACTIVE {
-            ranked.push((validator, total_delegated(sdk, validator)?));
+            ranked.push((validator, validator_total_at(sdk, validator, epoch)?));
         }
     }
     ranked.sort_unstable_by(|(a_address, a_stake), (b_address, b_stake)| {
@@ -179,11 +197,16 @@ pub fn selected_validators<SDK: SharedAPI>(sdk: &SDK) -> Result<Vec<Address>, Ex
 
 pub fn emit_modified<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
     let record = staking_storage().validators_accessor().entry(validator);
+    let changed_at = record.changed_at_accessor().get_checked(sdk)?;
+    let snapshot = staking_storage()
+        .validator_snapshots_accessor()
+        .entry(validator)
+        .entry(changed_at);
     events::ValidatorModified {
         validator,
         owner: record.owner_accessor().get_checked(sdk)?,
         status: record.status_accessor().get_checked(sdk)?,
-        commission_rate: record.commission_rate_accessor().get_checked(sdk)?,
+        commission_rate: snapshot.commission_rate_accessor().get_checked(sdk)?,
     }
     .emit(sdk)
 }
@@ -192,4 +215,101 @@ pub fn next_epoch<SDK: SharedAPI>(sdk: &SDK) -> Result<u64, ExitCode> {
     current_epoch(sdk)?
         .checked_add(1)
         .ok_or(ExitCode::IntegerOverflow)
+}
+
+pub fn touch_validator_snapshot<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    validator: Address,
+    epoch: u64,
+) -> Result<ValidatorSnapshotStorage, ExitCode> {
+    let storage = staking_storage();
+    let snapshots = storage.validator_snapshots_accessor().entry(validator);
+    let snapshot = snapshots.entry(epoch);
+    if snapshot.initialized_accessor().get_checked(sdk)? {
+        return Ok(snapshot);
+    }
+
+    let record = storage.validators_accessor().entry(validator);
+    let changed_at = record.changed_at_accessor().get_checked(sdk)?;
+    let previous = snapshots.entry(changed_at);
+    snapshot.initialized_accessor().set_checked(sdk, true)?;
+    snapshot
+        .total_delegated_accessor()
+        .set_checked(sdk, previous.total_delegated_accessor().get_checked(sdk)?)?;
+    snapshot
+        .commission_rate_accessor()
+        .set_checked(sdk, previous.commission_rate_accessor().get_checked(sdk)?)?;
+    snapshot
+        .slashes_count_accessor()
+        .set_checked(sdk, previous.slashes_count_accessor().get_checked(sdk)?)?;
+    if epoch > changed_at {
+        record.changed_at_accessor().set_checked(sdk, epoch)?;
+    }
+    Ok(snapshot)
+}
+
+pub fn validator_total_at<SDK: SharedAPI>(
+    sdk: &SDK,
+    validator: Address,
+    epoch: u64,
+) -> Result<U256, ExitCode> {
+    let storage = staking_storage();
+    let record = storage.validators_accessor().entry(validator);
+    if record.status_accessor().get_checked(sdk)? == STATUS_NOT_FOUND {
+        return Ok(U256::ZERO);
+    }
+
+    let mut lookup = core::cmp::min(epoch, record.changed_at_accessor().get_checked(sdk)?);
+    let snapshots = storage.validator_snapshots_accessor().entry(validator);
+    loop {
+        let snapshot = snapshots.entry(lookup);
+        if snapshot.initialized_accessor().get_checked(sdk)? {
+            return snapshot.total_delegated_accessor().get_checked(sdk);
+        }
+        if lookup == 0 {
+            return Ok(U256::ZERO);
+        }
+        lookup -= 1;
+    }
+}
+
+pub fn erc20_transfer_from_input(
+    from: Address,
+    to: Address,
+    amount: U256,
+) -> Result<Vec<u8>, ExitCode> {
+    let mut params = BytesMut::new();
+    SolidityABI::<(Address, Address, U256)>::encode(&(from, to, amount), &mut params, 0)
+        .map_err(|_| ExitCode::MalformedBuiltinParams)?;
+    let mut input = SIG_ERC20_TRANSFER_FROM.to_be_bytes().to_vec();
+    input.extend_from_slice(&params);
+    Ok(input)
+}
+
+pub fn safe_transfer_from<SDK: SharedAPI>(
+    sdk: &mut SDK,
+    from: Address,
+    amount: U256,
+) -> Result<(), ExitCode> {
+    let token = staking_storage()
+        .config_accessor()
+        .staking_token_accessor()
+        .get_checked(sdk)?;
+    if token.is_zero() {
+        return revert(sdk, ERR_ZERO_STAKING_TOKEN);
+    }
+    let recipient = sdk.context().contract_address();
+    let input = erc20_transfer_from_input(from, recipient, amount)?;
+    let result = sdk.call(token, U256::ZERO, &input, None);
+    if !result.status.is_ok() {
+        sdk.write(result.data);
+        return Err(result.status);
+    }
+    if !result.data.is_empty()
+        && !SolidityABI::<bool>::decode(&result.data, 0)
+            .map_err(|_| ExitCode::MalformedBuiltinParams)?
+    {
+        return revert(sdk, ERR_STAKING_TOKEN_CALL_FAILED);
+    }
+    Ok(())
 }

--- a/contracts/staking/src/util.rs
+++ b/contracts/staking/src/util.rs
@@ -159,7 +159,11 @@ pub fn set_validator<SDK: SharedAPI>(
         .get_checked(sdk)?
         .is_zero()
     {
-        return revert_with(sdk, ERR_VALIDATOR_OWNER_ALREADY_IN_USE, &validator);
+        return revert_with(
+            sdk,
+            ERR_VALIDATOR_OWNER_ALREADY_IN_USE,
+            &validator_owner,
+        );
     }
 
     record.owner_accessor().set_checked(sdk, validator_owner)?;
@@ -167,6 +171,14 @@ pub fn set_validator<SDK: SharedAPI>(
         .status_accessor()
         .set_checked(sdk, validator_status)?;
     record.changed_at_accessor().set_checked(sdk, changed_at)?;
+    record
+        .first_snapshot_epoch_p1_accessor()
+        .set_checked(
+            sdk,
+            changed_at
+                .checked_add(1)
+                .ok_or(ExitCode::IntegerOverflow)?,
+        )?;
     storage
         .owner_validators_accessor()
         .entry(validator_owner)
@@ -365,25 +377,31 @@ pub fn selected_validators<SDK: SharedAPI>(sdk: &SDK) -> Result<Vec<Address>, Ex
 /// choose a different committee at the top-k boundary.
 fn top_k_by_stake_at<SDK: SharedAPI>(
     sdk: &SDK,
-    mut candidates: Vec<Address>,
+    candidates: Vec<Address>,
     epoch: u64,
     cap: usize,
 ) -> Result<Vec<Address>, ExitCode> {
+    let mut candidates = candidates
+        .into_iter()
+        .map(|validator| Ok((validator, validator_total_at(sdk, validator, epoch)?)))
+        .collect::<Result<Vec<_>, ExitCode>>()?;
     let k = core::cmp::min(cap, candidates.len());
     for index in 0..k {
         let mut next = index;
-        let mut max_stake = validator_total_at(sdk, candidates[next], epoch)?;
-        for (candidate, validator) in candidates.iter().enumerate().skip(index + 1) {
-            let stake = validator_total_at(sdk, *validator, epoch)?;
-            if stake > max_stake {
+        let mut max_stake = candidates[next].1;
+        for (candidate, (_, stake)) in candidates.iter().enumerate().skip(index + 1) {
+            if *stake > max_stake {
                 next = candidate;
-                max_stake = stake;
+                max_stake = *stake;
             }
         }
         candidates.swap(index, next);
     }
     candidates.truncate(k);
-    Ok(candidates)
+    Ok(candidates
+        .into_iter()
+        .map(|(validator, _)| validator)
+        .collect())
 }
 
 pub fn emit_modified<SDK: SharedAPI>(sdk: &mut SDK, validator: Address) -> Result<(), ExitCode> {
@@ -451,6 +469,14 @@ pub fn touch_snapshot_at_or_before<SDK: SharedAPI>(
         return Ok(snapshot);
     }
     let record = storage.validators_accessor().entry(validator);
+    let first_p1 = record
+        .first_snapshot_epoch_p1_accessor()
+        .get_checked(sdk)?;
+    if first_p1 == 0 || epoch < first_p1 - 1 {
+        snapshot.initialized_accessor().set_checked(sdk, true)?;
+        return Ok(snapshot);
+    }
+    let floor = first_p1 - 1;
     let mut lookup = core::cmp::min(epoch, record.changed_at_accessor().get_checked(sdk)?);
     loop {
         let base = snapshots.entry(lookup);
@@ -470,7 +496,7 @@ pub fn touch_snapshot_at_or_before<SDK: SharedAPI>(
             }
             return Ok(snapshot);
         }
-        if lookup == 0 {
+        if lookup == floor {
             snapshot.initialized_accessor().set_checked(sdk, true)?;
             return Ok(snapshot);
         }
@@ -489,6 +515,13 @@ pub fn validator_total_at<SDK: SharedAPI>(
         return Ok(U256::ZERO);
     }
 
+    let first_p1 = record
+        .first_snapshot_epoch_p1_accessor()
+        .get_checked(sdk)?;
+    if first_p1 == 0 || epoch < first_p1 - 1 {
+        return Ok(U256::ZERO);
+    }
+    let floor = first_p1 - 1;
     let mut lookup = core::cmp::min(epoch, record.changed_at_accessor().get_checked(sdk)?);
     let snapshots = storage.validator_snapshots_accessor().entry(validator);
     loop {
@@ -496,7 +529,7 @@ pub fn validator_total_at<SDK: SharedAPI>(
         if snapshot.initialized_accessor().get_checked(sdk)? {
             return snapshot.total_delegated_accessor().get_checked(sdk);
         }
-        if lookup == 0 {
+        if lookup == floor {
             return Ok(U256::ZERO);
         }
         lookup -= 1;

--- a/crates/codec/src/lib.rs
+++ b/crates/codec/src/lib.rs
@@ -25,3 +25,4 @@ pub use encoder::*;
 pub use error::*;
 #[cfg(feature = "derive")]
 pub use fluentbase_codec_derive::Codec;
+pub use func::FunctionArgs;

--- a/crates/genesis/build.rs
+++ b/crates/genesis/build.rs
@@ -47,6 +47,7 @@ const GENESIS_CONTRACTS: &[(Address, fluentbase_contracts::BuildOutput)] = &[
     (fluentbase_sdk::PRECOMPILE_OAUTH2_VERIFIER, fluentbase_contracts::FLUENTBASE_CONTRACTS_OAUTH2),
     (fluentbase_sdk::PRECOMPILE_RIPEMD160, fluentbase_contracts::FLUENTBASE_CONTRACTS_RIPEMD160),
     (fluentbase_sdk::PRECOMPILE_RUNTIME_UPGRADE, fluentbase_contracts::FLUENTBASE_CONTRACTS_RUNTIME_UPGRADE),
+    (fluentbase_sdk::PRECOMPILE_STAKING, fluentbase_contracts::FLUENTBASE_CONTRACTS_STAKING),
     (fluentbase_sdk::PRECOMPILE_FEE_MANAGER, fluentbase_contracts::FLUENTBASE_CONTRACTS_FEE_MANAGER),
     (fluentbase_sdk::PRECOMPILE_WASM_RUNTIME, fluentbase_contracts::FLUENTBASE_CONTRACTS_WASM),
     (fluentbase_sdk::PRECOMPILE_SECP256K1_RECOVER, fluentbase_contracts::FLUENTBASE_CONTRACTS_ECRECOVER),

--- a/crates/genesis/build.rs
+++ b/crates/genesis/build.rs
@@ -47,7 +47,7 @@ const GENESIS_CONTRACTS: &[(Address, fluentbase_contracts::BuildOutput)] = &[
     (fluentbase_sdk::PRECOMPILE_OAUTH2_VERIFIER, fluentbase_contracts::FLUENTBASE_CONTRACTS_OAUTH2),
     (fluentbase_sdk::PRECOMPILE_RIPEMD160, fluentbase_contracts::FLUENTBASE_CONTRACTS_RIPEMD160),
     (fluentbase_sdk::PRECOMPILE_RUNTIME_UPGRADE, fluentbase_contracts::FLUENTBASE_CONTRACTS_RUNTIME_UPGRADE),
-    (fluentbase_sdk::PRECOMPILE_STAKING, fluentbase_contracts::FLUENTBASE_CONTRACTS_STAKING),
+    (fluentbase_sdk::GENESIS_STAKING, fluentbase_contracts::FLUENTBASE_CONTRACTS_STAKING),
     (fluentbase_sdk::PRECOMPILE_FEE_MANAGER, fluentbase_contracts::FLUENTBASE_CONTRACTS_FEE_MANAGER),
     (fluentbase_sdk::PRECOMPILE_WASM_RUNTIME, fluentbase_contracts::FLUENTBASE_CONTRACTS_WASM),
     (fluentbase_sdk::PRECOMPILE_SECP256K1_RECOVER, fluentbase_contracts::FLUENTBASE_CONTRACTS_ECRECOVER),

--- a/crates/sdk-derive/derive-core/src/event.rs
+++ b/crates/sdk-derive/derive-core/src/event.rs
@@ -199,7 +199,8 @@ fn generate_topics(indexed: &[&EventField], anonymous: bool, selector: &[u8; 32]
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.#name.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
 
                 if SolidityABI::<#ty>::is_dynamic() {
                     // Dynamic type: hash at runtime via SDK
@@ -232,7 +233,8 @@ fn generate_data(fields: &[&EventField]) -> TokenStream2 {
         let data = {
             let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
             let values = (#(self.#names.clone(),)*);
-            SolidityABI::encode_function_args(&values, &mut buf).expect("encode data fields");
+            SolidityABI::encode_function_args(&values, &mut buf)
+                .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
             buf.freeze()
         };
     }

--- a/crates/sdk-derive/derive-core/src/event.rs
+++ b/crates/sdk-derive/derive-core/src/event.rs
@@ -232,7 +232,7 @@ fn generate_data(fields: &[&EventField]) -> TokenStream2 {
         let data = {
             let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
             let values = (#(self.#names.clone(),)*);
-            SolidityABI::encode(&values, &mut buf, 0).expect("encode data fields");
+            SolidityABI::encode_function_args(&values, &mut buf).expect("encode data fields");
             buf.freeze()
         };
     }

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__all_indexed.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__all_indexed.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sdk-derive/derive-core/src/event.rs
-assertion_line: 279
 expression: generate(input)
 ---
 impl Approval {
@@ -27,7 +26,8 @@ impl Approval {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.owner.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {
@@ -39,7 +39,8 @@ impl Approval {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.spender.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {
@@ -51,7 +52,8 @@ impl Approval {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.value.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<U256>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__anonymous.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__anonymous.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sdk-derive/derive-core/src/event.rs
-assertion_line: 308
 expression: generate(input)
 ---
 impl Anonymous {
@@ -22,7 +21,8 @@ impl Anonymous {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.a.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {
@@ -34,7 +34,8 @@ impl Anonymous {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.b.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {
@@ -46,7 +47,8 @@ impl Anonymous {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.c.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {
@@ -58,7 +60,8 @@ impl Anonymous {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.d.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__basic_transfer.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__basic_transfer.snap
@@ -52,7 +52,8 @@ impl Transfer {
         let data = {
             let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
             let values = (self.value.clone(),);
-            SolidityABI::encode(&values, &mut buf, 0).expect("encode data fields");
+            SolidityABI::encode_function_args(&values, &mut buf)
+                .expect("encode data fields");
             buf.freeze()
         };
         sdk.emit_log(&topics, &data).ok()

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__basic_transfer.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__basic_transfer.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sdk-derive/derive-core/src/event.rs
-assertion_line: 264
 expression: generate(input)
 ---
 impl Transfer {
@@ -27,7 +26,8 @@ impl Transfer {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.from.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {
@@ -39,7 +39,8 @@ impl Transfer {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.to.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {
@@ -53,7 +54,7 @@ impl Transfer {
             let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
             let values = (self.value.clone(),);
             SolidityABI::encode_function_args(&values, &mut buf)
-                .expect("encode data fields");
+                .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
             buf.freeze()
         };
         sdk.emit_log(&topics, &data).ok()

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__dynamic_indexed.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__dynamic_indexed.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sdk-derive/derive-core/src/event.rs
-assertion_line: 321
 expression: generate(input)
 ---
 impl Message {
@@ -27,7 +26,8 @@ impl Message {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.sender.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<Address>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {
@@ -39,7 +39,8 @@ impl Message {
             {
                 let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
                 let value = self.text.clone();
-                SolidityABI::encode(&value, &mut buf, 0).expect("encode indexed field");
+                SolidityABI::encode(&value, &mut buf, 0)
+                    .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
                 if SolidityABI::<String>::is_dynamic() {
                     fluentbase_sdk::B256::new(SDK::keccak256(&buf).0)
                 } else {

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__no_indexed.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__no_indexed.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/sdk-derive/derive-core/src/event.rs
-assertion_line: 290
 expression: generate(input)
 ---
 impl DataStored {
@@ -29,7 +28,7 @@ impl DataStored {
             let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
             let values = (self.key.clone(), self.value.clone());
             SolidityABI::encode_function_args(&values, &mut buf)
-                .expect("encode data fields");
+                .map_err(|_| fluentbase_sdk::ExitCode::MalformedBuiltinParams)?;
             buf.freeze()
         };
         sdk.emit_log(&topics, &data).ok()

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__no_indexed.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__event__tests__no_indexed.snap
@@ -28,7 +28,8 @@ impl DataStored {
         let data = {
             let mut buf = fluentbase_sdk::codec::bytes::BytesMut::new();
             let values = (self.key.clone(), self.value.clone());
-            SolidityABI::encode(&values, &mut buf, 0).expect("encode data fields");
+            SolidityABI::encode_function_args(&values, &mut buf)
+                .expect("encode data fields");
             buf.freeze()
         };
         sdk.emit_log(&topics, &data).ok()

--- a/crates/sdk/src/storage/primitive.rs
+++ b/crates/sdk/src/storage/primitive.rs
@@ -296,6 +296,8 @@ storage_alias! {
     StorageUint16 => Uint<16, 1>,
     StorageUint32 => Uint<32, 1>,
     StorageUint64 => Uint<64, 1>,
+    StorageUint96 => Uint<96, 2>,
+    StorageUint112 => Uint<112, 2>,
     StorageUint128 => Uint<128, 2>,
     StorageUint256 => Uint<256, 4>,
 
@@ -349,6 +351,26 @@ mod tests {
         assert_eq!(u8_val.get(&sdk), 0xFF);
         assert_eq!(u16_val.get(&sdk), 0x5678);
         assert_eq!(u32_val.get(&sdk), 0x12345678);
+    }
+
+    #[test]
+    fn test_solidity_width_aliases_pack_into_one_slot() {
+        let mut sdk = MockStorage::new();
+        let slot = U256::from(1);
+        let u112 = StorageUint112::new(slot, 18);
+        let u32 = StorageU32::new(slot, 14);
+        let u16 = StorageU16::new(slot, 12);
+        let u96 = StorageUint96::new(slot, 0);
+
+        u112.set(&mut sdk, Uint::from(0x1122_u64));
+        u32.set(&mut sdk, 0x3344_5566);
+        u16.set(&mut sdk, 0x7788);
+        u96.set(&mut sdk, Uint::from(0x99aa_u64));
+
+        assert_eq!(
+            sdk.get_slot_hex(slot),
+            "0000000000000000000099aa7788334455660000000000000000000000001122"
+        );
     }
 
     #[test]

--- a/crates/types/src/genesis.rs
+++ b/crates/types/src/genesis.rs
@@ -51,6 +51,13 @@ pub const PRECOMPILE_WASM_RUNTIME: Address = address!("0x00000000000000000000000
 pub const PRECOMPILE_RUNTIME_UPGRADE: Address =
     address!("0x0000000000000000000000000000000000520010");
 
+/// Validator staking system contract.
+///
+/// Staking is part of the consensus-critical runtime and is deployed at a
+/// fixed address so protocol callers do not depend on CREATE address
+/// derivation.
+pub const PRECOMPILE_STAKING: Address = address!("0x0000000000000000000000000000000000520011");
+
 /// A precompile smart contract that can deploy child contracts using CREATE/CREATE2.
 pub const PRECOMPILE_CREATE2_FACTORY: Address =
     address!("0x4e59b44847b379578588920cA78FbF26c0B4956C");
@@ -147,6 +154,7 @@ pub const EXECUTE_USING_SYSTEM_RUNTIME_ADDRESSES: &[Address] = &[
     PRECOMPILE_RIPEMD160,
     PRECOMPILE_SECP256K1_RECOVER,
     PRECOMPILE_SHA256,
+    PRECOMPILE_STAKING,
     // PRECOMPILE_SVM_RUNTIME,
     PRECOMPILE_WASM_RUNTIME,
     PRECOMPILE_WEBAUTHN_VERIFIER,
@@ -174,6 +182,7 @@ pub const ENGINE_METERED_PRECOMPILES: &[Address] = &[
     PRECOMPILE_WASM_RUNTIME,
     PRECOMPILE_WEBAUTHN_VERIFIER,
     PRECOMPILE_UNIVERSAL_TOKEN_RUNTIME,
+    PRECOMPILE_STAKING,
 ];
 
 /// Returns `true` if the contract at `address` should be charged fuel by the runtime.

--- a/crates/types/src/genesis.rs
+++ b/crates/types/src/genesis.rs
@@ -51,12 +51,11 @@ pub const PRECOMPILE_WASM_RUNTIME: Address = address!("0x00000000000000000000000
 pub const PRECOMPILE_RUNTIME_UPGRADE: Address =
     address!("0x0000000000000000000000000000000000520010");
 
-/// Validator staking system contract.
-///
-/// Staking is part of the consensus-critical runtime and is deployed at a
-/// fixed address so protocol callers do not depend on CREATE address
-/// derivation.
-pub const PRECOMPILE_STAKING: Address = address!("0x0000000000000000000000000000000000520011");
+/// Validator staking rWasm contract deployed directly in genesis.
+pub const GENESIS_STAKING: Address = address!("0x0000000000000000000000000000000000520011");
+
+/// Governance rWasm contract address reserved for genesis deployment.
+pub const GENESIS_GOVERNANCE: Address = address!("0x0000000000000000000000000000000000520012");
 
 /// A precompile smart contract that can deploy child contracts using CREATE/CREATE2.
 pub const PRECOMPILE_CREATE2_FACTORY: Address =
@@ -154,7 +153,6 @@ pub const EXECUTE_USING_SYSTEM_RUNTIME_ADDRESSES: &[Address] = &[
     PRECOMPILE_RIPEMD160,
     PRECOMPILE_SECP256K1_RECOVER,
     PRECOMPILE_SHA256,
-    PRECOMPILE_STAKING,
     // PRECOMPILE_SVM_RUNTIME,
     PRECOMPILE_WASM_RUNTIME,
     PRECOMPILE_WEBAUTHN_VERIFIER,
@@ -182,7 +180,6 @@ pub const ENGINE_METERED_PRECOMPILES: &[Address] = &[
     PRECOMPILE_WASM_RUNTIME,
     PRECOMPILE_WEBAUTHN_VERIFIER,
     PRECOMPILE_UNIVERSAL_TOKEN_RUNTIME,
-    PRECOMPILE_STAKING,
 ];
 
 /// Returns `true` if the contract at `address` should be charged fuel by the runtime.

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -52,6 +52,8 @@ mod helpers;
 #[cfg(test)]
 mod router;
 #[cfg(test)]
+mod staking;
+#[cfg(test)]
 mod stateless;
 // #[cfg(all(test, feature = "svm"))]
 // pub mod svm;

--- a/e2e/src/staking.rs
+++ b/e2e/src/staking.rs
@@ -1,0 +1,180 @@
+use crate::EvmTestingContextWithGenesis;
+use alloy_sol_types::{sol, SolCall};
+use fluentbase_sdk::{
+    universal_token::{ApproveCommand, BalanceOfCommand, InitialSettings, UniversalTokenCommand},
+    Address, GENESIS_STAKING, U256,
+};
+use fluentbase_testing::EvmTestingContext;
+
+const OWNER: Address = Address::repeat_byte(0x11);
+const VALIDATOR: Address = Address::repeat_byte(0x22);
+const TOKEN: U256 = U256::from_limbs([1_000_000_000_000_000_000, 0, 0, 0]);
+
+sol! {
+    interface IStakingRwasm {
+        function initialize(
+            address initialOwner,
+            address[] validators,
+            uint256[] initialStakes,
+            uint16 commissionRate
+        ) external;
+        function configure(
+            address stakingToken,
+            uint32 activeValidatorsLength,
+            uint32 epochBlockInterval,
+            uint32 felonyThreshold,
+            uint32 validatorJailEpochLength,
+            uint32 undelegatePeriod,
+            uint256 minValidatorStakeAmount,
+            uint256 minStakingAmount,
+            uint64 dposActivationBlock,
+            address blsVerifier,
+            address evidenceDecoder,
+            uint256 minUndelegateBlocks
+        ) external;
+        function delegate(address validator, uint256 amount) external;
+        function undelegate(address validator, uint256 amount) external;
+        function claimDelegatorFee(address validator) external;
+        function getValidatorDelegation(address validator, address delegator)
+            external
+            view
+            returns (uint256 delegatedAmount, uint64 atEpoch);
+    }
+}
+
+fn call(
+    context: &mut EvmTestingContext,
+    caller: Address,
+    callee: Address,
+    input: Vec<u8>,
+) -> Vec<u8> {
+    let result = context.call_evm_tx(caller, callee, input.into(), Some(20_000_000), None);
+    assert!(result.is_success(), "call failed: {result:?}");
+    result.output().cloned().unwrap_or_default().to_vec()
+}
+
+fn token_balance(context: &mut EvmTestingContext, token: Address, owner: Address) -> U256 {
+    let mut input = Vec::new();
+    BalanceOfCommand { owner }.encode_for_send(&mut input);
+    let output = call(context, OWNER, token, input);
+    U256::try_from_be_slice(&output).expect("ERC-20 balanceOf output")
+}
+
+#[test]
+fn genesis_staking_custodies_and_returns_blend_through_real_rwasm_calls() {
+    let mut context = EvmTestingContext::default().with_full_genesis();
+    let initial_supply = TOKEN * U256::from(1_000);
+    let token = context.deploy_evm_tx(
+        OWNER,
+        InitialSettings {
+            token_name: "Blend".into(),
+            token_symbol: "BLEND".into(),
+            decimals: 18,
+            initial_supply,
+            minter: OWNER,
+            pauser: Address::ZERO,
+            wrapped: None,
+        }
+        .encode_with_prefix(),
+    );
+
+    call(
+        &mut context,
+        OWNER,
+        GENESIS_STAKING,
+        IStakingRwasm::configureCall {
+            stakingToken: token,
+            activeValidatorsLength: 21,
+            epochBlockInterval: 200,
+            felonyThreshold: 150,
+            validatorJailEpochLength: 7,
+            undelegatePeriod: 7,
+            minValidatorStakeAmount: TOKEN,
+            minStakingAmount: TOKEN,
+            dposActivationBlock: 1_000,
+            blsVerifier: Address::ZERO,
+            evidenceDecoder: Address::ZERO,
+            minUndelegateBlocks: U256::ZERO,
+        }
+        .abi_encode(),
+    );
+
+    let mut approve = Vec::new();
+    ApproveCommand {
+        spender: GENESIS_STAKING,
+        amount: TOKEN * U256::from(4),
+    }
+    .encode_for_send(&mut approve);
+    call(&mut context, OWNER, token, approve);
+    call(
+        &mut context,
+        OWNER,
+        GENESIS_STAKING,
+        IStakingRwasm::initializeCall {
+            initialOwner: OWNER,
+            validators: vec![VALIDATOR],
+            initialStakes: vec![TOKEN],
+            commissionRate: 0,
+        }
+        .abi_encode(),
+    );
+    call(
+        &mut context,
+        OWNER,
+        GENESIS_STAKING,
+        IStakingRwasm::delegateCall {
+            validator: VALIDATOR,
+            amount: TOKEN * U256::from(3),
+        }
+        .abi_encode(),
+    );
+    assert_eq!(
+        token_balance(&mut context, token, GENESIS_STAKING),
+        TOKEN * U256::from(4)
+    );
+
+    let output = call(
+        &mut context,
+        OWNER,
+        GENESIS_STAKING,
+        IStakingRwasm::getValidatorDelegationCall {
+            validator: VALIDATOR,
+            delegator: OWNER,
+        }
+        .abi_encode(),
+    );
+    let delegation =
+        IStakingRwasm::getValidatorDelegationCall::abi_decode_returns(&output).unwrap();
+    assert_eq!(delegation.delegatedAmount, TOKEN * U256::from(3));
+    assert_eq!(delegation.atEpoch, 2);
+
+    call(
+        &mut context,
+        OWNER,
+        GENESIS_STAKING,
+        IStakingRwasm::undelegateCall {
+            validator: VALIDATOR,
+            amount: TOKEN,
+        }
+        .abi_encode(),
+    );
+    context = context.with_block_number(3_000);
+    call(
+        &mut context,
+        OWNER,
+        GENESIS_STAKING,
+        IStakingRwasm::claimDelegatorFeeCall {
+            validator: VALIDATOR,
+        }
+        .abi_encode(),
+    );
+
+    assert_eq!(
+        token_balance(&mut context, token, GENESIS_STAKING),
+        TOKEN * U256::from(3)
+    );
+    assert_eq!(
+        token_balance(&mut context, token, OWNER),
+        initial_supply - TOKEN * U256::from(3)
+    );
+}

--- a/e2e/src/staking.rs
+++ b/e2e/src/staking.rs
@@ -2,7 +2,7 @@ use crate::EvmTestingContextWithGenesis;
 use alloy_sol_types::{sol, SolCall};
 use fluentbase_sdk::{
     universal_token::{ApproveCommand, BalanceOfCommand, InitialSettings, UniversalTokenCommand},
-    Address, GENESIS_STAKING, U256,
+    Address, GENESIS_GOVERNANCE, GENESIS_STAKING, U256,
 };
 use fluentbase_testing::EvmTestingContext;
 
@@ -53,6 +53,19 @@ fn call(
     result.output().cloned().unwrap_or_default().to_vec()
 }
 
+fn assert_reverts(
+    context: &mut EvmTestingContext,
+    caller: Address,
+    callee: Address,
+    input: Vec<u8>,
+) {
+    let result = context.call_evm_tx(caller, callee, input.into(), Some(20_000_000), None);
+    assert!(
+        !result.is_success(),
+        "call unexpectedly succeeded: {result:?}"
+    );
+}
+
 fn token_balance(context: &mut EvmTestingContext, token: Address, owner: Address) -> U256 {
     let mut input = Vec::new();
     BalanceOfCommand { owner }.encode_for_send(&mut input);
@@ -80,7 +93,7 @@ fn genesis_staking_custodies_and_returns_blend_through_real_rwasm_calls() {
 
     call(
         &mut context,
-        OWNER,
+        GENESIS_GOVERNANCE,
         GENESIS_STAKING,
         IStakingRwasm::configureCall {
             stakingToken: token,
@@ -98,6 +111,38 @@ fn genesis_staking_custodies_and_returns_blend_through_real_rwasm_calls() {
         }
         .abi_encode(),
     );
+    assert_reverts(
+        &mut context,
+        GENESIS_GOVERNANCE,
+        GENESIS_STAKING,
+        IStakingRwasm::configureCall {
+            stakingToken: token,
+            activeValidatorsLength: 21,
+            epochBlockInterval: 200,
+            felonyThreshold: 150,
+            validatorJailEpochLength: 7,
+            undelegatePeriod: 7,
+            minValidatorStakeAmount: TOKEN,
+            minStakingAmount: TOKEN,
+            dposActivationBlock: 1_000,
+            blsVerifier: Address::ZERO,
+            evidenceDecoder: Address::ZERO,
+            minUndelegateBlocks: U256::ZERO,
+        }
+        .abi_encode(),
+    );
+    assert_reverts(
+        &mut context,
+        OWNER,
+        GENESIS_STAKING,
+        IStakingRwasm::initializeCall {
+            initialOwner: OWNER,
+            validators: vec![VALIDATOR],
+            initialStakes: vec![TOKEN],
+            commissionRate: 0,
+        }
+        .abi_encode(),
+    );
 
     let mut approve = Vec::new();
     ApproveCommand {
@@ -108,7 +153,7 @@ fn genesis_staking_custodies_and_returns_blend_through_real_rwasm_calls() {
     call(&mut context, OWNER, token, approve);
     call(
         &mut context,
-        OWNER,
+        GENESIS_GOVERNANCE,
         GENESIS_STAKING,
         IStakingRwasm::initializeCall {
             initialOwner: OWNER,
@@ -146,6 +191,7 @@ fn genesis_staking_custodies_and_returns_blend_through_real_rwasm_calls() {
     let delegation =
         IStakingRwasm::getValidatorDelegationCall::abi_decode_returns(&output).unwrap();
     assert_eq!(delegation.delegatedAmount, TOKEN * U256::from(3));
+    // Block 1_400 is epoch 2: (1_400 - activation 1_000) / interval 200.
     assert_eq!(delegation.atEpoch, 2);
 
     call(


### PR DESCRIPTION
## Summary

- deploy staking at fixed genesis address `0x0000000000000000000000000000000000520011` as a normal rWasm contract using `SharedAPI`
- reserve governance at `0x0000000000000000000000000000000000520012`
- custody and pay the canonical BLEND ERC-20 through real contract calls
- embed the former ChainConfig state and governance surface under one ERC-7201 derived storage root
- preserve Solidity ABI selectors with `derive_keccak256_id!` and pinned hex comments

## Architecture

Staking is a genesis-deployed rWasm smart contract, not a system precompile, because BLEND staking requires ERC-20 calls. Genesis uses the one-shot `configure(address,uint32,uint32,uint32,uint32,uint32,uint256,uint256,uint64,address,address,uint256)` entrypoint to wire the token and full chain configuration. `getChainConfig()` resolves to staking itself. Bootstrap configuration/initialization is restricted to the reserved genesis-governance address, and runtime dependencies for liveness and the BLEND reserve are governance-wired, while validator and configuration mutations remain gated by the reserved governance address.

Storage uses nested `#[derive(Storage)]` structs under a single ERC-7201 root. `lib.rs` contains dispatch only; reusable helpers and staking domains live in focused modules.

## Implemented parity

- initialization, registry reads, stake snapshots, validator registration and lifecycle
- BLEND delegation, undelegation, delayed principal claims, redelegation, validator/delegator rewards, and bounded claims
- full embedded ChainConfig getters, constants, governance setters, activation locks, caps, and undelegation safety floor
- liveness slashing, halt guard, jail release, automatic readmission, and tombstone handling
- consensus-key PoP validation, historical keyed registries, canonical top-k selection, committee persistence/pruning, DKG mint bits, and signer resolution
- notarize/finalize/nullify-finalize equivocation verification, replay protection, permanent jail, and self-stake seizure split
- Solidity-compatible dynamic calldata, return values, custom errors, and event data

The intentionally omitted Solidity methods are UUPS/Ownable proxy-management scaffolding and the unused legacy `getSystemReward()` / `getStakingPool()` dependency getters; they are not staking behavior in the non-proxy rWasm design.

## Validation

- staking unit/regression suite: 31 passing
- codec suite: 82 passing plus 2 doc tests
- SDK derive suite: 99 passing
- real full-genesis BLEND custody/delegation/undelegation E2E: passing
- staking clippy with warnings denied: passing
- release `wasm32-unknown-unknown` no-std build: passing

Linear: FLU-989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete staking contract with governance-configurable parameters, validator lifecycle, delegation/undelegation, epoch rewards, and fee claiming.
  * Introduced consensus-key registration, deterministic epoch committee commitments, and committee-related queries.
  * Added liveness tooling (jailing/readmission) and terminal equivocation slashing.
  * Added staking-specific events and included the staking contract in genesis deployments.
* **Tests**
  * Added extensive unit tests and a full end-to-end staking flow test (including ERC-20 interactions).
* **Documentation**
  * Added staking contract documentation and updated workspace/README entries.
* **Chores**
  * Improved event log encoding for malformed parameters and extended SDK storage numeric aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->