### PR TITLE
ci(release): require canonical release tags before signing artifacts or moving Docker latest (FLU-1164)

### DIFF
--- a/.github/scripts/check-release-supply-chain.sh
+++ b/.github/scripts/check-release-supply-chain.sh
@@ -24,4 +24,40 @@ for required in 'release-manifest.sh create' 'release-manifest.sh verify' 'sbom'
   fi
 done
 
+# --- Canonical release-tag guards (independent of the workflow argument) ---
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The tag grammar must keep rejecting invalid suffixes (v1.4.0oops, v1.4.00, ...).
+if ! "${script_dir}/check-release-tag.sh" --self-test >&2; then
+  echo "check-release-tag.sh self-test failed" >&2
+  fail=1
+fi
+
+# Every pipeline that signs artifacts, drafts releases, publishes crates, or
+# moves Docker channels must call the shared canonical tag validation.
+for guarded in .github/workflows/release.yml .github/workflows/publish.yml \
+  .github/workflows/build-docker.yml .github/workflows/docker.yml Makefile; do
+  if ! grep -q 'check-release-tag\.sh' "$guarded"; then
+    echo "${guarded}: missing canonical release-tag validation (check-release-tag.sh)" >&2
+    fail=1
+  fi
+done
+
+# In release.yml, every job that builds, signs, uploads, or drafts a release
+# must sit behind check-version in the job DAG, so a noncanonical tag cannot
+# produce externally visible artifacts even when the workflow fails overall.
+release_workflow=.github/workflows/release.yml
+for job in build-genesis build draft-release; do
+  needs="$(awk -v job="$job" '
+    $0 == "  " job ":" { injob = 1; next }
+    injob && /^  [A-Za-z0-9_-]+:/ { injob = 0 }
+    injob && /^    needs:/ { print; exit }
+  ' "$release_workflow")"
+  if [[ "$needs" != *check-version* ]]; then
+    echo "${release_workflow}: job '${job}' must depend on check-version (found: ${needs:-no needs line})" >&2
+    fail=1
+  fi
+done
+
 exit "$fail"

