### PR TITLE
fix(revm,runtime): halt deterministically instead of panicking on the rWASM↔REVM resume boundary

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -472,7 +472,7 @@ fn execute_rwasm_frame<CTX: ContextTr, INSP: Inspector<CTX>>(
 ///
 /// This function re-enters the runtime via `syscall_resume_impl`, charges gas, and then
 /// routes the final result through the normal halt path.
-fn execute_rwasm_resume<CTX: ContextTr, INSP: Inspector<CTX>>(
+pub(crate) fn execute_rwasm_resume<CTX: ContextTr, INSP: Inspector<CTX>>(
     frame: &mut RwasmFrame,
     ctx: &mut CTX,
     interruption_outcome: SystemInterruptionOutcome,
@@ -486,8 +486,20 @@ fn execute_rwasm_resume<CTX: ContextTr, INSP: Inspector<CTX>>(
     } = interruption_outcome;
 
     // `result` is expected to exist if we got here; interruption plumbing guarantees it.
-    let result = result.unwrap();
+    // If the handler failed to fill it, halt the transaction deterministically instead of
+    // panicking: with `panic = "abort"` a panic here would kill the node.
     let call_id = inputs.call_id;
+    let Some(result) = result else {
+        warn!(
+            call_id,
+            "revm: missing interruption result on resume, halting frame"
+        );
+        default_runtime_executor().forget_runtime(call_id);
+        return Ok(NextAction::error(
+            ExitCode::UnknownError,
+            frame.interpreter.gas,
+        ));
+    };
     let preloaded_slot_costs = inputs.preloaded_slot_costs.clone();
 
     // Convert REVM gas accounts into runtime fuel units.
@@ -538,8 +550,17 @@ fn execute_rwasm_resume<CTX: ContextTr, INSP: Inspector<CTX>>(
         inputs.fuel16_ptr,
     ) else {
         // Note: this should never happen, because we always call resume here at 0 depth level, but
-        //  it's the only error that can be triggered inside
-        unreachable!("revm: received exit code from resume, this should never happen");
+        //  it's the only error that can be triggered inside. Halt deterministically instead of
+        //  panicking: with `panic = "abort"` a panic here would kill the node.
+        warn!(
+            call_id,
+            "revm: received exit code from resume, halting frame"
+        );
+        default_runtime_executor().forget_runtime(call_id);
+        return Ok(NextAction::error(
+            ExitCode::UnknownError,
+            frame.interpreter.gas,
+        ));
     };
 
     let return_data: Bytes = runtime_context.execution_result.return_data.into();
@@ -618,7 +639,7 @@ fn get_ownable_account_mut<'a, CTX: ContextTr + 'a>(
 /// - update ownable account metadata if present
 ///
 /// This is effectively the bridge from system runtime semantics back into REVM journal writes.
-fn process_runtime_execution_outcome<CTX: ContextTr>(
+pub(crate) fn process_runtime_execution_outcome<CTX: ContextTr>(
     target_address: &Address,
     ctx: &mut CTX,
     gas: &mut Gas,
@@ -694,11 +715,16 @@ fn process_runtime_execution_outcome<CTX: ContextTr>(
 
     if let Some(new_metadata) = new_metadata {
         // Safety: `new_metadata` should only be set by ownable accounts. If a non-ownable system
-        // contract sets it, that indicates a severe invariant break.
-        let owner_address = ownable_account_bytecode
-            .as_ref()
-            .map(|v| v.owner_address)
-            .unwrap();
+        // contract sets it, that indicates a severe invariant break; fail the frame
+        // deterministically instead of panicking (with `panic = "abort"` a panic kills the node).
+        let Some(owner_address) = ownable_account_bytecode.as_ref().map(|v| v.owner_address) else {
+            warn!(
+                ?target_address,
+                "revm: new_metadata returned for a non-ownable account, halting frame"
+            );
+            *exit_code = ExitCode::UnknownError;
+            return Ok(());
+        };
         ctx.journal_mut().set_code(
             *target_address,
             Bytecode::new_ownable_account(owner_address, new_metadata),
@@ -799,7 +825,7 @@ fn process_execution_result<CTX: ContextTr, INSP: Inspector<CTX>>(
 ///
 /// For interruptions, we decode invocation params from return bytes and delegate to the
 /// host interruption executor.
-fn process_exec_result<CTX: ContextTr, INSP: Inspector<CTX>>(
+pub(crate) fn process_exec_result<CTX: ContextTr, INSP: Inspector<CTX>>(
     frame: &mut RwasmFrame,
     ctx: &mut CTX,
     inspector: Option<&mut INSP>,
@@ -823,12 +849,21 @@ fn process_exec_result<CTX: ContextTr, INSP: Inspector<CTX>>(
     let call_id = exit_code as u32;
 
     // Decode syscall invocation parameters from return data.
+    //
+    // Interruption params are produced by the trusted SDK and must always decode. If they don't,
+    // drop the saved runtime and halt the frame deterministically instead of panicking: with
+    // `panic = "abort"` a panic here would kill the node.
     let Some(syscall_params) = SyscallInvocationParams::decode(&return_data) else {
-        unreachable!(
-            "revm: can't decode invocation params: exit_code={}, return_data={}",
-            exit_code,
-            return_data.len()
+        warn!(
+            call_id,
+            return_data_len = return_data.len(),
+            "revm: can't decode invocation params, halting frame"
         );
+        default_runtime_executor().forget_runtime(call_id);
+        return Ok(NextAction::error(
+            ExitCode::UnknownError,
+            frame.interpreter.gas,
+        ));
     };
 
     let gas = frame.interpreter.gas;

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -1099,3 +1099,118 @@ mod storage_inspector_tests {
         assert_eq!(inspector.step_end_value, Some(new_value));
     }
 }
+
+/// Regression tests for the rWASM↔REVM resume boundary: host-side invariant violations must
+/// resolve into deterministic transaction halts, never panics (the release profile is
+/// `panic = "abort"`, so a panic on this path kills the node).
+#[cfg(test)]
+mod resume_boundary_tests {
+    use super::*;
+    use crate::executor::{
+        execute_rwasm_resume, process_exec_result, process_runtime_execution_outcome,
+    };
+    use fluentbase_sdk::{system::RuntimeExecutionOutcomeV1, ExitCode};
+    use revm::handler::system_interruption::{SystemInterruptionInputs, SystemInterruptionOutcome};
+
+    fn new_context() -> RwasmContext<InMemoryDB> {
+        let mut ctx = RwasmContext::new(InMemoryDB::default(), RwasmSpecId::PRAGUE);
+        ctx.cfg = CfgEnv::new_with_spec(RwasmSpecId::PRAGUE);
+        ctx.block = BlockEnv::default();
+        ctx.tx = TxEnv::default();
+        ctx
+    }
+
+    #[test]
+    fn malformed_interruption_params_halt_instead_of_panicking() {
+        let mut ctx = new_context();
+        let mut frame = RwasmFrame::default();
+        frame.interpreter.gas = Gas::new(100_000);
+
+        // A positive exit code marks an interruption whose invocation params must decode from
+        // return data; feed undecodable garbage and expect a clean deterministic halt.
+        let next_action = process_exec_result::<_, NoOpInspector>(
+            &mut frame,
+            &mut ctx,
+            None,
+            5,
+            bytes!("deadbeef"),
+            None,
+        )
+        .unwrap();
+
+        match next_action {
+            NextAction::Return(result) => {
+                assert_eq!(result.result, InstructionResult::UnknownError);
+            }
+            _ => panic!("expected a returned halt"),
+        }
+    }
+
+    #[test]
+    fn missing_resume_result_halts_instead_of_panicking() {
+        let mut ctx = new_context();
+        let mut frame = RwasmFrame::default();
+        frame.interpreter.gas = Gas::new(100_000);
+
+        // The interruption handler must fill `result` before resume; simulate the broken
+        // ordering where it did not.
+        let outcome = SystemInterruptionOutcome {
+            inputs: SystemInterruptionInputs {
+                call_id: 7,
+                code_hash: B256::ZERO,
+                input: 0..0,
+                fuel_limit: 0,
+                state: STATE_MAIN,
+                fuel16_ptr: 0,
+                gas: Gas::new(0),
+                preloaded_slot_costs: None,
+            },
+            result: None,
+            halted_frame: false,
+        };
+
+        let next_action =
+            execute_rwasm_resume::<_, NoOpInspector>(&mut frame, &mut ctx, outcome, None).unwrap();
+
+        match next_action {
+            NextAction::Return(result) => {
+                assert_eq!(result.result, InstructionResult::UnknownError);
+            }
+            _ => panic!("expected a returned halt"),
+        }
+    }
+
+    #[test]
+    fn new_metadata_without_ownable_account_fails_frame_instead_of_panicking() {
+        let mut ctx = new_context();
+        let target = address!("2222222222222222222222222222222222222222");
+        let mut gas = Gas::new(100_000);
+        let mut exit_code = ExitCode::Ok;
+
+        // A structured outcome carrying `new_metadata` while the executing account is not an
+        // ownable account is a severe invariant break; it must fail the frame, not the node.
+        let outcome = RuntimeExecutionOutcomeV1 {
+            exit_code: ExitCode::Ok,
+            output: Bytes::new(),
+            storage: None,
+            logs: vec![],
+            new_metadata: Some(bytes!("1234")),
+            touched_storage_slots: None,
+            transfers: None,
+        };
+        let mut return_data: Bytes = outcome.encode().into();
+
+        process_runtime_execution_outcome(
+            &target,
+            &mut ctx,
+            &mut gas,
+            &mut return_data,
+            &mut exit_code,
+            None,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(exit_code, ExitCode::UnknownError);
+    }
+}

--- a/crates/runtime/src/executor.rs
+++ b/crates/runtime/src/executor.rs
@@ -455,11 +455,17 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         exit_code: i32,
     ) -> ExecutionResult {
         let timer = RuntimeTimer::start();
+        // The call_id must reference a runtime saved by this transaction. If it doesn't, that's a
+        // host-side invariant break; return a deterministic error instead of panicking, because
+        // with `panic = "abort"` a panic here would kill the node.
         let Some(mut runtime) = self.recoverable_runtimes.remove(&call_id) else {
-            unreachable!(
-                "runtime: missing recoverable runtime for resume, this should never happen: call_id={}, fuel_consumed={}, exit_code={}",
-                call_id, fuel_consumed, exit_code
-            )
+            return ExecutionResult {
+                exit_code: ExitCode::UnknownError.into_i32(),
+                fuel_consumed,
+                fuel_refunded: 0,
+                output: vec![],
+                return_data: vec![],
+            };
         };
         metrics::set_recoverable_runtimes(self.recoverable_runtimes.len());
         let (mode, state) = runtime_labels(&runtime);
@@ -523,9 +529,12 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         offset: usize,
         buffer: &mut [u8],
     ) -> Result<(), TrapCode> {
-        let runtime_ref = self.recoverable_runtimes.get_mut(&call_id).expect(
-            "runtime: missing recoverable runtime for memory read, this should never happen",
-        );
+        // Reads must target a live suspended runtime. If the runtime is gone, surface a trap the
+        // callers already handle gracefully instead of panicking (with `panic = "abort"` a panic
+        // here would kill the node).
+        let Some(runtime_ref) = self.recoverable_runtimes.get_mut(&call_id) else {
+            return Err(TrapCode::MemoryOutOfBounds);
+        };
         runtime_ref.memory_read(offset, buffer)
     }
 }
@@ -556,7 +565,7 @@ mod tests {
         MAX_IN_FLIGHT_MEMORY_BYTES,
     };
     use rwasm::{
-        ExecutionEngine, RwasmModule, StrategyDefinition, N_BYTES_PER_MEMORY_PAGE,
+        ExecutionEngine, RwasmModule, StrategyDefinition, TrapCode, N_BYTES_PER_MEMORY_PAGE,
         N_DEFAULT_MAX_MEMORY_PAGES,
     };
 
@@ -591,6 +600,30 @@ mod tests {
         assert_eq!(result.fuel_consumed, 100);
         assert_eq!(result.fuel_refunded, 0);
         assert!(result.output.is_empty());
+    }
+
+    #[test]
+    fn resume_with_missing_recoverable_runtime_returns_deterministic_error() {
+        let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
+
+        // No runtime was ever saved under this call_id; resume must fail cleanly, not panic.
+        let result = executor.resume(42, &[], 0, 100, 0, ExitCode::Ok.into_i32());
+
+        assert_eq!(result.exit_code, ExitCode::UnknownError.into_i32());
+        assert_eq!(result.fuel_consumed, 100);
+        assert_eq!(result.fuel_refunded, 0);
+        assert!(result.output.is_empty());
+        assert!(result.return_data.is_empty());
+    }
+
+    #[test]
+    fn memory_read_with_missing_recoverable_runtime_returns_trap() {
+        let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
+
+        let mut buffer = [0u8; 4];
+        let result = executor.memory_read(42, 0, &mut buffer);
+
+        assert_eq!(result, Err(TrapCode::MemoryOutOfBounds));
     }
 
     /// Initial pages the Rust/Wasm toolchain emits for a contract that allocates nothing of its

--- a/docs/07-rwasm-integration.md
+++ b/docs/07-rwasm-integration.md
@@ -67,6 +67,12 @@ A dependency bump can silently change any of these.
 2. rerun interruption/resume e2e paths,
 3. recheck allocation/bounds safety on memory helper paths,
 4. verify gas/fuel settlement remains deterministic,
-5. update docs in same PR.
+5. re-audit the invariant-violation halt paths on the rWASM↔REVM resume boundary
+   (`crates/revm/src/executor.rs`: `execute_rwasm_resume`, `process_exec_result`,
+   `process_runtime_execution_outcome`; `crates/runtime/src/executor.rs`: `resume`,
+   `memory_read`) — an upgrade that changes trap/interruption behavior may make these
+   deterministic `UnknownError` halts reachable, and they must stay halts, not panics
+   (release profile is `panic = "abort"`),
+6. update docs in same PR.
 
 If one of these steps is skipped, regressions can escape into consensus path.


### PR DESCRIPTION
## Summary

Resolves [FLU-1161](https://linear.app/fluentlabs-xyz/issue/FLU-1161/medium-consensus-critical-rwasmrevm-resume-boundary-uses).

The host side of the interruption/resume protocol enforced several "this should never happen" invariants with `unwrap()` / `expect()` / `unreachable!()`. Since the release profile uses `panic = "abort"`, any of these firing would abort the process — a node crash, and a coordinated chain halt if the trigger is block-deterministic. This PR converts all six sites into graceful, deterministic error halts so an invariant violation fails the transaction instead of killing the node.

## Changes

**`crates/revm/src/executor.rs`**
- `execute_rwasm_resume`: a missing interruption `result` and an error from `syscall_resume_impl` now log a warning, drop the saved recoverable runtime for that `call_id`, and halt the frame with `ExitCode::UnknownError` (a deterministic REVM halt).
- `process_exec_result`: undecodable syscall invocation params take the same path instead of `unreachable!`.
- `process_runtime_execution_outcome`: `new_metadata` returned for a non-ownable account sets the frame's exit code to `UnknownError` and skips `set_code`; the journal checkpoint revert discards any partial writes.

**`crates/runtime/src/executor.rs`**
- `resume` with an unknown `call_id` returns an `ExecutionResult` with `ExitCode::UnknownError`, mirroring the existing `call_id`-overflow precedent and preserving the passed-in fuel accounting.
- `memory_read` with an unknown `call_id` returns `Err(TrapCode::MemoryOutOfBounds)`, which every caller in `syscall.rs` already handles gracefully.

**Docs**: added a re-audit step for these sites to the rWasm upgrade checklist in `docs/07-rwasm-integration.md`, since these halt paths are defended by upstream invariants that a dependency bump can silently break.

## Design note

`ExitCode::UnknownError` was chosen over `UnexpectedFatalExecutionFailure` because the latter maps to `InstructionResult::FatalExternalError`, which escalates beyond a per-transaction halt; `UnknownError` guarantees the failure stays a caught, deterministic transaction result on every path.

## Testing

- New regression tests in `crates/revm/src/tests.rs` (`resume_boundary_tests`) feed malformed interruption params, a missing resume result, and a `new_metadata`-without-ownable-account outcome, asserting a clean `InstructionResult::UnknownError` halt.
- New tests in the runtime crate cover missing-recoverable-runtime states for `resume` and `memory_read`.
- Full suites pass: fluentbase-runtime (74 passed), fluentbase-revm (45 passed); rustfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)