### PR TITLE
fix(runtime-upgrade): preserve EVM upgrade bytecode

### DIFF
--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -1230,7 +1230,7 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                 current_target_address == PRECOMPILE_RUNTIME_UPGRADE,
                 MalformedBuiltinParams
             );
-            let (input, lazy_contract_input) = get_input_validated!(>= 20);
+            let (input, lazy_contract_input) = get_input_validated!(>= Address::len_bytes());
             let target_address = Address::from_slice(&input[..Address::len_bytes()]);
             debug_syscall!("UPGRADE_RUNTIME", "target={:?}", target_address);
             // P.S: We can't validate the target address here, otherwise it will require a fork
@@ -1262,7 +1262,7 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                 current_target_address == PRECOMPILE_RUNTIME_UPGRADE,
                 MalformedBuiltinParams
             );
-            let (input, lazy_contract_input) = get_input_validated!(>= 21);
+            let (input, lazy_contract_input) = get_input_validated!(>= Address::len_bytes());
             let target_address = Address::from_slice(&input[..Address::len_bytes()]);
             let Ok(evm_binary) = lazy_contract_input() else {
                 return_halt!(MemoryOutOfBounds);

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -1268,7 +1268,7 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
                 return_halt!(MemoryOutOfBounds);
             };
             let evm_binary: Bytes = evm_binary.into();
-            if evm_binary.len() > EVM_MAX_CODE_SIZE {
+            if evm_binary.is_empty() || evm_binary.len() > EVM_MAX_CODE_SIZE {
                 return_halt!(MalformedBuiltinParams);
             }
             #[cfg(feature = "std")]

--- a/e2e/src/update_account.rs
+++ b/e2e/src/update_account.rs
@@ -68,6 +68,10 @@ fn test_upgrade_solidity_contract_preserves_storage() {
         Some(&U256::from_be_slice(stored_value.as_slice()))
     );
 
+    let result = ctx.call_evm_tx(DEPLOYER_ADDRESS, contract_address, Bytes::new(), None, None);
+    assert!(result.is_success(), "{result:?}");
+    assert_eq!(result.output().unwrap(), stored_value.as_slice());
+
     let mut recompile_args = BytesMut::new();
     SolidityABI::<(Address,)>::encode_function_args(&(contract_address,), &mut recompile_args)
         .unwrap();


### PR DESCRIPTION
## Summary

- consume exactly the encoded 20-byte address header for EVM runtime upgrades
- express both WASM and EVM runtime-upgrade headers with `Address::len_bytes()`
- execute the upgraded EVM contract in the regression test and assert its preserved storage return value

## Root cause

`upgrade_evm_runtime_into` writes `address || bytecode`, but the EVM syscall handler consumed 21 bytes before reading the bytecode. That dropped the first opcode and shifted the analyzed program by one byte.

## Verification

- Regression test before the fix: failed because the upgraded contract returned empty output instead of the stored 32-byte value
- `cargo test -p fluentbase-e2e test_upgrade_solidity_contract_preserves_storage -- --nocapture`
- `cargo test -p fluentbase-e2e --no-default-features --features std test_upgrade_solidity_contract_preserves_storage -- --nocapture`
- `cargo test -p fluentbase-e2e update_account:: -- --nocapture`
- `cargo clippy -p fluentbase-revm -p fluentbase-e2e --all-targets -- -D warnings`
- `cargo fmt --check`

## Live-network impact check

Scanned every `RuntimeUpgraded(address,bytes32,string,bytes32)` log emitted by the runtime-upgrade contract and fetched the full calldata for every unique transaction, including nested Safe calls:

- devnet through block 3,980,666: 147 transactions
- testnet through block 33,527,771: 135 transactions
- mainnet through block 11,748,573: 85 transactions

No transaction calldata contained the affected `upgradeEvmTo(address,uint256,string,bytes)` selector (`0x39135ae2`). Existing live upgrades used other runtime-upgrade paths, so no live EVM contract was upgraded through the faulty path.

Linear: https://linear.app/fluentlabs-xyz/issue/FLU-1024/fix-evm-runtime-upgrade-syscall-header-length


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime contract upgrades by correctly validating target addresses.
  * WASM and EVM upgrades no longer require unnecessary contract data beyond the address.
  * Preserved contract storage is now verified after upgrades to ensure existing values remain accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->