--- a/.github/scripts/check-release-tag.sh
+++ b/.github/scripts/check-release-tag.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Canonical release-tag validation, shared by every pipeline that signs
+# artifacts, drafts releases, publishes crates, or moves Docker channels
+# (release.yml, publish.yml, docker.yml, build-docker.yml, Makefile).
+#
+# Usage:
+#   check-release-tag.sh <tag> [cargo-toml]   validate a tag against the
+#                                             workspace version (default ./Cargo.toml)
+#   check-release-tag.sh --self-test          run the built-in guard tests
+#
+# The only accepted forms are:
+#   v<workspace-version>          -> channel=stable
+#   v<workspace-version>-rc.N     -> channel=prerelease (N >= 1, no leading zeros)
+# and when the workspace version is itself an rc (X.Y.Z-rc.N), only the exact
+# tag v<workspace-version> is accepted (channel=prerelease).
+#
+# On success the resolved channel is printed to stdout as `channel=<...>` and
+# appended to $GITHUB_OUTPUT when set. Anything else fails with exit 1: a typo
+# such as v1.4.0oops or v1.4.00 must never reach signing, release drafts,
+# crates.io publishing, or the Docker `latest` channel.
+set -euo pipefail
+
+readonly NUM='(0|[1-9][0-9]*)'
+readonly BASE_RE="^${NUM}\.${NUM}\.${NUM}$"
+readonly RC_RE='^rc\.([1-9][0-9]*)$'
+
+validate() {
+  local tag="$1" cargo_ver="$2" base rc channel
+
+  base="$cargo_ver"
+  rc=""
+  if [[ "$cargo_ver" == *-* ]]; then
+    base="${cargo_ver%%-*}"
+    rc="${cargo_ver#*-}"
+  fi
+  if ! [[ "$base" =~ $BASE_RE ]] || { [[ -n "$rc" ]] && ! [[ "$rc" =~ $RC_RE ]]; }; then
+    echo "workspace version '$cargo_ver' is not canonical (X.Y.Z or X.Y.Z-rc.N)" >&2
+    return 1
+  fi
+
+  if [[ "$tag" == "v$cargo_ver" ]]; then
+    channel="stable"
+    if [[ -n "$rc" ]]; then
+      channel="prerelease"
+    fi
+  elif [[ -z "$rc" && "$tag" == "v$cargo_ver-rc."* ]] \
+    && [[ "${tag#"v$cargo_ver-"}" =~ $RC_RE ]]; then
+    channel="prerelease"
+  else
+    echo "tag '$tag' is not canonical for workspace version '$cargo_ver'" >&2
+    if [[ -z "$rc" ]]; then
+      echo "accepted forms: v${cargo_ver} or v${cargo_ver}-rc.N (N >= 1)" >&2
+    else
+      echo "accepted form: v${cargo_ver}" >&2
+    fi
+    return 1
+  fi
+
+  echo "channel=$channel"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "channel=$channel" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+self_test() {
+  local failures=0
+
+  expect() {
+    local want="$1" tag="$2" cargo_ver="$3" out status
+    out="$(GITHUB_OUTPUT= validate "$tag" "$cargo_ver" 2>/dev/null)" && status=0 || status=$?
+    if [[ "$want" == "reject" ]]; then
+      if [[ "$status" -eq 0 ]]; then
+        echo "self-test: expected rejection of tag '$tag' (workspace $cargo_ver), got '$out'" >&2
+        failures=$((failures + 1))
+      fi
+    elif [[ "$status" -ne 0 || "$out" != "channel=$want" ]]; then
+      echo "self-test: expected tag '$tag' (workspace $cargo_ver) -> $want, got status=$status output='$out'" >&2
+      failures=$((failures + 1))
+    fi
+  }
+
+  expect stable     v1.4.0        1.4.0
+  expect stable     v0.3.7        0.3.7
+  expect prerelease v1.4.0-rc.1   1.4.0
+  expect prerelease v1.4.0-rc.10  1.4.0
+  expect prerelease v1.4.0-rc.2   1.4.0-rc.2
+
+  # Invalid suffixes and typos must never pass.
+  expect reject v1.4.0oops     1.4.0
+  expect reject v1.4.00        1.4.0
+  expect reject v1.4.0.1       1.4.0
+  expect reject v1.4.1         1.4.0
+  expect reject 1.4.0          1.4.0
+  expect reject vv1.4.0        1.4.0
+  expect reject v1.4.0-dev     1.4.0
+  expect reject v1.4.0-rc      1.4.0
+  expect reject v1.4.0-rc1     1.4.0
+  expect reject v1.4.0-rc.0    1.4.0
+  expect reject v1.4.0-rc.01   1.4.0
+  expect reject v1.4.0-rc.1.1  1.4.0
+  # A workspace still on an rc accepts only its exact tag.
+  expect reject v1.4.0         1.4.0-rc.2
+  expect reject v1.4.0-rc.3    1.4.0-rc.2
+  expect reject v1.4.0-rc.2-rc.1 1.4.0-rc.2
+  # Non-canonical workspace versions are refused outright.
+  expect reject v01.4.0        01.4.0
+  expect reject v1.4.0-nightly 1.4.0-nightly
+
+  if [[ "$failures" -ne 0 ]]; then
+    echo "check-release-tag.sh self-test: $failures case(s) failed" >&2
+    return 1
+  fi
+  echo "check-release-tag.sh self-test: all cases passed"
+}
+
+main() {
+  if [[ "${1:-}" == "--self-test" ]]; then
+    self_test
+    return
+  fi
+  if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "usage: $0 <tag> [cargo-toml] | $0 --self-test" >&2
+    return 2
+  fi
+  local tag="$1" cargo_toml="${2:-Cargo.toml}" cargo_ver
+  cargo_ver="$(grep -m1 '^version' "$cargo_toml" | awk -F'=' '{print $2}' | tr -d ' "')"
+  if [[ -z "$cargo_ver" ]]; then
+    echo "unable to read workspace version from $cargo_toml" >&2
+    return 1
+  fi
+  validate "$tag" "$cargo_ver"
+}
+
+main "$@"

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -35,6 +35,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - name: Validate release tag
+        id: tag
+        if: ${{ github.ref_type == 'tag' }}
+        # Tag pushes publish a public image tag and may advance `latest`, so the
+        # tag must be canonical (v<workspace-version> or v<workspace-version>-rc.N).
+        # Emits channel=stable|prerelease; only `stable` may move `latest`.
+        run: ./.github/scripts/check-release-tag.sh "${GITHUB_REF_NAME}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
@@ -62,6 +70,7 @@ jobs:
           INPUT_DOCKER_TAG: ${{ inputs.docker_tag }}
           INPUT_BRANCH: ${{ inputs.branch }}
           INPUT_PUSH_LATEST: ${{ inputs.push_latest }}
+          TAG_CHANNEL: ${{ steps.tag.outputs.channel }}
         run: |
           set -euo pipefail
 
@@ -96,8 +105,14 @@ jobs:
           IS_RC=true
           fi
 
+          # `latest` moves only for the canonical stable tag (channel=stable,
+          # emitted by check-release-tag.sh) or an explicit non-rc dispatch.
           PUSH_LATEST=false
-          if [[ "$IS_RC" != "true" ]] && { [[ "$EVENT" == "workflow_dispatch" && "${INPUT_PUSH_LATEST}" == "true" ]] || [[ "$REF_TYPE" == "tag" ]]; }; then
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+          if [[ "$IS_RC" != "true" && "${INPUT_PUSH_LATEST}" == "true" ]]; then
+          PUSH_LATEST=true
+          fi
+          elif [[ "$REF_TYPE" == "tag" && "${TAG_CHANNEL}" == "stable" ]]; then
           PUSH_LATEST=true
           fi
           TAGS="${IMAGE}:${VERSION}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,8 +20,23 @@ env:
   CXX: clang++
 
 jobs:
+  check-version:
+    name: check release tag
+    runs-on: ubuntu-24.04
+    outputs:
+      channel: ${{ steps.tag.outputs.channel }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Validate release tag
+        id: tag
+        # Both build jobs depend on this gate: only the canonical
+        # v<workspace-version> tag (channel=stable) may advance the public
+        # `latest` image, and only v<workspace-version>-rc.N builds an rc image.
+        run: ./.github/scripts/check-release-tag.sh "${GITHUB_REF_NAME}"
+
   build-rc:
-    if: contains(github.ref, '-rc')
+    needs: check-version
+    if: ${{ needs.check-version.outputs.channel == 'prerelease' }}
     name: build and push as release candidate
     runs-on: ubuntu-24.04
     permissions:
@@ -58,7 +73,8 @@ jobs:
         run: ${{ matrix.build.command }}
 
   build:
-    if: ${{ !contains(github.ref, '-rc') }}
+    needs: check-version
+    if: ${{ needs.check-version.outputs.channel == 'stable' }}
     name: build and push as latest
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Extract and sanitize version
-        id: extract_version
-        run: |
-          VERSION="${GITHUB_REF_NAME}"
-          VERSION="${VERSION//\//-}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
         with:
@@ -43,15 +36,21 @@ jobs:
         with:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Verify crate version matches tag
+      - name: Verify canonical release tag
+        # crates.io publishing is irreversible, so only the exact canonical
+        # stable tag v<workspace-version> may publish. A workflow_dispatch dry
+        # run from a non-tag ref has no tag to validate and publishes nothing.
         run: |
-          tag="${{ steps.extract_version.outputs.version }}"
-          tag="${tag#v}"
-          cargo_ver=$(grep -m1 '^version' Cargo.toml | awk -F'=' '{print $2}' | tr -d ' "')
-          [[ "$tag" == "$cargo_ver"* ]] || {
-            echo "Tag $tag doesn't match the Cargo version $cargo_ver"
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            echo "Not a tag ref; skipping tag validation (dry run only)"
+            exit 0
+          fi
+          channel="$(./.github/scripts/check-release-tag.sh "${GITHUB_REF_NAME}")"
+          echo "$channel"
+          if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" && "$channel" != "channel=stable" ]]; then
+            echo "crates.io publishing requires the canonical stable release tag" >&2
             exit 1
-          }
+          fi
 
       - name: Publish to crates.io
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,28 +49,36 @@ jobs:
 
   check-version:
     name: check version
-    if: ${{ github.event.inputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
     needs: extract-version
+    outputs:
+      channel: ${{ steps.validate.outputs.channel }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
-        with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
-      - name: Verify crate version matches tag
-        # Check that the Cargo version starts with the tag,
-        # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
+      - name: Verify canonical release tag
+        id: validate
+        # Every job that builds, signs, uploads, or drafts a release depends on
+        # this job, so nothing externally visible can be produced from a
+        # noncanonical tag (e.g. v1.4.0oops). Only v<workspace-version> and
+        # v<workspace-version>-rc.N are accepted. A dry run has no tag to
+        # validate; any other non-tag execution is refused.
+        env:
+          TAG: ${{ needs.extract-version.outputs.VERSION }}
         run: |
-          tag="${{ needs.extract-version.outputs.VERSION }}"
-          tag=${tag#v}
-          cargo_ver=$(grep -m1 '^version' Cargo.toml | awk -F'=' '{print $2}' | tr -d ' "')
-          [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn’t match the Cargo version $cargo_ver"; exit 1; }
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            ./.github/scripts/check-release-tag.sh "$TAG"
+          elif [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
+            echo "Dry run without a tag; skipping tag validation"
+          else
+            echo "Non-dry-run executions must run from a canonical release tag" >&2
+            exit 1
+          fi
 
   build-genesis:
     name: build genesis
     runs-on: ubuntu-latest
 
-    needs: extract-version
+    needs: [ extract-version, check-version ]
     permissions:
       contents: read
       packages: read
@@ -307,7 +315,7 @@ jobs:
   build:
     name: build release
     runs-on: ${{ matrix.configs.os }}
-    needs: extract-version
+    needs: [ extract-version, check-version ]
     continue-on-error: ${{ matrix.configs.allow_fail }}
     strategy:
       fail-fast: true
@@ -453,7 +461,7 @@ jobs:
 
   draft-release:
     name: draft release
-    needs: [ build, build-genesis, extract-version ]
+    needs: [ build, build-genesis, extract-version, check-version ]
     if: ${{ github.event.inputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
     env:
@@ -496,11 +504,12 @@ jobs:
         env:
           GITHUB_USER: ${{ github.repository_owner }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_CHANNEL: ${{ needs.check-version.outputs.channel }}
         # The formatting here is borrowed from Lighthouse (which is borrowed from OpenEthereum):
         # https://github.com/openethereum/openethereum/blob/6c2d392d867b058ff867c4373e40850ca3f96969/.github/workflows/build.yml
         run: |
           prerelease_flag=""
-          if [[ "${GITHUB_REF}" == *-rc* ]]; then
+          if [[ "${TAG_CHANNEL}" == "prerelease" ]]; then
             prerelease_flag="--prerelease"
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,8 @@ docker-build-push-git-sha: ## Build and push a cross-arch Docker image tagged wi
 # `docker buildx create --use --driver docker-container --name cross-builder`
 .PHONY: docker-build-push-latest
 docker-build-push-latest: ## Build and push a cross-arch Docker image tagged with the latest git tag and `latest`.
+	@./.github/scripts/check-release-tag.sh "$(GIT_TAG)" | grep -qx "channel=stable" || { \
+		echo "Refusing to move 'latest': '$(GIT_TAG)' is not the canonical stable release tag" >&2; exit 1; }
 	$(call docker_build_push,$(GIT_TAG),latest)
 
 # Note: This requires a buildx builder with emulation support. For example:


### PR DESCRIPTION
Fixes [FLU-1164](https://linear.app/fluentlabs-xyz/issue/FLU-1164/medium-require-canonical-release-tags-before-signing-artifacts-or): release validation accepted arbitrary version suffixes (`v1.4.0oops` passed the prefix check for `1.4.0`), the signing/build/draft jobs in `release.yml` did not depend on the check at all, and the Docker workflows treated every non-`-rc` `v*` tag as stable and advanced the public `latest` channel.

## Changes

**New shared validator — `.github/scripts/check-release-tag.sh`**
Single canonical tag grammar for every release pipeline: only `v<workspace-version>` (→ `channel=stable`) and `v<workspace-version>-rc.N`, N ≥ 1 (→ `channel=prerelease`) are accepted; when the workspace version is itself an rc, only its exact tag passes. Includes a `--self-test` covering invalid suffixes (`v1.4.0oops`, `v1.4.00`, `v1.4.0-rc1`, `v1.4.0.1`, …).

**`release.yml`**
- `check-version` now uses the validator and runs on every non-dry-run execution (non-tag, non-dry-run refs are refused).
- `build`, `build-genesis`, and `draft-release` all gained a hard `needs: check-version` edge, so nothing is built, signed, uploaded, or drafted from a noncanonical tag — previously these jobs ran independently and the workflow could "fail" after the artifacts and draft already existed.
- The draft's `--prerelease` flag now comes from the validated channel instead of a `*-rc*` substring match.

**`publish.yml`**
Replaces the permissive prefix comparison; crates.io publishing requires the exact canonical stable tag.

**`build-docker.yml`, `docker.yml`, `Makefile`**
Tag pushes are validated before any image is built; `latest` moves only for `channel=stable` (or an explicit non-rc `workflow_dispatch` with `push_latest`, as before). `docker.yml`'s two build jobs now sit behind a `check-version` gate keyed on the validated channel, and `make docker-build-push-latest` itself refuses a noncanonical/rc `GIT_TAG` as a last line of defense.

**Guard tests — `check-release-supply-chain.sh`** (runs in CI's `release-supply-chain` job)
- runs the tag validator's self-test (invalid-suffix regression guard),
- requires the validator marker in all four workflows and the Makefile,
- asserts the `release.yml` job-DAG edges (`build`, `build-genesis`, `draft-release` → `check-version`), verified to fail when an edge is removed.

## Validation

- `check-release-tag.sh --self-test` — all 23 cases pass.
- `check-release-supply-chain.sh .github/workflows/release.yml` — passes; fails as expected on a mutated copy with the `needs` edge removed.
- All five touched workflows YAML-validated; job DAG inspected with `yq`.
- `make GIT_TAG=v1.4.0oops docker-build-push-latest` and `GIT_TAG=v1.4.0-rc.1` both refuse before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canonical release-tag validation for stable and prerelease versions.
  * Release workflows now identify release channels consistently and gate builds, publishing, and image creation accordingly.
  * Docker `latest` images are published only for validated stable releases or eligible manual runs.

* **Bug Fixes**
  * Prevented malformed or prerelease tags from incorrectly publishing stable artifacts or advancing the `latest` image.
  * Added safeguards to ensure release jobs run only after successful version validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->