### PR TITLE
docs(audits): add internal Fluentbase security audit history

### DIFF
--- a/audits/2026-06-16-fluentbase-audit.md
+++ b/audits/2026-06-16-fluentbase-audit.md
@@ -1,0 +1,145 @@
+# Fluentbase Security Audit — 2026-06-16
+
+- **Date:** 2026-06-16 (fixes landed 2026-06-17)
+- **Repository:** `fluentlabs-xyz/fluentbase`
+- **Audited commit:** not recorded in the ticket (branch `devel`)
+- **Linear:** `FLU-856`
+- **Fix PRs:** #440
+- **Focus:** Offensive re-audit along three axes — value security (mint/steal in
+  system contracts), node liveness (crafted tx/block halting the node), and common
+  Rust attack classes + dependency advisories.
+
+## Scope
+
+The token, bridge, fee-manager, storage, and upgrade-authority value paths; host
+panic/liveness surfaces (module factory, deploy path, decoders, genesis loading);
+and workspace dependency advisories. Two headline results: (1) no
+mint/steal/double-spend/upgrade-bypass exists — the value layer is well-built and
+needed no code changes; (2) the real new risk is a panic-amplifier that can turn
+any single host panic into a persistent chain halt.
+
+## Result
+
+| Crit | High | Medium | Low/Info |
+| --- | --- | --- | --- |
+| 0 | 2 | 3 | several |
+
+All value-theft attacks were **blocked** (see Notes). The findings below are
+liveness, allocation, and process/operational hardening items.
+
+## Findings
+
+### High
+
+#### N1 — Panic amplifier: any host panic can permanently brick the node
+
+- **Severity:** High · **Status:** Recommended (tracked) · **Linear:** `FLU-856` · **Fix:** —
+- **Where:** `Cargo.toml` `panic = "unwind"` with **zero** `catch_unwind` in the
+  codebase; `crates/runtime/src/module_factory.rs` holds execution state behind a
+  global `Arc<Mutex>` accessed via `.lock().unwrap()`.
+- **Impact:** If any host panic fires while the lock is held, the `Mutex` is
+  **poisoned**, so every subsequent block's `.lock().unwrap()` panics forever — a
+  persistent halt, not a one-block failure. This converts every latent/gated host
+  panic into a much sharper liveness risk.
+- **Remediation:** Wrap block/tx execution in `catch_unwind` (or `panic = "abort"`
+  + supervised restart), and replace `.lock().unwrap()` with poison recovery
+  (`lock().unwrap_or_else(|e| e.into_inner())`).
+
+#### N2 — Host panic on malformed module at deploy
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-856` · **Fix:** #440
+- **Where:** `crates/revm/src/executor.rs` — `RwasmModule::new(...)` reaches
+  `unreachable!("rwasm: malformed rwasm binary")` on bad bytes, running natively
+  during CREATE.
+- **Impact:** Gated today to delegated-runtime-owned accounts, but it sits directly
+  on the runtime-upgrade / recompile path. Any translator bug emitting a
+  `0xEF`-prefixed-but-undecodable output is an instant halt.
+- **Remediation:** Return `ExitCode::MalformedBuiltinParams`; never `unreachable!`
+  on bytes crossing the VM boundary.
+
+#### Genesis signature verification stub
+
+- **Severity:** High (devnet/testnet) / Low (mainnet) · **Status:** Fixed · **Linear:** `FLU-856` · **Fix:** #440
+- **Where:** `crates/node/src/utils.rs` — signature verification is a no-op stub.
+- **Impact:** Devnet/testnet have no hash pin, so a substituted genesis is
+  accepted; mainnet is hash-pinned.
+- **Remediation:** Implement real fail-closed detached-signature verification.
+
+### Medium
+
+#### N3 — Unbounded host allocation (OOM) in bincode decode
+
+- **Severity:** Medium (latent) · **Status:** Recommended (tracked) · **Linear:** `FLU-856` · **Fix:** —
+- **Where:** `crates/types/src/bincode.rs` and `bincode::config::legacy()` callers
+  set no decode limit; host-side `Vec::with_capacity(len)` in
+  `system/new_frame_input.rs` and `system/journal_storage.rs` trusts a length
+  prefix.
+- **Impact:** OOM primitive; gated today because the lengths come from the trusted
+  system runtime.
+- **Remediation:** Apply `.with_limit::<N>()` on every host decode.
+
+#### Genesis zip-bomb
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-856` · **Fix:** #440
+- **Where:** `crates/node/src/utils.rs` — `read_to_string` on a `GzDecoder` with no
+  size cap → startup OOM.
+- **Remediation:** `.take(MAX)` on the decompression stream.
+
+#### Shared default authority for two roles (operational)
+
+- **Severity:** Medium (operational) · **Status:** Recommended (tracked) · **Linear:** `FLU-856` · **Fix:** —
+- **Where:** `crates/types/src/genesis.rs` sets the same default authority for both
+  runtime-upgrade **and** fee-manager.
+- **Impact:** Whoever holds that key controls arbitrary-code-install on any account
+  **and** the fee treasury until owners are reassigned.
+- **Remediation:** Use distinct keys per role; confirm the post-genesis runbook
+  reassigns both to multisigs.
+
+### Low / Informational
+
+- **No `cargo-deny`/`cargo-audit` gate** (process gap). Live advisory hits were all
+  transitive/non-consensus (`ring 0.16.20`, `rustls 0.21`, `tungstenite 0.20`,
+  `spin 0.5.2`); `curve25519-dalek 4.1.3` is the patched version. Dead
+  `libsecp256k1` declared in workspace deps — remove.
+- **`unsafe impl Send/Sync for EthVM`** (`crates/evm/src/evm.rs`) — unsound over
+  revm's `Rc`-backed `SharedMemory`; no cross-thread use today (latent).
+- **`overflow-checks = false` in release** — not exploitable (value/gas/fuel paths
+  use `checked_*`/`saturating_*`); enable once N1 is fixed.
+- **Corrected ratings from the prior round:** revm `panic!("revm: fatal external
+  error")` is a real DB/`ContextError`, not calldata → Info; `crypto.rs`
+  `unwrap_exit_code` panics run guest-side → Low; `prevrandao().unwrap()` and
+  `unreachable!` syscall-param guards are host-constructed/header-gated → Low.
+
+## Notes
+
+**Value-theft matrix (all BLOCKED).** Every attack attempted against the value
+layer was blocked; no code change was needed there.
+
+| Attack | Blocked by |
+| --- | --- |
+| Unauthorized mint to self | `caller == minter` gate, `universal-token/src/lib.rs` |
+| Burn someone else's tokens | minter-only guard |
+| `transferFrom` over/without allowance | `checked_sub` allowance written before balances |
+| Balance over/underflow (overflow-checks OFF) | every balance/supply/allowance op uses `checked_add`/`checked_sub` |
+| Permit signature replay | nonce increment + chainId/contract-bound domain + low-s, `erc2612.rs` |
+| Storage-key collision | `keccak256(key‖slot)` + ERC-7201 namespaces, `crates/sdk/src/storage/map.rs` |
+| Direct `UPGRADE_RUNTIME` syscall | `target == PRECOMPILE_RUNTIME_UPGRADE` assert, `crates/revm/src/syscall.rs` |
+| Bridge mint with no L1 deposit / forged event | post-hook requires one log from the bridge address, `crates/revm/src/bridge.rs` |
+| Bridge double-mint via nested calls / replay | per-frame log window, journaled mint reverts on revert |
+| Wrapped-token withdraw drain | reconciliation rejects `balance < Σtransfers`, `crates/revm/src/executor.rs` |
+| fee-manager non-owner withdraw | `only_owner` on every mutator, `contracts/fee-manager/src/lib.rs` |
+
+**Fix priority (as filed):** (1) N1 panic amplifier — highest leverage,
+de-risks every other host panic; (2) genesis signature stub + zip-bomb cap;
+(3) N2; (4) N3 bincode limits + cargo-deny gate + dep dedup + remove `EthVM`
+Send/Sync + remove dead `libsecp256k1`.
+
+## Re-review checklist for future audits
+
+- Confirm block/tx execution is panic-contained and the module-factory mutex
+  recovers from poisoning (N1).
+- Confirm no `unreachable!`/`unwrap` on bytes crossing the VM boundary on the
+  CREATE / runtime-upgrade path (N2).
+- Confirm every host-side bincode decode has an explicit limit (N3).
+- Confirm genesis signature verification is fail-closed and gz decoding is size
+  capped.

