### PR TITLE
feat(runtime-upgrade): support Solidity contracts

### DIFF
--- a/contracts/runtime-upgrade/README.md
+++ b/contracts/runtime-upgrade/README.md
@@ -50,7 +50,7 @@ Removing the pair prevents replaying the same planned target/hash entry after it
 
 - `owner` can perform direct upgrades, recompile existing targets, and replace the current plan.
 - `upgrador` can execute only owner-approved target/hash pairs from the current plan.
-- Host-side syscall enforcement remains the final boundary: `SYSCALL_ID_UPGRADE_RUNTIME` must only
+- Host-side syscall enforcement remains the final boundary: `SYSCALL_ID_UPGRADE_WASM_RUNTIME` must only
   be reachable through the runtime-upgrade precompile execution path.
 
 ## Operational Notes

--- a/contracts/runtime-upgrade/src/lib.rs
+++ b/contracts/runtime-upgrade/src/lib.rs
@@ -13,7 +13,7 @@ use fluentbase_sdk::{
     derive::{router, Contract, Event},
     hex,
     storage::{StorageAddress, StorageBytes32, StorageString, StorageVec},
-    syscall::{encode, SYSCALL_ID_UPGRADE_EVM_RUNTIME, SYSCALL_ID_UPGRADE_RUNTIME},
+    syscall::{encode, SYSCALL_ID_UPGRADE_EVM_RUNTIME, SYSCALL_ID_UPGRADE_WASM_RUNTIME},
     Address, Bytes, ContextReader, ExitCode, RwasmCompilationResult, SharedAPI, B256,
     DEFAULT_UPDATE_GENESIS_AUTH, EVM_MAX_CODE_SIZE, STATE_MAIN, SYSTEM_ADDRESS, WASM_MAGIC_BYTES,
 };
