### PR TITLE
chore: bump rwasm to 0.4.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12324,9 +12324,9 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e76cddefd31473f933059faa2b11efca2489337b2b785c2e2b7110fac45e1f"
+checksum = "f01cfed0a61eba768d862177034af80731bbcfe0a9ab5ecc96a5f49bc5e222c8"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ fluentbase-types = { path = "./crates/types", default-features = false, version 
 #solana_rbpf = { path = "../rbpf", default-features = false }
 
 # rwasm
-rwasm = { version = "0.4.5", default-features = false }
+rwasm = { version = "0.4.6", default-features = false }
 
 # alloy
 alloy-primitives = { version = "1.5.6", default-features = false, features = ["map-foldhash", "sha3-keccak", "rlp"] }

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -4187,9 +4187,9 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e76cddefd31473f933059faa2b11efca2489337b2b785c2e2b7110fac45e1f"
+checksum = "f01cfed0a61eba768d862177034af80731bbcfe0a9ab5ecc96a5f49bc5e222c8"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",

--- a/evm-e2e/Cargo.lock
+++ b/evm-e2e/Cargo.lock
@@ -4173,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e76cddefd31473f933059faa2b11efca2489337b2b785c2e2b7110fac45e1f"
+checksum = "f01cfed0a61eba768d862177034af80731bbcfe0a9ab5ecc96a5f49bc5e222c8"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -4067,9 +4067,9 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e76cddefd31473f933059faa2b11efca2489337b2b785c2e2b7110fac45e1f"
+checksum = "f01cfed0a61eba768d862177034af80731bbcfe0a9ab5ecc96a5f49bc5e222c8"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",


### PR DESCRIPTION
## Summary

- Update the workspace and dependent lockfiles from rwasm 0.4.5 to 0.4.6.
- Refresh the resolved package checksum consistently across all lockfiles.

## Testing

- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying runtime dependency to version 0.4.6.
  * Retained the existing feature configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->