--- a/audits/2026-07-10-fluentbase-audit.md
+++ b/audits/2026-07-10-fluentbase-audit.md
@@ -1,0 +1,265 @@
+# Fluentbase Security Audit — 2026-07-10
+
+- **Date:** 2026-07-10 (fixes landed 2026-07-14 → 2026-07-17)
+- **Repository:** `fluentlabs-xyz/fluentbase` (audited commit
+  `99ba646fbb64906305149fbd2c444d06bda974e4`); rWasm reviewed as a dependency
+  (`fluentlabs-xyz/rwasm` @ `46573169788f2b2b8b051b5443d398f3680146e9`)
+- **Audited commit:** `99ba646fbb64906305149fbd2c444d06bda974e4`
+- **Linear:** parent items `FLU-935`…`FLU-946` (Fluentbase); `FLU-947`…`FLU-952`
+  (rWasm dependency)
+- **Fix PRs:** Fluentbase #457–#467; rWasm #162, #163, #164
+- **Focus:** Host runtime, EVM/REVM, genesis, runtime-upgrade CLI, precompiles,
+  and the rWasm dependency reached during contract execution.
+
+## Scope
+
+Fluentbase host findings use the `H-01` / `M-0x` / `L-0x` / `I-0x` series; the
+rWasm dependency findings produced in the same pass use `RWASM-01…06`. Both are
+recorded here because this was a single combined pass; the rWasm items are kept
+for continuity with the report maintained alongside the rWasm repository.
+
+## Result
+
+| Series | Crit | High | Medium | Low | Info |
+| --- | --- | --- | --- | --- | --- |
+| Fluentbase (H/M/L/I) | 0 | 1 | 4 | 2 | 5 |
+| rWasm dependency (RWASM-01…06) | 1 | 2 | 2 | 1 | — |
+
+## Findings
+
+### Fluentbase host findings
+
+#### H-01 — Meter bulk Wasm memory and enforce transaction-wide memory limits
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-935` · **Fix:** #459
+- **Where:** `crates/sdk/src/types/rwasm.rs`, `contracts/wasm/src/lib.rs`,
+  `crates/runtime/src/executor.rs`, `crates/runtime/src/syscall_handler/host/exec.rs`.
+- **Impact:** Untrusted Wasm compiled with rWasm's default
+  `consume_fuel_for_bulk_ops = false`, so `memory.grow/fill/copy/init` and table
+  ops got fixed operator charges instead of size-proportional cost; suspended
+  parent runtimes stay resident during nested execution, letting transaction memory
+  exceed the per-runtime cap → validator OOM / block stalls / liveness degradation.
+- **Remediation:** Enable bulk-op metering on every untrusted path; add a
+  transaction-wide memory budget covering active + suspended runtimes; make
+  allocation failure deterministic.
+
+#### M-01 — Make runtime-upgrade CLI fail closed and abort partial batches
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-936` · **Fix:** #461
+- **Where:** `bins/runtime-upgrade/main.rs`.
+- **Impact:** The CLI could report success after failed/partial upgrades (malformed
+  modules skipped, missing modules → `RwasmModule::default()`, `DONE` printed
+  without checking `receipt.status`, `Ok(None)` treated as success, post-upgrade
+  mismatch only warns) → mixed system-runtime versions while the operator sees
+  exit 0.
+- **Remediation:** Preflight-reject absent/malformed/oversized artifacts; require
+  mined receipt `status == 1`; treat dropped/absent/timeout/mismatch as fatal; stop
+  on first failure with non-zero exit; verify all code hashes before broadcasting.
+
+#### M-02 — Make genesis artifacts reproducible and bind releases to immutable hashes
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-937` · **Fix:** #460
+- **Where:** `crates/genesis/build.rs`, `.github/workflows/release.yml`.
+- **Impact:** The devnet/testnet genesis timestamp derived from `SystemTime::now()`,
+  so the same commit/tag can produce a different genesis JSON/hash on rebuild;
+  operators with nominally identical artifacts can initialize different chains.
+- **Remediation:** Replace wall-clock fields with reviewed immutable manifest
+  values; publish/verify the expected uncompressed genesis hash before signing;
+  refuse publication on rebuild mismatch; signed manifest binding
+  network/version/commit/genesis hash.
+
+#### M-03 — Return canonical EVM code hash for cold EXTCODEHASH
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-938` · **Fix:** #457, #458
+- **Where:** `crates/revm/src/syscall.rs`.
+- **Impact:** `CODE_HASH` used `load_..._skip_cold_load(..., load_code = false)`;
+  on a cold load Reth supplies `code: None`, so the fallback returned the wrapper
+  bytecode hash, and after `EXTCODESIZE`/`EXTCODECOPY` warmed the account a later
+  `EXTCODEHASH` could return the original EVM hash — an access-order-dependent
+  result that breaks code-hash allowlists, proxy/factory validation, etc.
+- **Remediation:** Load code in the `CODE_HASH` path (or expose the original EVM
+  hash as first-class metadata); return one canonical hash independent of access
+  order.
+
+#### M-04 — Evict cached system-runtime instances after every abnormal exit
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-939` · **Fix:** #463
+- **Where:** `crates/runtime/src/runtime/system_runtime.rs`, `crates/sdk/src/entrypoint.rs`.
+- **Impact:** Thread-local Wasmtime instances (store/memory/globals/allocator
+  persist) were evicted after a non-OK result and `OutOfFuel`, but other Wasmtime
+  traps only set `UnexpectedFatalExecutionFailure` and returned without eviction →
+  a later call on the same worker thread can inherit dirty state or a persistent
+  trap.
+- **Remediation:** Evict after every trap/abnormal return; add an RAII health guard;
+  include metering mode + compilation config in the cache key; bound cached instance
+  count.
+
+#### L-01 — Implement or fork-gate correct BLOBBASEFEE semantics
+
+- **Severity:** Low · **Status:** Fixed · **Linear:** `FLU-940` · **Fix:** —
+- **Where:** `crates/evm/src/host.rs`.
+- **Impact:** Default REVM context selects Osaka (where `BLOBBASEFEE` is active) but
+  the host returned ordinary `block_base_fee()` instead of the blob gas price →
+  non-Ethereum value for ordinary contracts. (Deeper delegated-EVM blob finding
+  tracked later as `FLU-1057` in the 2026-08-05 audit.)
+- **Remediation:** Supply correct excess-blob-gas fields and derive the Ethereum
+  blob gas price, or fork-gate the opcode; re-enable current-fork differential
+  tests.
+
+#### L-02 — Clarify or complete WebAuthn relying-party validation
+
+- **Severity:** Low / design risk · **Status:** Fixed · **Linear:** `FLU-941` · **Fix:** #464
+- **Where:** WebAuthn precompile (`contracts/webauthn`).
+- **Impact:** Verifies challenge, type, UP/UV flags, and P-256 signature but not
+  expected RP-ID hash, origin policy, counter, or extensions, and the ABI provides
+  no expected RP ID/origin — integrators may treat a selective assertion-signature
+  primitive as a complete relying-party verifier.
+- **Remediation:** Rename/document as a selective verifier, or add expected RP-ID
+  hash + origin policy inputs and enforce them on-chain (the PR added strict
+  policy checks).
+
+#### I-01 — Remove or implement the active OAuth2 verifier placeholder
+
+- **Severity:** Informational · **Status:** Canceled · **Linear:** `FLU-942` · **Fix:** —
+- **Where:** `contracts/oauth2/src/lib.rs` returns
+  `ExitCode::UnreachableCodeReached` while its address is in the
+  system-precompile/genesis surface.
+- **Impact:** Docs/integrations could treat a non-functional address as
+  operational.
+- **Remediation:** Implement or fork-gate/remove the address. (Ticket later
+  canceled; no fix landed under this ID.)
+
+#### I-02 — Complete and gate root/STF interruption continuation
+
+- **Severity:** Informational (release-blocking before STF/zkVM) · **Status:** Fixed · **Linear:** `FLU-943` · **Fix:** #462
+- **Where:** root/STF interruption path (`syscall_exec_continue`).
+- **Impact:** Contained `unimplemented!` with unfinished root serialization; no
+  default-path user panic confirmed, but unsafe to enable for STF/zkVM mode.
+- **Remediation:** Feature/fork-gate activation until complete; remove
+  `unimplemented!`/placeholder serialization in the enabled mode.
+
+#### I-03 — Apply full storage gas semantics to metadata storage syscalls
+
+- **Severity:** Informational / secondary · **Status:** Fixed · **Linear:** `FLU-944` · **Fix:** #465
+- **Where:** metadata storage read/write handlers (journal `sload`/`sstore`).
+- **Impact:** No cold/warm access, dynamic SSTORE cost, stipend checks, or refunds;
+  reachability primarily via the excluded SVM path.
+- **Remediation:** Apply EVM-equivalent access + dynamic write pricing; enforce
+  static-call restrictions and refunds; gate SVM enablement on tests.
+
+#### I-04 — Include compilation configuration fingerprints in runtime and build caches
+
+- **Severity:** Informational / hardening · **Status:** Fixed · **Linear:** `FLU-945` · **Fix:** #466
+- **Where:** system-runtime instance cache + genesis compilation cache.
+- **Impact:** Cached by code hash / Wasm bytes even though behavior depends on
+  address-derived metering mode, memory limits, linker config, engine/backend, and
+  fork settings.
+- **Remediation:** Key caches by `(code hash, engine/backend, metering mode,
+  limits, linker version, config/fork version)` and `(Wasm hash, config
+  fingerprint)`; invalidate across upgrades/forks.
+
+#### I-05 — Harden release and CI supply-chain integrity
+
+- **Severity:** Informational / supply-chain · **Status:** Fixed · **Linear:** `FLU-946` · **Fix:** #467
+- **Where:** release/CI workflows.
+- **Impact:** Mutable action/toolchain/image/branch/tag references; `--locked` not
+  consistently required; no complete immutable provenance chain. (Further tag
+  canonicalization gaps found later as `FLU-1164` in the 2026-08-20 audit.)
+- **Remediation:** Pin Actions by SHA; pin toolchains/tools/images by version +
+  digest; use `--locked`; generate provenance + SBOM; bind all critical inputs and
+  output hashes in a signed manifest.
+
+### rWasm dependency findings
+
+#### RWASM-01 — Verify serialized rWasm before native execution
+
+- **Severity:** Critical · **Status:** Fixed · **Linear:** `FLU-947` · **Fix:** rwasm #162
+- **Where:** `RwasmModule::new_checked` (`src/module/mod.rs`); executor pointer use
+  in `vm/engine.rs`, `vm/instr_ptr.rs`, `vm/value_stack.rs`.
+- **Impact:** `new_checked` verified only bincode-decodability, not the semantic
+  invariants the native VM relies on (`source_pc`, branch/call/table targets, local
+  depths, syscall indexes). A malformed artifact can reach OOB pointer operations
+  through a safe public API — crashes, OOB read/write, UB, potentially native code
+  execution.
+- **Remediation:** Sealed verified module type + complete bytecode verifier;
+  native execution only for verified modules; raw-artifact fuzzing. (The verifier's
+  own gaps were then found in the 2026-08-07 rWasm audit, `FLU-1094`/`FLU-1097`.)
+
+#### RWASM-02 — Bind syscalls to a module-specific capability manifest
+
+- **Severity:** High · **Status:** Canceled · **Linear:** `FLU-948` · **Fix:** —
+- **Where:** serialized format (`src/module/mod.rs`), `invoke_syscall`
+  (`src/vm/executor.rs`), `src/vm/import_linker.rs`.
+- **Impact:** The format retains no authoritative import manifest; a crafted
+  artifact can encode any `sys_func_idx` registered in the runtime linker,
+  bypassing capability separation where the linker holds privileged functions.
+- **Remediation:** Per-module verified syscall manifest checked before execution.
+  (Ticket canceled; mitigated in practice by a linker containing only permitted
+  functions.)
+
+#### RWASM-03 — Meter bulk operations and make memory growth fallible
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-949` · **Fix:** rwasm #163
+- **Where:** `src/compiler/config.rs`, `src/compiler/translator.rs`,
+  `src/isa/memory.rs`, `src/isa/table.rs`, `src/vm/memory.rs`.
+- **Impact:** `consume_fuel_for_bulk_ops = false` by default → bulk ops charged only
+  fixed cost; `GlobalMemory::grow` via `BytesMut::resize` can abort the process
+  instead of returning `memory.grow == -1`. This is the rWasm-side root cause of
+  H-01.
+- **Remediation:** Proportional charging as the secure default with checked `u64`
+  arithmetic; fallible allocation returning `u32::MAX`; aggregate memory budget;
+  keep both strategy costs aligned.
+
+#### RWASM-04 — Bound serialized-module decoding allocations
+
+- **Severity:** Medium · **Status:** Canceled · **Linear:** `FLU-950` · **Fix:** —
+- **Where:** `src/module/mod.rs` (`new_checked` bincode decode).
+- **Impact:** No total/container size limit; attacker-sized code/data/element/hint
+  vectors trigger reservation/capacity-overflow/OOM before any semantic verifier
+  runs (bypasses runtime fuel).
+- **Remediation:** Per-section limits + bounded decoding. (Ticket canceled; the
+  same class was re-found and fixed as `FLU-1096` in the 2026-08-07 rWasm audit.)
+
+#### RWASM-05 — Bind suspended execution state to its instance
+
+- **Severity:** Medium · **Status:** Canceled · **Linear:** `FLU-951` · **Fix:** —
+- **Where:** `src/vm/store.rs`, `src/vm/instance.rs`, `src/vm/engine.rs`.
+- **Impact:** `resume` doesn't verify the `resumable_context` belongs to the
+  resuming instance/module; overlapping execution guarded only by `debug_assert!`;
+  resuming without a context reaches `unreachable!` → wrong-instance resume or
+  crash.
+- **Remediation:** Bind `ReusableContext` to a stable identity; typed errors
+  (`AlreadySuspended`/`NotSuspended`/`WrongInstance`/`IncompatibleModule`). (Ticket
+  canceled under this ID.)
+
+#### RWASM-06 — Reject partially encoded `source_pc` fields
+
+- **Severity:** Low · **Status:** Fixed · **Linear:** `FLU-952` · **Fix:** rwasm #164
+- **Where:** `src/module/mod.rs` (`RwasmModuleInner::decode` legacy fallback).
+- **Impact:** `UnexpectedEnd` on the final `source_pc` is treated as legacy with a
+  `debug_assert_eq!` on the missing-byte count; in release a partially-present field
+  can be accepted as legacy → truncating an artifact silently changes its entry
+  point to zero while still being accepted.
+- **Remediation:** Apply the legacy fallback only when zero bytes are present;
+  reject partial fields in debug and release; add an explicit format/version
+  discriminator.
+
+## Notes
+
+Four of the six rWasm dependency items were canceled under their July IDs
+(RWASM-02/04/05) or fixed (RWASM-01/03/06); the decode-bounds class (RWASM-04) and
+verifier-completeness class (RWASM-01) were subsequently re-found and driven to
+closure in the 2026-08-07 rWasm audit.
+
+## Re-review checklist for future audits
+
+- Confirm bulk-op metering is enabled by default and a transaction-wide memory
+  budget covers suspended frames (H-01 / RWASM-03).
+- Confirm `EXTCODEHASH` is access-order-independent for delegated EVM contracts
+  (M-03).
+- Confirm the runtime-upgrade CLI fails closed on every partial-batch path (M-01).
+- Confirm the rWasm semantic verifier is applied before native execution, and
+  re-check its completeness against `FLU-1094`/`FLU-1097` (RWASM-01).
+- Re-open the canceled hardening items (RWASM-02 capability manifest, RWASM-04
+  decode bounds, RWASM-05 suspended-state binding) if the executable format or
+  raw-artifact entry points change.