@@ -329,7 +329,7 @@ impl<SDK: SharedAPI> App<SDK> {
         let mut buffer = vec![0u8; encode::upgrade_runtime_size_hint(rwasm_bytecode.len())];
         encode::upgrade_runtime_into(&mut &mut buffer[..], &target_address, &rwasm_bytecode);
         let (_fuel_consumed, _fuel_refunded, exit_code) = self.sdk.native_exec(
-            SYSCALL_ID_UPGRADE_RUNTIME,
+            SYSCALL_ID_UPGRADE_WASM_RUNTIME,
             Cow::Owned(buffer),
             None,
             STATE_MAIN,

--- a/contracts/runtime-upgrade/src/lib.rs
+++ b/contracts/runtime-upgrade/src/lib.rs
@@ -13,9 +13,9 @@ use fluentbase_sdk::{
     derive::{router, Contract, Event},
     hex,
     storage::{StorageAddress, StorageBytes32, StorageString, StorageVec},
-    syscall::{encode, SYSCALL_ID_UPGRADE_RUNTIME},
+    syscall::{encode, SYSCALL_ID_UPGRADE_EVM_RUNTIME, SYSCALL_ID_UPGRADE_RUNTIME},
     Address, Bytes, ContextReader, ExitCode, RwasmCompilationResult, SharedAPI, B256,
-    DEFAULT_UPDATE_GENESIS_AUTH, STATE_MAIN, SYSTEM_ADDRESS, WASM_MAGIC_BYTES,
+    DEFAULT_UPDATE_GENESIS_AUTH, EVM_MAX_CODE_SIZE, STATE_MAIN, SYSTEM_ADDRESS, WASM_MAGIC_BYTES,
 };
 
 #[derive(Event)]
@@ -71,6 +71,15 @@ trait RuntimeUpgradeTr {
         wasm_bytecode: Bytes,
     );
 
+    /// Upgrade a Solidity contract using its deployed EVM runtime bytecode.
+    fn upgrade_evm_to(
+        &mut self,
+        target_address: Address,
+        genesis_hash: B256,
+        genesis_version: String,
+        evm_bytecode: Bytes,
+    );
+
     /// Recompile already deployed WASM runtime smart contract
     fn recompile(&mut self, target_address: Address);
 
@@ -112,6 +121,26 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
     ) {
         _ = self.only_owner();
         let code_hash = self.compile_and_install(target_address, wasm_bytecode);
+        RuntimeUpgraded {
+            target_address,
+            genesis_hash,
+            genesis_version,
+            code_hash,
+        }
+        .emit(&mut self.sdk)
+        .unwrap();
+    }
+
+    #[function_id("upgradeEvmTo(address,uint256,string,bytes)")]
+    fn upgrade_evm_to(
+        &mut self,
+        target_address: Address,
+        genesis_hash: B256,
+        genesis_version: String,
+        evm_bytecode: Bytes,
+    ) {
+        _ = self.only_owner();
+        let code_hash = self.install_evm(target_address, evm_bytecode);
         RuntimeUpgraded {
             target_address,
             genesis_hash,
@@ -308,6 +337,34 @@ impl<SDK: SharedAPI> App<SDK> {
 
         if exit_code != ExitCode::Ok.into_i32() {
             panic!("runtime-upgrade: failed to upgrade");
+        }
+
+        let Ok(code_hash) = self.sdk.code_hash(&target_address).ok() else {
+            panic!("runtime-upgrade: can't obtain code hash");
+        };
+
+        code_hash
+    }
+
+    fn install_evm(&mut self, target_address: Address, evm_bytecode: Bytes) -> B256 {
+        if evm_bytecode.is_empty() {
+            panic!("runtime-upgrade: empty evm bytecode");
+        }
+        if evm_bytecode.len() > EVM_MAX_CODE_SIZE {
+            panic!("runtime-upgrade: evm bytecode exceeds maximum size");
+        }
+
+        let mut buffer = vec![0u8; encode::upgrade_evm_runtime_size_hint(evm_bytecode.len())];
+        encode::upgrade_evm_runtime_into(&mut &mut buffer[..], &target_address, &evm_bytecode);
+        let (_fuel_consumed, _fuel_refunded, exit_code) = self.sdk.native_exec(
+            SYSCALL_ID_UPGRADE_EVM_RUNTIME,
+            Cow::Owned(buffer),
+            None,
+            STATE_MAIN,
+        );
+
+        if exit_code != ExitCode::Ok.into_i32() {
+            panic!("runtime-upgrade: failed to upgrade evm contract");
         }
 
         let Ok(code_hash) = self.sdk.code_hash(&target_address).ok() else {

--- a/contracts/runtime-upgrade/src/tests.rs
+++ b/contracts/runtime-upgrade/src/tests.rs
@@ -81,6 +81,28 @@ fn test_recompile_encoding() {
 }
 
 #[test]
+fn test_upgrade_evm_to_encoding() {
+    let target = address!("2222222222222222222222222222222222222222");
+    let genesis_hash = B256::from([0xab; 32]);
+    let genesis_version = "v1.0.0".to_string();
+    let evm_bytecode = bytes!("6001600055");
+
+    let call = UpgradeEvmToCall::new((
+        target,
+        genesis_hash,
+        genesis_version.clone(),
+        evm_bytecode.clone(),
+    ));
+    let encoded = call.encode();
+
+    let decoded = UpgradeEvmToCall::decode(&&encoded[4..]).expect("failed to decode");
+    assert_eq!(decoded.0 .0, target);
+    assert_eq!(decoded.0 .1, genesis_hash);
+    assert_eq!(decoded.0 .2, genesis_version);
+    assert_eq!(decoded.0 .3, evm_bytecode);
+}
+
+#[test]
 fn test_plan_upgrade_encoding() {
     let genesis_hash = B256::from([0xab; 32]);
     let genesis_version = "v1.0.0".to_string();

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -18,7 +18,7 @@ use fluentbase_sdk::{
     byteorder::{ByteOrder, LittleEndian, ReadBytesExt},
     bytes::Buf,
     calc_create_metadata_address, is_execute_using_system_runtime, Address, Bytes, ExitCode, Log,
-    LogData, B256, EXT_CODE_COPY_MAX_COPY_SIZE, FUEL_DENOM_RATE, KECCAK_EMPTY,
+    LogData, B256, EVM_MAX_CODE_SIZE, EXT_CODE_COPY_MAX_COPY_SIZE, FUEL_DENOM_RATE, KECCAK_EMPTY,
     PRECOMPILE_EVM_RUNTIME, PRECOMPILE_RUNTIME_UPGRADE, STATE_MAIN, U256,
 };
 use revm::{
@@ -1231,7 +1231,7 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                 MalformedBuiltinParams
             );
             let (input, lazy_contract_input) = get_input_validated!(>= 20);
-            let target_address = Address::from_slice(&input);
+            let target_address = Address::from_slice(&input[..Address::len_bytes()]);
             debug_syscall!("UPGRADE_RUNTIME", "target={:?}", target_address);
             // P.S: We can't validate the target address here, otherwise it will require a fork
             //  to release new contracts from genesis
@@ -1251,6 +1251,34 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             };
             let bytecode = Bytecode::Rwasm(rwasm_bytecode.into());
             // Make sure an account is loaded
+            _ = ctx.journal_mut().load_account_with_code(target_address)?;
+            ctx.journal_mut().set_code(target_address, bytecode);
+            return_result!(Ok);
+        }
+
+        SYSCALL_ID_UPGRADE_EVM_RUNTIME => {
+            assert_halt!(!is_static, StateChangeDuringStaticCall);
+            assert_halt!(
+                current_target_address == PRECOMPILE_RUNTIME_UPGRADE,
+                MalformedBuiltinParams
+            );
+            let (input, lazy_contract_input) = get_input_validated!(>= 21);
+            let target_address = Address::from_slice(&input[..Address::len_bytes()]);
+            let Ok(evm_binary) = lazy_contract_input() else {
+                return_halt!(MemoryOutOfBounds);
+            };
+            let evm_binary: Bytes = evm_binary.into();
+            if evm_binary.len() > EVM_MAX_CODE_SIZE {
+                return_halt!(MalformedBuiltinParams);
+            }
+            #[cfg(feature = "std")]
+            warn!(
+                ?target_address,
+                bytecode_size = evm_binary.len(),
+                "Upgrading EVM contract"
+            );
+            let metadata = EthereumMetadata::new_analyzed(evm_binary).write_to_bytes();
+            let bytecode = Bytecode::new_ownable_account(PRECOMPILE_EVM_RUNTIME, metadata);
             _ = ctx.journal_mut().load_account_with_code(target_address)?;
             ctx.journal_mut().set_code(target_address, bytecode);
             return_result!(Ok);

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -1223,7 +1223,7 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             return_result!(hash, Ok);
         }
 
-        SYSCALL_ID_UPGRADE_RUNTIME => {
+        SYSCALL_ID_UPGRADE_WASM_RUNTIME => {
             assert_halt!(!is_static, StateChangeDuringStaticCall);
             // This syscall can be called only by runtime upgrade smart contract
             assert_halt!(

--- a/crates/sdk/src/syscall.rs
+++ b/crates/sdk/src/syscall.rs
@@ -30,4 +30,5 @@ pub const SYSCALL_ID_METADATA_STORAGE_READ: B256 = B256::with_last_byte(0x44);
 pub const SYSCALL_ID_METADATA_STORAGE_WRITE: B256 = B256::with_last_byte(0x45);
 pub const SYSCALL_ID_METADATA_ACCOUNT_OWNER: B256 = B256::with_last_byte(0x46);
 
+pub const SYSCALL_ID_UPGRADE_EVM_RUNTIME: B256 = B256::with_last_byte(0xfe);
 pub const SYSCALL_ID_UPGRADE_RUNTIME: B256 = B256::with_last_byte(0xff);

--- a/crates/sdk/src/syscall.rs
+++ b/crates/sdk/src/syscall.rs
@@ -31,4 +31,4 @@ pub const SYSCALL_ID_METADATA_STORAGE_WRITE: B256 = B256::with_last_byte(0x45);
 pub const SYSCALL_ID_METADATA_ACCOUNT_OWNER: B256 = B256::with_last_byte(0x46);
 
 pub const SYSCALL_ID_UPGRADE_EVM_RUNTIME: B256 = B256::with_last_byte(0xfe);
-pub const SYSCALL_ID_UPGRADE_RUNTIME: B256 = B256::with_last_byte(0xff);
+pub const SYSCALL_ID_UPGRADE_WASM_RUNTIME: B256 = B256::with_last_byte(0xff);

--- a/crates/sdk/src/syscall/encode.rs
+++ b/crates/sdk/src/syscall/encode.rs
@@ -331,3 +331,14 @@ pub fn upgrade_runtime_into<B: BufMut>(out: &mut B, address: &Address, rwasm_byt
     out.put_slice(address.as_slice());
     out.put_slice(rwasm_bytecode);
 }
+
+#[inline(always)]
+pub const fn upgrade_evm_runtime_size_hint(evm_bytecode_len: usize) -> usize {
+    Address::len_bytes() + evm_bytecode_len
+}
+
+#[inline(always)]
+pub fn upgrade_evm_runtime_into<B: BufMut>(out: &mut B, address: &Address, evm_bytecode: &[u8]) {
+    out.put_slice(address.as_slice());
+    out.put_slice(evm_bytecode);
+}

--- a/e2e/src/update_account.rs
+++ b/e2e/src/update_account.rs
@@ -3,12 +3,86 @@ use bytes::BytesMut;
 use fluentbase_codec::SolidityABI;
 use fluentbase_genesis::GENESIS_CONTRACTS_BY_ADDRESS;
 use fluentbase_sdk::{
-    address, bytes, compile_rwasm_maybe_system, Address, Bytes, B256, DEFAULT_UPDATE_GENESIS_AUTH,
-    PRECOMPILE_EVM_RUNTIME, PRECOMPILE_RUNTIME_UPGRADE, UPDATE_GENESIS_PREFIX,
+    address, bytes, compile_rwasm_maybe_system, crypto::crypto_keccak256, Address, Bytes, B256,
+    DEFAULT_UPDATE_GENESIS_AUTH, PRECOMPILE_EVM_RUNTIME, PRECOMPILE_RUNTIME_UPGRADE, U256,
+    UPDATE_GENESIS_PREFIX,
 };
 use fluentbase_testing::EvmTestingContext;
 use hex_literal::hex;
 use revm::context::result::ExecutionResult;
+
+#[test]
+fn test_upgrade_solidity_contract_preserves_storage() {
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+    const DEPLOYER_ADDRESS: Address = address!("0x7777777777777777777777777777777777777777");
+
+    // Runtime stores the first ABI argument in slot zero.
+    let (contract_address, _) = ctx.deploy_evm_tx_with_gas(
+        DEPLOYER_ADDRESS,
+        hex!("6007600c60003960076000f360043560005500").into(),
+    );
+    let old_code = ctx.get_code(contract_address).unwrap().original_bytes();
+    let stored_value = B256::from([0x42; 32]);
+    let mut store_input = vec![0u8; 4];
+    store_input.extend_from_slice(stored_value.as_slice());
+    assert!(ctx
+        .call_evm_tx(
+            DEPLOYER_ADDRESS,
+            contract_address,
+            store_input.into(),
+            None,
+            None,
+        )
+        .is_success());
+
+    // New deployed runtime returns slot zero.
+    let new_runtime = bytes!("60005460005260206000f3");
+    let mut upgrade_args = BytesMut::new();
+    SolidityABI::<(Address, B256, String, Bytes)>::encode_function_args(
+        &(
+            contract_address,
+            B256::ZERO,
+            "v1.0.1".to_string(),
+            new_runtime.clone(),
+        ),
+        &mut upgrade_args,
+    )
+    .unwrap();
+    let selector = crypto_keccak256(b"upgradeEvmTo(address,uint256,string,bytes)");
+    let mut upgrade_input = selector[..4].to_vec();
+    upgrade_input.extend_from_slice(&upgrade_args);
+
+    let result = ctx.call_evm_tx(
+        DEFAULT_UPDATE_GENESIS_AUTH,
+        PRECOMPILE_RUNTIME_UPGRADE,
+        upgrade_input.into(),
+        None,
+        None,
+    );
+    assert!(result.is_success(), "{result:?}");
+    let upgraded_code = ctx.get_code(contract_address).unwrap();
+    assert_ne!(upgraded_code.original_bytes(), old_code);
+    let account = ctx.db.cache.accounts.get(&contract_address).unwrap();
+    assert_eq!(
+        account.storage.get(&U256::ZERO),
+        Some(&U256::from_be_slice(stored_value.as_slice()))
+    );
+
+    let mut recompile_args = BytesMut::new();
+    SolidityABI::<(Address,)>::encode_function_args(&(contract_address,), &mut recompile_args)
+        .unwrap();
+    let selector = crypto_keccak256(b"recompile(address)");
+    let mut recompile_input = selector[..4].to_vec();
+    recompile_input.extend_from_slice(&recompile_args);
+    let result = ctx.call_evm_tx(
+        DEFAULT_UPDATE_GENESIS_AUTH,
+        PRECOMPILE_RUNTIME_UPGRADE,
+        recompile_input.into(),
+        None,
+        None,
+    );
+    assert!(!result.is_success());
+}
 
 #[test]
 #[should_panic(


### PR DESCRIPTION
## Summary

- add an owner-only `upgradeEvmTo(address,uint256,string,bytes)` entry point that accepts deployed Solidity runtime bytecode
- add a dedicated privileged host syscall that installs canonical EVM ownable-account metadata while preserving the target account and storage
- keep the existing WASM upgrade ABI unchanged and keep `recompile(address)` WASM-only

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p fluentbase-sdk -p fluentbase-revm --all-targets -- -D warnings`
- `cargo test --manifest-path contracts/Cargo.toml -p fluentbase-contracts-runtime-upgrade --lib`
- `cargo test -p fluentbase-e2e test_upgrade_solidity_contract_preserves_storage -- --nocapture`

Linear: FLU-998


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for upgrading Solidity/EVM contracts through the runtime upgrade interface.
  * EVM bytecode is validated for size and deployment compatibility before installation.
  * Added an `upgradeEvmTo` entry point with ownership checks and upgrade event reporting.
* **Bug Fixes**
  * Improved runtime upgrade input parsing and address handling.
  * Upgraded contracts retain existing storage values.
* **Tests**
  * Added coverage for upgrade call encoding and end-to-end Solidity contract upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->