### PR TITLE
fix(docker): align runtime glibc with cross builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,16 @@ define docker_build_push
 	mkdir -p $(BIN_DIR)/arm64
 	cp $(CARGO_TARGET_DIR)/aarch64-unknown-linux-gnu/$(PROFILE)/fluent $(BIN_DIR)/arm64/fluent
 
+	@set -eu; for arch in amd64 arm64; do \
+		image="fluent-smoke-$$arch:$(GIT_SHA)"; \
+		docker buildx build --file ./docker/Dockerfile.cross . \
+			--platform "linux/$$arch" \
+			--tag "$$image" \
+			--load; \
+		docker run --rm --platform "linux/$$arch" "$$image" --version; \
+		docker image rm "$$image"; \
+	done
+
 	docker buildx build --file ./docker/Dockerfile.cross . \
 		--platform linux/amd64,linux/arm64 \
 		--tag $(DOCKER_IMAGE_NAME):$(1) \

--- a/Makefile
+++ b/Makefile
@@ -255,12 +255,14 @@ define docker_build_push
 
 	@set -eu; for arch in amd64 arm64; do \
 		image="fluent-smoke-$$arch:$(GIT_SHA)"; \
+		trap 'docker image rm -f "$$image" >/dev/null 2>&1 || true' 0; \
 		docker buildx build --file ./docker/Dockerfile.cross . \
 			--platform "linux/$$arch" \
 			--tag "$$image" \
 			--load; \
 		docker run --rm --platform "linux/$$arch" "$$image" --version; \
 		docker image rm "$$image"; \
+		trap - 0; \
 	done
 
 	docker buildx build --file ./docker/Dockerfile.cross . \

--- a/docker/Dockerfile.cross
+++ b/docker/Dockerfile.cross
@@ -1,7 +1,5 @@
-# This image is meant to enable cross-architecture builds.
-# It assumes the fluent binary has already been compiled for `$TARGETPLATFORM` and is
-# locatable in `./dist/bin/$TARGETARCH`
-FROM --platform=$TARGETPLATFORM ubuntu:22.04
+# Keep the runtime glibc aligned with the Ubuntu 24.04 cross-build sysroot.
+FROM --platform=$TARGETPLATFORM ubuntu:24.04
 
 LABEL org.opencontainers.image.source=https://github.com/fluentlabs-xyz/fluent
 LABEL org.opencontainers.image.licenses="MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary

- run the final Fluent image on Ubuntu 24.04, matching the pinned `cross` build sysroot
- smoke-test the amd64 and arm64 images before publishing the multi-arch manifest

## Root cause

The pinned `cross` revision builds Linux binaries against Ubuntu 24.04/glibc 2.39, while the final image used Ubuntu 22.04/glibc 2.35. The arm64 binary therefore required unavailable `GLIBC_2.38` and `GLIBC_2.39` symbols at startup.

## Validation

- `git diff --check`
- `make -n docker-build-push-latest`

The local environment has no Docker daemon. The release workflow now performs the actual per-architecture startup check before push.

Linear: [FLU-1000](https://linear.app/fluentlabs-xyz/issue/FLU-1000/docker-image-for-fluent-v132-doesnt-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-architecture Docker image reliability by validating AMD64 and ARM64 images before publishing.
  * Updated the cross-architecture runtime base to Ubuntu 24.04 for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->