--- a/audits/2026-08-05-fluentbase-audit.md
+++ b/audits/2026-08-05-fluentbase-audit.md
@@ -1,0 +1,414 @@
+# Fluentbase Security Audit — 2026-08-05
+
+- **Date:** 2026-08-05 (fixes landed 2026-08-06 → 2026-08-07)
+- **Repository:** `fluentlabs-xyz/fluentbase`
+- **Audited commit:** `19a1fe0f9ff9616684e157a89f6eb8b313f9f980`
+- **Linear:** parent `FLU-1045`; subtasks `FLU-1046`…`FLU-1079`
+- **Fix PRs:** one per finding, landed on the finding's Linear issue
+- **Focus:** Full rWasm/EVM pass — 15 `crates/*` audits + 18 `contracts/*` audits;
+  SVM and inactive code excluded; `contracts/nitro` excluded by request.
+
+## Scope
+
+Independent per-crate and per-contract source reviews with an adversarial
+adjudication pass. 49 raw confirmed candidates were reduced to 34 unique root
+causes (5 duplicate instances merged; 10 downgraded/rejected). Contract scopes
+clean at Medium+: `bls12381`, `bn256`, `ecrecover`, `eip2935`, `identity`, `kzg`,
+`modexp`, `oauth2`, `ripemd160`, `sha256`, `wasm`.
+
+## Result
+
+| Crit | High | Medium | Total subtasks |
+| --- | --- | --- | --- |
+| 0 | 6 | 28 | 34 |
+
+All findings are Fixed unless marked otherwise (`FLU-1058` was Canceled).
+
+## Findings
+
+### High
+
+#### FLU-1046 — Bound aggregate rWasm output to prevent validator memory exhaustion
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-1046` · **Fix:** —
+- **Where:** `crates/runtime/src/syscall_handler/host/write_output.rs`,
+  `.../forward_output.rs`, `crates/runtime/src/executor.rs`.
+- **Impact:** `_write`/`_forward_output` each validate their range but append to one
+  unconstrained host `Vec<u8>`; at 3 gas/word a guest can grow host output toward
+  1 GiB under the block gas limit, and allocator failure isn't a deterministic guest
+  error → permissionless validator memory exhaustion.
+- **Remediation:** Consensus-defined aggregate output cap checked with overflow-safe
+  arithmetic before allocate/copy; deterministic VM error when exceeded.
+
+#### FLU-1047 — Meter initial rWasm memory and cap aggregate suspended-frame memory
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-1047` · **Fix:** —
+- **Where:** `crates/runtime/src/runtime/contract_runtime.rs`,
+  `crates/runtime/src/executor.rs`, `crates/runtime/src/syscall_handler/host/exec.rs`.
+- **Impact:** A guest can declare ~1024 initial pages; rWasm runs the initial
+  `memory.grow` with fuel injection disabled during instantiation (~64 MiB before
+  charging), and suspended runtimes stay in `recoverable_runtimes` with no aggregate
+  budget → memory exhaustion before per-instance limits.
+- **Remediation:** Meter/reject initial growth before allocation; aggregate memory
+  budget over active + suspended frames; fallible reservation.
+
+#### FLU-1048 — Authenticate runtime-upgrade release artifacts before signing upgrades
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-1048` · **Fix:** —
+- **Where:** `bins/runtime-upgrade/main.rs`; producer `.github/workflows/release.yml`.
+- **Impact:** The privileged CLI accepts an unsigned same-name cached JSON or the
+  gzip without verifying the detached signature/manifest; the selected hint WASM is
+  then encoded into owner-gated calls and broadcast → cache substitution / compromised
+  asset becomes operator-signed system code.
+- **Remediation:** Verify pinned signer + signature (or trusted manifest) before use;
+  bind to network/release/filename/digest; fail closed before wallet access.
+
+#### FLU-1049 — Implement fail-closed genesis signature verification for built-in networks
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-1049` · **Fix:** —
+- **Where:** `crates/node/src/utils.rs`, `crates/node/src/chainspec.rs`.
+- **Impact:** `verify_detached_signature` ignores both paths and returns success;
+  devnet/testnet lack an independent genesis hash → substituted artifacts control
+  genesis allocations and system code.
+- **Remediation:** Real verification against a pinned key, bound to the exact
+  compressed artifact; no decompression/parse before authentication.
+
+#### FLU-1050 — Revoke planned runtime-upgrade authority on ownership transitions
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-1050` · **Fix:** —
+- **Where:** `contracts/runtime-upgrade/src/lib.rs`.
+- **Impact:** `changeOwner`/`renounceOwnership` mutate only the owner slot; a
+  `planned_updater` stored by the prior owner stays authorized to install approved
+  target/hash pairs → owner rotation doesn't revoke delegated upgrade capability.
+- **Remediation:** Clear all planned-upgrade authority + plan state atomically on
+  owner transfer/renunciation; emit a cancellation event.
+
+#### FLU-1051 — Validate ABI collection lengths before unmetered runtime-upgrade allocation
+
+- **Severity:** High · **Status:** Fixed · **Linear:** `FLU-1051` · **Fix:** —
+- **Where:** `crates/codec/src/vec.rs`, `crates/sdk-derive/derive-core/src/router.rs`,
+  `contracts/runtime-upgrade/src/lib.rs`.
+- **Impact:** The router decodes both dynamic arrays before the `planUpgrade` owner
+  check; `Vec<T>::decode` calls `Vec::with_capacity(count)` before proving any body
+  exists, and runtime-upgrade runs without memory-growth fuel → a tiny
+  unauthenticated call forces a large reserve/zero-fill.
+- **Remediation:** Prove count + head/body tables fit the buffer with checked
+  arithmetic before reserve/iterate; protocol element/byte cap; `try_reserve` after
+  validation; meter decode work.
+
+### Medium
+
+#### FLU-1052 — Charge dynamic SSTORE and LOG gas before committing Universal Token effects
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1052` · **Fix:** —
+- **Where:** `contracts/universal-token/src/lib.rs`, `crates/sdk/src/system.rs`,
+  `crates/revm/src/executor.rs`.
+- **Impact:** REVM precharges SLOAD-like access then commits returned `sstore`
+  transitions and logs without transition-dependent SSTORE cost/refunds or LOG cost
+  → token calls persist state/emit logs below canonical EVM cost. (Closely related to
+  the later High `FLU-1160` in the 2026-08-20 audit.)
+- **Remediation:** Charge canonical dynamic SSTORE + cold/warm + refund + LOG gas
+  before committing; fail atomically on insufficient gas.
+
+#### FLU-1053 — Parse strict WebAuthn clientDataJSON instead of matching caller-selected substrings
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1053` · **Fix:** —
+- **Where:** `contracts/webauthn/src/lib.rs`, `.../webauthn.rs`.
+- **Impact:** `verifyStrict` compares caller-selected substrings without parsing
+  JSON; duplicate/decoy `origin`/`type`/`challenge` members can satisfy selected
+  bytes with different semantics.
+- **Remediation:** Strict deterministic parse; exactly one correctly-typed member;
+  reject duplicates/malformed; compare decoded values.
+
+#### FLU-1054 — Truncated Compact u64/i64 values panic during decode
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1054` · **Fix:** —
+- **Where:** `crates/codec/src/primitive.rs`.
+- **Impact:** Guard checks `ALIGN == 4` rather than decoded width; a 4–7-byte
+  `u64`/`i64` passes and reaches an 8-byte read → bounds panic.
+- **Remediation:** Validate `offset.checked_add(word_size)` against the chunk.
+
+#### FLU-1055 — ABI decoders panic on out-of-range dynamic offsets and bodies
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1055` · **Fix:** —
+- **Where:** `crates/codec/src/bytes_codec.rs`, `crates/codec-derive/src/lib.rs`,
+  `crates/codec/src/hash.rs`.
+- **Impact:** `SolidityABI::decode` slices attacker-controlled ranges without
+  validation → bounds panic instead of a codec error; WebAuthn's derived dynamic
+  structs give unprivileged reachability. (Re-validated as still reproducible in the
+  2026-08-20 audit.)
+- **Remediation:** One checked-range helper (`checked_add`) used by all generated
+  decoders.
+
+#### FLU-1056 — Zero-length EXTCODECOPY and CALL outputs fail on ignored large offsets
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1056` · **Fix:** —
+- **Where:** `crates/evm/src/opcodes.rs`.
+- **Impact:** With `len == 0` and a huge offset, the resume path narrows the offset
+  and raises `InvalidOperandOOG`, changing canonical semantics for EXTCODECOPY and
+  CALL/CALLCODE/DELEGATECALL/STATICCALL output ranges.
+- **Remediation:** Decode length first; zero length → empty sentinel range without
+  converting the offset.
+
+#### FLU-1057 — Delegated EVM returns zero for BLOBBASEFEE and every BLOBHASH
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1057` · **Fix:** —
+- **Where:** `crates/evm/src/host.rs`, `crates/revm/src/executor.rs`,
+  `crates/sdk/src/types/context.rs`.
+- **Impact:** `blob_gasprice()`/`blob_hash(i)` always return zero and the shared
+  context omits both → contracts commit state inconsistent with canonical EVM.
+- **Remediation:** Version the shared context to carry blob gas price + ordered
+  versioned hashes.
+
+#### FLU-1058 — Genesis downloads/caches allow unbounded compressed-body buffering
+
+- **Severity:** Medium · **Status:** Canceled · **Linear:** `FLU-1058` · **Fix:** —
+- **Where:** `crates/node/src/utils.rs`, `bins/runtime-upgrade/main.rs`.
+- **Impact:** A compromised response / replaced cache is fully buffered by
+  `Response::bytes()` then duplicated by file reads; only decompressed JSON is capped
+  → memory/disk exhaustion before authentication.
+- **Remediation:** Streaming hard-limit remediation filed; ticket canceled under this
+  ID.
+
+#### FLU-1059 — rWasm Ed25519 addition returns the unchanged first operand
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1059` · **Fix:** —
+- **Where:** `crates/types/src/rwasm_context.rs`,
+  `crates/runtime/src/syscall_handler/edwards/edwards_add.rs`.
+- **Impact:** `ed25519_add(p, q)` returns `p` while the host writes `p + q` through
+  `q_ptr` → rWasm caller gets unchanged `p`, native backend the sum
+  (backend-dependent behavior on a public crypto syscall).
+- **Remediation:** Write the result to `p_ptr` (or change both ABI sides
+  consistently).
+
+#### FLU-1060 — Delegated EVM always executes Osaka regardless of active fork
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1060` · **Fix:** —
+- **Where:** `crates/evm/src/evm.rs`, `.../utils.rs`, `contracts/evm/src/lib.rs`,
+  `crates/node/src/chainspec.rs`.
+- **Impact:** Delegated bytecode gets no active fork; `EthVM::new` always selects
+  Osaka, so pre-activation opcodes (e.g. `CLZ`) execute while the spec declares
+  Prague.
+- **Remediation:** Carry a versioned active `SpecId` through the shared context; init
+  runtime flags + gas from it; include fork in cache identity.
+
+#### FLU-1061 — Unknown RPC transaction type stops consensus block ingestion
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1061` · **Fix:** —
+- **Where:** `crates/node/src/launcher.rs`.
+- **Impact:** An unknown transaction envelope reaches `expect` and panics the
+  detached subscription task; the outer loop ends "successfully" and the node
+  silently stops following blocks until restart. (Still the canonical tracker as of
+  the 2026-08-20 audit.)
+- **Remediation:** Concrete network type or fallible conversion; supervise the
+  subscription; treat unexpected termination as retryable/fatal, not success.
+
+#### FLU-1062 — Malformed system precompiles halt without consuming supplied gas
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1062` · **Fix:** —
+- **Where:** `contracts/blake2f` (representative), `bls12381`, `kzg`, `modexp`,
+  `ripemd160`, BN256 invalid-input paths; `crates/runtime/src/executor.rs`,
+  `crates/revm/src/executor.rs`.
+- **Impact:** A direct malformed precompile call returns `Err` before success-only
+  `sync_evm_gas`; the rWasm engine reports ~no fuel and `process_halt` returns
+  remaining frame gas, whereas native REVM spends all gas.
+- **Remediation:** Centrally enforce that exceptional rWasm precompile halts spend
+  the frame's remaining regular gas.
+
+#### FLU-1063 — Published struct ABI selectors diverge from compiled routers
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1063` · **Fix:** —
+- **Where:** `crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs`,
+  `.../method.rs`, `crates/build/src/generators/solidity.rs`, `.../struct_parser.rs`.
+- **Impact:** An unresolved struct becomes an empty tuple and fixes the router
+  selector from `()`; artifact generation inserts real components only into the
+  published ABI → tooling calls a selector the router won't accept.
+- **Remediation:** Resolve all components before selector calculation; fail if the
+  ABI-recomputed selector differs from the router selector.
+
+#### FLU-1064 — Duplicate struct names make ABI artifacts order-dependent
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1064` · **Fix:** —
+- **Where:** `crates/build/src/generators/struct_parser.rs`.
+- **Impact:** Unsorted directory results folded with `HashMap::extend` and bare-name
+  keys → two modules defining `Config` overwrite by filesystem order; identical
+  source yields different ABI layouts.
+- **Remediation:** Deterministic module traversal; module-qualified type paths; fail
+  on ambiguous names.
+
+#### FLU-1065 — Contract builds execute mutable Docker tags without digest enforcement
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1065` · **Fix:** —
+- **Where:** `crates/build/src/lib.rs`, `crates/build/src/docker.rs`.
+- **Impact:** The reproducible-build path selects a mutable `name:version` tag,
+  trusts any matching local image, validates no digest, and mounts source read-write
+  → a poisoned/retagged image can alter artifacts and persist in cache.
+- **Remediation:** Require `name@sha256:digest` + verified provenance; compare the
+  resolved digest before `docker run`; isolate writable outputs from source.
+
+#### FLU-1066 — Signed and fixed-bytes mapping keys use noncanonical Solidity slots
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1066` · **Fix:** —
+- **Where:** `crates/sdk/src/storage/map.rs`, `.../primitive.rs`.
+- **Impact:** `StorageMap::entry` right-aligns every key in a zero word; Solidity
+  sign-extends negative integer keys and left-aligns/right-pads `bytesN` → the same
+  logical key addresses different storage at mixed-language / proof / upgrade
+  boundaries.
+- **Remediation:** A mapping-key encoding trait with Solidity-compatible per-type
+  rules.
+
+#### FLU-1067 — StorageVec index multiplication wraps into earlier elements
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1067` · **Fix:** —
+- **Where:** `crates/sdk/src/storage/vec.rs`, `contracts/Cargo.toml`.
+- **Impact:** For multi-slot `T`, `index * T::SLOTS as u64` wraps before conversion
+  to `U256` in release; a large index via the unchecked `at` accessor aliases a low
+  element and corrupts ownership/accounting state.
+- **Remediation:** Multiply after converting to `U256` (or `checked_mul`); add a
+  bounds-checked accessor.
+
+#### FLU-1068 — Overlong token metadata can persist invalid UTF-8 and poison reads
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1068` · **Fix:** —
+- **Where:** `crates/sdk/src/types/storage.rs`, `contracts/universal-token/src/lib.rs`,
+  `.../erc2612.rs`.
+- **Impact:** Release omits the only length assertion; an overlong name/symbol is
+  truncated to 32 bytes, possibly splitting a UTF-8 code point; later metadata/permit
+  reads unwrap UTF-8 decoding and panic, persistently disabling those paths.
+- **Remediation:** Reject overlong metadata before storage mutation; validate
+  constructor lengths; return errors instead of unwrapping.
+
+#### FLU-1069 — Solidity interface file changes do not invalidate incremental builds
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1069` · **Fix:** —
+- **Where:** `crates/sdk-derive/src/lib.rs`.
+- **Impact:** Path-form Solidity macros read `.sol` files but emit no tracked
+  dependency → changing only the interface can leave the crate fresh, embedding stale
+  methods/selectors.
+- **Remediation:** Emit a hidden `include_str!`/dep-info input for the resolved path.
+
+#### FLU-1070 — Dynamic event data includes a noncanonical outer tuple offset
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1070` · **Fix:** —
+- **Where:** `crates/sdk-derive/derive-core/src/event.rs`,
+  `contracts/runtime-upgrade/src/lib.rs`.
+- **Impact:** Non-indexed event fields encoded as one dynamic tuple add an outer
+  offset absent from Solidity event data → runtime-upgrade logs can be
+  rejected/misread by standard decoders.
+- **Remediation:** Encode non-indexed fields with top-level function-argument
+  semantics.
+
+#### FLU-1071 — Indexed reference event topics use ordinary ABI encoding
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1071` · **Fix:** —
+- **Where:** `crates/sdk-derive/derive-core/src/event.rs`.
+- **Impact:** Generated topics hash ordinary ABI encoding for dynamic indexed fields
+  and copy a first word for static composites, unlike Solidity's special indexed
+  encoding → filters/indexers miss affected logs.
+- **Remediation:** Classify value vs reference/composite and implement Solidity's
+  indexed encoding exactly.
+
+#### FLU-1072 — Generated view and pure clients issue mutable CALLs
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1072` · **Fix:** —
+- **Where:** `crates/sdk-derive/derive-core/src/sol_input.rs`, `.../client.rs`.
+- **Impact:** `view`/`pure` maps to `&self` but client generation always emits
+  mutable `sdk.call` → in a non-static frame a malicious target can mutate state or
+  re-enter where Solidity would enforce `STATICCALL`.
+- **Remediation:** Preserve mutability; use `static_call` for view/pure; forbid
+  attached value.
+
+#### FLU-1073 — Fixed byte-array selectors disagree with generated calldata codecs
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1073` · **Fix:** —
+- **Where:** `crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs`,
+  `.../codec.rs`.
+- **Impact:** `[u8; N]` (N ≤ 32) canonicalizes to `bytesN` for the selector but the
+  codec encodes `uint8[N]` → canonical calldata selects the route but fails decode.
+- **Remediation:** Map consistently to `uint8[N]` or use a real `FixedBytes<N>` codec
+  when the selector advertises `bytesN`.
+
+#### FLU-1074 — Solidity imports silently drop unsupported functions and parameters
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1074` · **Fix:** —
+- **Where:** `crates/sdk-derive/derive-core/src/sol_input.rs`.
+- **Impact:** Function/parameter conversion failures discarded with `.ok()` → a
+  valid-but-unsupported type can silently remove a security parameter, change a
+  selector, or drop a method while compilation succeeds.
+- **Remediation:** Collect/propagate conversion errors with spans; never emit a
+  partial surface.
+
+#### FLU-1075 — Enforce WASM and rWasm size caps in runtime upgrades
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1075` · **Fix:** —
+- **Where:** `contracts/runtime-upgrade/src/lib.rs`, `crates/revm/src/syscall.rs`,
+  `crates/types/src/lib.rs`.
+- **Impact:** `compile_and_install` checks only the magic; neither boundary rejects
+  raw WASM above 1 MiB or serialized rWasm above 12 MiB → oversized artifacts consume
+  control-plane compilation resources and persist oversized code.
+- **Remediation:** Reject over-limit raw input before compilation and over-limit
+  serialized output before native execution; repeat the cap in the host syscall.
+
+#### FLU-1076 — Emit the installed code hash for canonical precompile upgrades
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1076` · **Fix:** —
+- **Where:** `contracts/runtime-upgrade/src/lib.rs`, `crates/revm/src/syscall.rs`.
+- **Impact:** Installers obtain `RuntimeUpgraded.codeHash` via the EVM-facing syscall,
+  which returns zero for canonical precompile addresses → upgrades of
+  consensus-critical crypto precompiles emit a zero artifact hash, breaking
+  event-level release verification.
+- **Remediation:** Compute the event value from the installed bytes (or a privileged
+  raw-state code-hash syscall); keep ordinary EVM masking zero.
+
+#### FLU-1077 — Reject trailing legacy UST constructor bytes before persisting metadata
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1077` · **Fix:** —
+- **Where:** `crates/sdk/src/universal_token/storage.rs`,
+  `contracts/universal-token/src/lib.rs`, `crates/revm/src/executor.rs`.
+- **Impact:** A UST payload longer than canonical V1/V2 routes to a legacy decoder
+  that doesn't require end-of-input; the constructor persists the full attacker input
+  (including trailing bytes) as account metadata, uncharged → underpriced state
+  growth + recurring overhead.
+- **Remediation:** Require exact legacy consumption; persist a canonical re-encoding;
+  enforce size + deposit gas on the final serialized code.
+
+#### FLU-1078 — Prevent zero-address ownership changes from restoring fee bootstrap authority
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1078` · **Fix:** —
+- **Where:** `contracts/fee-manager/src/lib.rs`, `crates/types/src/genesis.rs`.
+- **Impact:** `changeOwner(address(0))` stores zero while `owner()`/`only_owner()`
+  interpret zero as `DEFAULT_FEE_MANAGER_AUTH` → after migrating to a multisig, an
+  erroneous zero transition silently reactivates the retired genesis key.
+- **Remediation:** Reject `Address::ZERO` before storage mutation; keep
+  `renounceOwnership()` writing `SYSTEM_ADDRESS` as the explicit fork-only transition.
+
+#### FLU-1079 — Charge the EIP-7951 P256 verification gas schedule
+
+- **Severity:** Medium · **Status:** Fixed · **Linear:** `FLU-1079` · **Fix:** —
+- **Where:** `contracts/eip7951/src/lib.rs`; pinned `revm-rwasm .../secp256r1.rs`;
+  `crates/genesis/build.rs`, `crates/types/src/genesis.rs`.
+- **Impact:** The genesis precompile at `0x100` charges the old RIP-7212 3,450-gas
+  variant although EIP-7951 specifies 6,900, with no compensating meter → attackers
+  buy ~2× the intended P256 work per block.
+- **Remediation:** Use `P256VERIFY_BASE_GAS_FEE_OSAKA` + `p256_verify_osaka`
+  atomically; preserve invalid-input behavior.
+
+## Notes
+
+Cross-cutting themes: **codec/ABI canonicalization** (FLU-1055, 1063, 1064, 1066,
+1070, 1071, 1072, 1073, 1074); **gas/metering parity with canonical REVM**
+(FLU-1052, 1056, 1057, 1060, 1062, 1075, 1076, 1079); **unmetered/unbounded
+allocation** (FLU-1046, 1047, 1051, 1054, 1058, 1077); **runtime-upgrade authority
+& provenance** (FLU-1048, 1049, 1050, 1075, 1076).
+
+## Re-review checklist for future audits
+
+- Re-run codec/ABI parity tests against an independent Solidity encoder for
+  selectors, indexed event topics, event data framing, mapping-key slots, and
+  `bytesN` codecs.
+- Confirm delegated-EVM opcodes read the active fork and correct blob/gas values, and
+  that system-runtime + precompile halts match pinned REVM gas.
+- Confirm every host decode / router argument uses checked length validation +
+  `try_reserve` before allocation.
+- Confirm runtime-upgrade artifacts are authenticated, size-capped, and that
+  ownership transitions revoke planned-upgrade authority.

--- a/audits/2026-08-20-fluentbase-audit.md
+++ b/audits/2026-08-20-fluentbase-audit.md
@@ -1,0 +1,148 @@
+# Fluentbase Security Audit — 2026-08-20
+
+- **Date:** 2026-08-20 (fixes landed 2026-08-20 → 2026-08-21)
+- **Repository:** `fluentlabs-xyz/fluentbase`
+- **Audited commit:** `0fd4ded21a684b1bc702eb9ca081959eb7a7df49` (`v1.4.0`)
+- **Linear:** parent `FLU-1159`; subtasks `FLU-1160`, `FLU-1161`, `FLU-1163`, `FLU-1164`
+- **Fix PRs:** #499, #500, #502
+- **Focus:** End-to-end pass on the `v1.4.0` snapshot — Critical/High first (filter:
+  Critical and High only), then a follow-up Medium pass on the same snapshot.
+
+## Scope
+
+All Rust/source surfaces under `contracts/` (all system contracts and precompiles,
+including the disabled SVM contract) and `crates/` (runtime, REVM/EVM, codec/derive,
+SDK/derive, types, crypto, build/contracts/genesis/node/release/testing, SVM groups),
+plus Fluent-reached dependency paths: `revm-rwasm` @ `8674122294…`, `reth-core-rwasm`
+@ `a1701b3b…`, and `rwasm 0.4.7` (source rev `edfd3da6…`). Source review and
+executable tests were the authority.
+
+## Result
+
+| Crit | High | Medium |
+| --- | --- | --- |
+| 0 | 1 | 2 net-new + 3 revalidated |
+
+The historical Critical/High classes did not reproduce (see Notes).
+
+## Findings
+
+### High
+
+#### FLU-1160 — Universal-token storage writes skip SSTORE write cost & EIP-8037 state gas
+
+- **Severity:** High · **Status:** Accepted/documented · **Linear:** `FLU-1160` · **Fix:** #499
+- **Where:** `crates/revm/src/executor.rs:298-367` (preload, read-cost only),
+  `:684-686` (`sstore` commit with no gas/state-gas),
+  `crates/sdk/src/universal_token/storage.rs`.
+- **Impact:** For engine-metered system runtimes — in practice the Universal Token,
+  the only stateful one in `EXECUTE_USING_SYSTEM_RUNTIME_ADDRESSES` — storage writes
+  are buffered and committed via `JournaledState::sstore` while its `SStoreResult` is
+  dropped, so only the up-front SLOAD read price is charged (cold 2100 / warm 100),
+  never the EIP-2200 write premium or EIP-8037 state gas. `transfer` to a fresh
+  address costs ~cold SLOAD instead of ~`SSTORE_SET` (20000) + state gas; an attacker
+  can spray 1-wei transfers/approvals/mints to fresh slots at ~10% of intended cost →
+  state-growth DoS. The metadata-write path (`sstore_gas` in `syscall.rs`) and
+  `contracts/eip2935` (via `SYSCALL_ID_STORAGE_WRITE`) charge correctly, proving the
+  gap is specific to the buffered envelope path.
+- **Remediation:** On committing the system-runtime storage diff, use each
+  `SStoreResult` to charge EIP-2200 dynamic write cost + EIP-8037 state gas, crediting
+  the read cost the preloader already charged; halt out-of-fuel if the frame can't
+  afford it. The team accepted and documented the underpricing for this snapshot (PR
+  #499) rather than changing the metering.
+
+### Medium
+
+#### FLU-1161 — Consensus-critical rWASM↔REVM resume boundary uses `unwrap`/`expect`/`unreachable!` under `panic="abort"`
+
+- **Severity:** Medium (high blast radius × low likelihood) · **Status:** Fixed · **Linear:** `FLU-1161` · **Fix:** #500
+- **Where:** `crates/revm/src/executor.rs:489,542,698-701,826-832`;
+  `crates/runtime/src/executor.rs:458-463,526-528`.
+- **Impact:** Release profile is `panic = "abort"`, so any of these firing aborts the
+  process; sitting on the hottest consensus path driven by cross-boundary data, a
+  reachable instance crashes the node and a block-deterministic trigger halts every
+  node on that block. Each site is gated by *upstream* invariants (compiler output
+  shape, handler ordering, rWASM dependency behavior), not a local check — the class a
+  dependency bump can silently break.
+- **Remediation:** Convert these sites into graceful deterministic error halts so an
+  invariant violation fails the transaction/block instead of aborting the node; add
+  regression coverage for malformed interruption params / missing recoverable-runtime
+  states; re-audit them in the rwasm upgrade checklist.
+
+#### FLU-1164 — Require canonical release tags before signing artifacts or pushing Docker latest
+
+- **Severity:** Medium · **Status:** Fixed (Final Review) · **Linear:** `FLU-1164` · **Fix:** #502
+- **Where:** `.github/workflows/release.yml` (broad `v*` trigger, permissive prefix
+  compare, sign/build/release/draft jobs omit `check-version`), `publish.yml`,
+  `build-docker.yml`, `docker.yml`, `Makefile:227`.
+- **Impact:** `v1.4.0oops` passes `[[ "$tag" == "$cargo_ver"* ]]`, and even a failing
+  tag doesn't block the independent build/sign/draft jobs; the Docker workflows treat
+  every non-`-rc` `v*` tag as stable and advance public `latest` → signed-but-misleading
+  artifacts/metadata and unintended movement of image channels, even when the workflow
+  finishes "failed" overall.
+- **Remediation:** Centralize canonical tag parsing (permit only `v<workspace-version>`
+  and supported prerelease forms); make every sign/upload/publish/draft/Docker-`latest`
+  job depend on that validation; add guard tests. Distinct from `FLU-946` (provenance/SBOM)
+  and `FLU-1065` (builder-image digest).
+
+#### FLU-1163 — Bound the module cache's secondary code-hash index
+
+- **Severity:** Medium · **Status:** Canceled (accepted hardening item) · **Linear:** `FLU-1163` · **Fix:** —
+- **Where:** `crates/runtime/src/module_factory.rs:17-24,26-64,67-87,198-279`;
+  `crates/types/src/compilation_cache.rs:25-42,94-105`.
+- **Impact:** The 1 GiB compiled-module LRU has an unbounded, process-lifetime
+  secondary `code_hash → CompiledModuleCacheKey` index; primary eviction doesn't remove
+  the secondary entry → over sustained valid deployment churn a validator retains
+  bookkeeping for every distinct executed code hash and RSS grows beyond the 1 GiB
+  budget (availability only; no state divergence; hash-only panic not reachable on the
+  normal REVM path).
+- **Remediation:** Remove the secondary map if hash-only execution is unneeded, or
+  prune it atomically on primary eviction and bound its entries; turn a hash-only miss
+  into a deterministic error; add a forced-eviction regression test. (The old primary
+  cache was fixed historically as `FLU-391`/PR #216; the secondary index is a distinct
+  later regression from commit `11389b4f46`.)
+
+#### Revalidated Medium items (not re-filed)
+
+- **Severity:** Medium · **Status:** Open/tracked elsewhere · **Linear:** `FLU-1055`, `FLU-1061`, `FLU-1161`
+- **FLU-1055** (ABI decoders panic on out-of-range dynamic offsets/bodies, from the
+  2026-08-05 audit) remains reproducible in the current codec derive output.
+- **FLU-1061** (unknown RPC transaction type stops consensus block ingestion) is still
+  the exact tracker for consensus-subscription termination on an undecodable RPC block.
+- **FLU-1161** (above) already covers the rWASM↔REVM resume invariant hardening.
+
+## Notes
+
+**High/Critical regression conclusions.** The historical Critical/High classes did
+not reproduce: initial-memory allocation is charged before allocation and aggregate
+suspended-frame memory is capped (closes 2026-08-05 `FLU-1046`/`FLU-1047`); precompile
+input/gas/curve validation held; direct delegated-runtime calls and static metadata
+mutations are blocked; runtime upgrades require both contract authorization and
+host-side upgrade authority; interruption state is transaction-scoped; ordinary REVM
+execution always supplies bytecode to the module cache. Two items were assessed and
+*not* elevated to High: the unbounded secondary module-cache index (filed as Medium
+`FLU-1163`) and SVM's incomplete compute-meter adapter (SVM is excluded from the live
+system-runtime set).
+
+**Verification (as run).** Passed: `fluentbase-runtime --lib` (72, 1 ignored),
+`fluentbase-evm --lib` (2), `fluentbase-revm --lib` (42), codec/SDK/derive/types
+suites (codec 76 + integration/doctests, codec-derive 4, SDK 80, sdk-derive-core 136,
+types 9), contracts workspace (all enabled; WebAuthn fuel benchmark ignored), build
+(19 lib + 23 integration), release verification (38), genesis (1), node (2), rWasm
+0.4.7 targeted fuel (6) / interruption (5, 1 ignored) / value-stack-bounds (10).
+Not run: packaged rWasm `module::verification`/Wasmtime targets (packaging gap),
+standalone SVM build (disabled manifests), Docker-mutating integration tests. Final
+worktree clean.
+
+## Re-review checklist for future audits
+
+- Re-check whether system-runtime (Universal Token) storage writes charge SSTORE +
+  state gas, or confirm the `FLU-1160` acceptance still holds and is documented.
+- Confirm the rWASM↔REVM resume boundary still halts deterministically rather than
+  aborting (`FLU-1161`) — re-audit on every `rwasm`/`revm-rwasm` bump.
+- Confirm release tag validation is a dependency of every sign/publish/Docker-latest
+  job (`FLU-1164`).
+- Watch the secondary module-cache index growth (`FLU-1163`) on long-running
+  validators.
+- Re-confirm `FLU-1055` (codec panic) is closed before relying on derived ABI decoders
+  for untrusted input.

--- a/audits/README.md
+++ b/audits/README.md
@@ -1,0 +1,72 @@
+# Fluentbase & rWasm Security Audit History
+
+This folder is the durable record of security audits performed against the
+**Fluentbase** execution stack (`fluentlabs-xyz/fluentbase`) and its **rWasm**
+dependency (`fluentlabs-xyz/rwasm`, plus `revm-rwasm` / `reth-core-rwasm`).
+
+Each internal audit that was tracked in Linear and used to drive fixes has its
+own self-contained Markdown report so a future reviewer can re-check the same
+surfaces without re-deriving the history from tickets. External vendor reports
+are kept as PDFs.
+
+Reports for audits of the **rWasm repository itself** are maintained alongside
+that repository, not here — this folder keeps only the Fluentbase host audits
+(including the combined pass that reviewed rWasm as a dependency). See
+[rWasm reports maintained elsewhere](#rwasm-reports-maintained-elsewhere).
+
+## Conventions
+
+- **File name:** `YYYY-MM-DD-<repo>-audit.md`, where `<repo>` is `fluentbase` or
+  `rwasm` and the date is the audit date.
+- **Document format (every report):** H1 title `# <Repo> Security Audit — <date>`
+  → metadata block (**Date**, **Repository**, **Audited commit**, **Linear**,
+  **Fix PRs**, **Focus**) → `## Scope` → `## Result` (severity counts) →
+  `## Findings` (grouped by `### Critical/High/Medium/Low`, each finding a
+  `#### <ID> — <title>` with a `Severity · Status · Linear · Fix` lead line and
+  `Where` / `Impact` / `Remediation` bullets) → optional `## Notes` →
+  `## Re-review checklist for future audits`.
+
+## External vendor reports
+
+| File | Vendor | Date |
+| --- | --- | --- |
+| [`Veridise_2025_09_22.pdf`](Veridise_2025_09_22.pdf) | Veridise | 2025-09-22 |
+| [`Cantina_2026_02_23.pdf`](Cantina_2026_02_23.pdf) | Cantina | 2026-02-23 |
+
+## Fluentbase audit reports
+
+Newest first.
+
+| Report | Date | Repo(s) | Crit | High | Med | Low/Info | Fix PRs |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| [2026-08-20](2026-08-20-fluentbase-audit.md) | 2026-08-20 | fluentbase | 0 | 1 | 3 | — | #499, #500, #502 |
+| [2026-08-05](2026-08-05-fluentbase-audit.md) | 2026-08-05 | fluentbase | 0 | 6 | 28 | — | many (per finding) |
+| [2026-07-10](2026-07-10-fluentbase-audit.md) | 2026-07-10 | fluentbase (+ rwasm dep) | 1 | 2 | 4 | 8 | #457–#467, #162–#164 |
+| [2026-06-16](2026-06-16-fluentbase-audit.md) | 2026-06-16 | fluentbase | 0 | 2 | 3 | several | #440 |
+
+The 2026-07-10 report is a combined pass: its Fluentbase host findings
+(`H-01`, `M-0x`, `L-0x`, `I-0x`) are why it lives here, and it also records the
+rWasm dependency findings (`RWASM-01…06`) produced in the same pass.
+
+## rWasm reports maintained elsewhere
+
+Audits whose primary target was the `fluentlabs-xyz/rwasm` repository are kept
+with that repository, under the same naming/format convention. For reference:
+
+| Report | Date | Crit | High | Med | Low/Info | Fix PRs |
+| --- | --- | --- | --- | --- | --- | --- |
+| `2026-08-07-rwasm-audit.md` | 2026-08-07 | 2 | 6 | 7 | — | rwasm #171–#177 |
+| `2026-06-18-rwasm-audit.md` | 2026-06-18 | 0 | 0 | 1 | many | rwasm #154 |
+| `2026-05-01-rwasm-audit.md` | 2026-05-01 | — | — | — | — | rwasm #153 (+ FLU-32/33) |
+
+> **Also out of scope here:** the Solidity bridge/gateway contract audit of
+> 2026-06-18 (Linear `FLU-857`, repo `fluentlabs-xyz/solidity-contracts`,
+> PR #103) targets a different repository. Internal crate-level intake audits
+> `FLU-30` (`crates/sdk-derive`) and `FLU-31` (`crates/build`) produced no
+> tracked Medium+ findings and are not reproduced as standalone reports.
+
+## Provenance
+
+Every report is reconstructed from the corresponding Linear issue and its
+sub-issues; the parent Linear IDs are cited at the top of each report so the
+original tracking, comments, and PR links remain reachable.


### PR DESCRIPTION
## What

Adds self-contained Markdown reports for the internal **Fluentbase** security audits that were tracked in Linear and used to drive fixes, under `audits/` (next to the existing external Veridise/Cantina PDFs).

New files:
- `audits/README.md` — index + conventions
- `audits/2026-06-16-fluentbase-audit.md` — offensive re-audit (FLU-856, PR #440)
- `audits/2026-07-10-fluentbase-audit.md` — combined Fluentbase + rWasm-dependency pass (FLU-935..952, PRs #457–#467 / rwasm #162–#164)
- `audits/2026-08-05-fluentbase-audit.md` — full rWasm/EVM audit, 6 High + 28 Medium (FLU-1045 + 34 subtasks)
- `audits/2026-08-20-fluentbase-audit.md` — v1.4.0 audit (FLU-1159 + subtasks, PRs #499/#500/#502)

## Why

Preserve the audit history in-repo so future reviewers (and re-audits) can re-check the same surfaces — findings, source locations, remediations, fix PRs — without re-deriving everything from tickets. Each report ends with a "Re-review checklist for future audits" to seed the next pass.

## Conventions (uniform across all reports)

- **File name:** `YYYY-MM-DD-<repo>-audit.md`
- **Document format:** title → metadata block (Date, Repository, Audited commit, Linear, Fix PRs, Focus) → Scope → Result (severity counts) → Findings (grouped by severity; each `#### <ID> — <title>` with a `Severity · Status · Linear · Fix` lead line and Where/Impact/Remediation) → optional Notes → Re-review checklist.

## Reviewer notes

- **No code changes** — documentation only.
- Reports whose **primary target is the rWasm repository** (2026-05-01, 2026-06-18, 2026-08-07) are intentionally **not** included here; they're maintained alongside `fluentlabs-xyz/rwasm` under the same naming/format. The README lists them for reference.
- Also out of scope: the Solidity bridge audit (`FLU-857`, `solidity-contracts` repo) and the two crate-intake audits (`FLU-30`, `FLU-31`) that produced no tracked Medium+ findings.
- Fix status is recorded faithfully, including items that were **Canceled** (e.g. FLU-1058, FLU-1163) or **Accepted/documented** rather than eliminated (FLU-1160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)