### PR TITLE
fix: address codec and SDK audit follow-ups

### DIFF
--- a/crates/build/src/generators/solidity.rs
+++ b/crates/build/src/generators/solidity.rs
@@ -7,6 +7,7 @@ use fluentbase_sdk_derive_core::{
         function::FunctionABI,
         structs::{StructRegistry, StructResolver},
     },
+    attr::StateMutabilityExt,
     constructor::{process_constructor_with_structs, Constructor},
     method::ParsedMethod,
     router::{process_router_with_structs, Router},
@@ -198,11 +199,12 @@ fn constructor_entry(
     constructor: &ParsedMethod<ImplItemFn>,
     resolver: &StructResolver,
 ) -> Result<Value> {
-    constructor
+    let mut abi = constructor
         .parsed_signature()
         .constructor_abi_with(resolver)
-        .map_err(|error| anyhow!("Failed to build the constructor ABI: {error}"))?
-        .to_json_value()
+        .map_err(|error| anyhow!("Failed to build the constructor ABI: {error}"))?;
+    abi.state_mutability = constructor.state_mutability().as_str().to_string();
+    abi.to_json_value()
         .context("Failed to serialize the constructor ABI")
 }
 

--- a/crates/build/tests/abi_generation.rs
+++ b/crates/build/tests/abi_generation.rs
@@ -390,10 +390,9 @@ fn nested_struct_selectors_agree_with_the_router() {
     let abi = generate_abi(&project).expect("generate ABI");
     let interface = generate_interface("Nested", &abi).expect("generate interface");
     assert!(
-        interface
-            .contains(
-                "function createUser(User calldata user) external payable returns (address _0);"
-            ),
+        interface.contains(
+            "function createUser(User calldata user) external payable returns (address _0);"
+        ),
         "unexpected interface: {interface}"
     );
 }

--- a/crates/build/tests/abi_generation.rs
+++ b/crates/build/tests/abi_generation.rs
@@ -391,7 +391,9 @@ fn nested_struct_selectors_agree_with_the_router() {
     let interface = generate_interface("Nested", &abi).expect("generate interface");
     assert!(
         interface
-            .contains("function createUser(User calldata user) external returns (address _0);"),
+            .contains(
+                "function createUser(User calldata user) external payable returns (address _0);"
+            ),
         "unexpected interface: {interface}"
     );
 }

--- a/crates/build/tests/snapshots/abi_generation__array_struct_abi.snap
+++ b/crates/build/tests/snapshots/abi_generation__array_struct_abi.snap
@@ -46,7 +46,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -109,7 +109,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -149,7 +149,7 @@ expression: abi
         "type": "tuple[]"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -200,7 +200,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -270,7 +270,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -333,7 +333,7 @@ expression: abi
         "type": "tuple"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/crates/build/tests/snapshots/abi_generation__direct_impl_constructor.snap
+++ b/crates/build/tests/snapshots/abi_generation__direct_impl_constructor.snap
@@ -33,7 +33,7 @@ expression: abi
         "type": "tuple"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "constructor"
   },
   {
@@ -57,7 +57,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -76,7 +76,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -89,7 +89,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/crates/build/tests/snapshots/abi_generation__edge_cases_struct_abi.snap
+++ b/crates/build/tests/snapshots/abi_generation__edge_cases_struct_abi.snap
@@ -20,7 +20,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -46,7 +46,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -82,7 +82,7 @@ expression: abi
         "type": "address"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -102,7 +102,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -183,7 +183,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -249,7 +249,7 @@ expression: abi
         "type": "address"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -303,7 +303,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -317,7 +317,7 @@ expression: abi
         "type": "tuple"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -347,7 +347,7 @@ expression: abi
         "type": "tuple"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -389,7 +389,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   }
 ]

--- a/crates/build/tests/snapshots/abi_generation__nested_struct_abi.snap
+++ b/crates/build/tests/snapshots/abi_generation__nested_struct_abi.snap
@@ -53,7 +53,7 @@ expression: abi
         "type": "address"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -184,7 +184,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -332,7 +332,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -385,7 +385,7 @@ expression: abi
         "type": "tuple"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -611,7 +611,7 @@ expression: abi
         "type": "tuple"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   }
 ]

--- a/crates/build/tests/snapshots/abi_generation__simple_struct_abi.snap
+++ b/crates/build/tests/snapshots/abi_generation__simple_struct_abi.snap
@@ -41,7 +41,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -82,7 +82,7 @@ expression: abi
         "type": "tuple"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -145,7 +145,7 @@ expression: abi
         "type": "tuple"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -169,7 +169,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   }
 ]

--- a/crates/build/tests/snapshots/abi_generation__trait_impl_constructor.snap
+++ b/crates/build/tests/snapshots/abi_generation__trait_impl_constructor.snap
@@ -21,7 +21,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "constructor"
   },
   {
@@ -45,7 +45,7 @@ expression: abi
         "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -69,7 +69,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -88,7 +88,7 @@ expression: abi
         "type": "bool"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   }
 ]

--- a/crates/codec-derive/src/lib.rs
+++ b/crates/codec-derive/src/lib.rs
@@ -305,9 +305,9 @@ impl CodecStruct {
 
                 let mut tmp = if <Self as #crate_path::Encoder<B, ALIGN, {true}, {#is_static}>>::IS_DYNAMIC {
                     let offset = #crate_path::read_u32_aligned::<B, ALIGN>(&buf.chunk(), aligned_offset)? as usize;
-                    &buf.chunk()[offset..]
+                    #crate_path::checked_decode_slice_from(buf, offset, "struct body exceeds input")?
                 } else {
-                    &buf.chunk()[aligned_offset..]
+                    #crate_path::checked_decode_slice_from(buf, aligned_offset, "struct head exceeds input")?
                 };
 
                 let mut current_offset = 0;

--- a/crates/codec-derive/src/snapshots/fluentbase_codec_derive__tests__empty_struct.snap
+++ b/crates/codec-derive/src/snapshots/fluentbase_codec_derive__tests__empty_struct.snap
@@ -57,9 +57,17 @@ impl<
                 B,
                 ALIGN,
             >(&buf.chunk(), aligned_offset)? as usize;
-            &buf.chunk()[offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                offset,
+                "struct body exceeds input",
+            )?
         } else {
-            &buf.chunk()[aligned_offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                aligned_offset,
+                "struct head exceeds input",
+            )?
         };
         let mut current_offset = 0;
         Ok(EmptyStruct {})
@@ -156,9 +164,17 @@ impl<
                 B,
                 ALIGN,
             >(&buf.chunk(), aligned_offset)? as usize;
-            &buf.chunk()[offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                offset,
+                "struct body exceeds input",
+            )?
         } else {
-            &buf.chunk()[aligned_offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                aligned_offset,
+                "struct head exceeds input",
+            )?
         };
         let mut current_offset = 0;
         Ok(EmptyStruct {})

--- a/crates/codec-derive/src/snapshots/fluentbase_codec_derive__tests__generic_struct.snap
+++ b/crates/codec-derive/src/snapshots/fluentbase_codec_derive__tests__generic_struct.snap
@@ -201,9 +201,17 @@ where
                 B,
                 ALIGN,
             >(&buf.chunk(), aligned_offset)? as usize;
-            &buf.chunk()[offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                offset,
+                "struct body exceeds input",
+            )?
         } else {
-            &buf.chunk()[aligned_offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                aligned_offset,
+                "struct head exceeds input",
+            )?
         };
         let mut current_offset = 0;
         let field1 = <T as ::fluentbase_sdk::codec::Encoder<
@@ -507,9 +515,17 @@ where
                 B,
                 ALIGN,
             >(&buf.chunk(), aligned_offset)? as usize;
-            &buf.chunk()[offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                offset,
+                "struct body exceeds input",
+            )?
         } else {
-            &buf.chunk()[aligned_offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                aligned_offset,
+                "struct head exceeds input",
+            )?
         };
         let mut current_offset = 0;
         let field1 = <T as ::fluentbase_sdk::codec::Encoder<

--- a/crates/codec-derive/src/snapshots/fluentbase_codec_derive__tests__simple_struct.snap
+++ b/crates/codec-derive/src/snapshots/fluentbase_codec_derive__tests__simple_struct.snap
@@ -262,9 +262,17 @@ where
                 B,
                 ALIGN,
             >(&buf.chunk(), aligned_offset)? as usize;
-            &buf.chunk()[offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                offset,
+                "struct body exceeds input",
+            )?
         } else {
-            &buf.chunk()[aligned_offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                aligned_offset,
+                "struct head exceeds input",
+            )?
         };
         let mut current_offset = 0;
         let bool_val = <bool as ::fluentbase_sdk::codec::Encoder<
@@ -659,9 +667,17 @@ where
                 B,
                 ALIGN,
             >(&buf.chunk(), aligned_offset)? as usize;
-            &buf.chunk()[offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                offset,
+                "struct body exceeds input",
+            )?
         } else {
-            &buf.chunk()[aligned_offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                aligned_offset,
+                "struct head exceeds input",
+            )?
         };
         let mut current_offset = 0;
         let bool_val = <bool as ::fluentbase_sdk::codec::Encoder<

--- a/crates/codec-derive/src/snapshots/fluentbase_codec_derive__tests__single_field_struct.snap
+++ b/crates/codec-derive/src/snapshots/fluentbase_codec_derive__tests__single_field_struct.snap
@@ -123,9 +123,17 @@ where
                 B,
                 ALIGN,
             >(&buf.chunk(), aligned_offset)? as usize;
-            &buf.chunk()[offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                offset,
+                "struct body exceeds input",
+            )?
         } else {
-            &buf.chunk()[aligned_offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                aligned_offset,
+                "struct head exceeds input",
+            )?
         };
         let mut current_offset = 0;
         let value = <u64 as ::fluentbase_sdk::codec::Encoder<
@@ -314,9 +322,17 @@ where
                 B,
                 ALIGN,
             >(&buf.chunk(), aligned_offset)? as usize;
-            &buf.chunk()[offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                offset,
+                "struct body exceeds input",
+            )?
         } else {
-            &buf.chunk()[aligned_offset..]
+            ::fluentbase_sdk::codec::checked_decode_slice_from(
+                buf,
+                aligned_offset,
+                "struct head exceeds input",
+            )?
         };
         let mut current_offset = 0;
         let value = <u64 as ::fluentbase_sdk::codec::Encoder<

--- a/crates/codec/src/encoder.rs
+++ b/crates/codec/src/encoder.rs
@@ -282,7 +282,11 @@ pub(crate) fn checked_decode_slice<'a>(
 }
 
 /// Returns the remaining contiguous data starting at `offset` after validating the offset.
-pub(crate) fn checked_decode_slice_from<'a>(
+///
+/// This is public for code emitted by `fluentbase-codec-derive`; it is not part of the stable
+/// high-level codec API.
+#[doc(hidden)]
+pub fn checked_decode_slice_from<'a>(
     buf: &'a impl Buf,
     offset: usize,
     msg: &'static str,

--- a/crates/codec/src/tuple.rs
+++ b/crates/codec/src/tuple.rs
@@ -1,6 +1,6 @@
 use crate::{
     alloc::string::ToString,
-    encoder::{align_up, read_u32_aligned, write_u32_aligned, Encoder},
+    encoder::{align_up, checked_decode_slice_from, read_u32_aligned, write_u32_aligned, Encoder},
     error::{CodecError, DecodingError},
 };
 use byteorder::ByteOrder;
@@ -68,9 +68,9 @@ where
     fn decode(buf: &impl Buf, offset: usize) -> Result<Self, CodecError> {
         let chunk = if Self::IS_DYNAMIC {
             let dynamic_offset = read_u32_aligned::<B, ALIGN>(&buf.chunk(), offset)? as usize;
-            &buf.chunk()[dynamic_offset..]
+            checked_decode_slice_from(buf, dynamic_offset, "tuple body exceeds input")?
         } else {
-            &buf.chunk()[offset..]
+            checked_decode_slice_from(buf, offset, "tuple head exceeds input")?
         };
 
         Ok((T::decode(&chunk, 0)?,))

--- a/crates/codec/tests/roundtrip/structs.rs
+++ b/crates/codec/tests/roundtrip/structs.rs
@@ -114,6 +114,19 @@ mod solidity {
     use super::*;
 
     #[test]
+    fn malformed_dynamic_struct_offset_returns_error() {
+        #[derive(Codec, Debug, PartialEq)]
+        struct DynamicStruct {
+            value: Bytes,
+        }
+
+        let mut encoded = vec![0u8; 32];
+        encoded[28..].copy_from_slice(&u32::MAX.to_be_bytes());
+
+        assert!(SolidityABI::<DynamicStruct>::decode(&Bytes::from(encoded), 0).is_err());
+    }
+
+    #[test]
     fn test_one_field_struct() {
         let expected_encoded = hex::decode(
             "00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000e48656c6c6f2c20576f726c642121000000000000000000000000000000000000"

--- a/crates/codec/tests/roundtrip/tuples.rs
+++ b/crates/codec/tests/roundtrip/tuples.rs
@@ -78,6 +78,14 @@ fn test_tuple_single_solidity() {
 }
 
 #[test]
+fn malformed_singleton_tuple_offset_returns_error() {
+    let mut encoded = vec![0u8; 32];
+    encoded[28..].copy_from_slice(&u32::MAX.to_be_bytes());
+
+    assert!(SolidityABI::<(Bytes,)>::decode(&Bytes::from(encoded), 0).is_err());
+}
+
+#[test]
 fn test_tuple_wasm() {
     // Define expected encoding with clear structure:
     // - First 4 bytes: offset to bytes data (4)

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -49,6 +49,11 @@ use std::{
 };
 use tracing::warn;
 
+fn out_of_fuel_with_current_gas(gas: &mut Gas) -> NextAction {
+    gas.spend_all();
+    NextAction::out_of_fuel(*gas)
+}
+
 fn should_overwrite_delegated_bytecode<'a, CTX: ContextTr>(
     frame: &mut RwasmFrame,
     ctx: &mut CTX,
@@ -352,18 +357,14 @@ fn execute_rwasm_frame<CTX: ContextTr, INSP: Inspector<CTX>>(
                     // loop in `process_runtime_execution_outcome` for why no SSTORE write cost
                     // is charged on commit.
                     if !interpreter.gas.record_regular_cost(gas_cost) {
-                        return Ok(NextAction::out_of_fuel(Gas::new_spent(
-                            interpreter.gas.remaining(),
-                        )));
+                        return Ok(out_of_fuel_with_current_gas(&mut interpreter.gas));
                     }
                     _ = storage.insert(k, data.data);
                     preloaded_slot_costs.push((k, gas_cost));
                 }
                 // We need more gas to execute the cold sload
                 Err(JournalLoadError::ColdLoadSkipped) => {
-                    return Ok(NextAction::out_of_fuel(Gas::new_spent(
-                        interpreter.gas.remaining(),
-                    )))
+                    return Ok(out_of_fuel_with_current_gas(&mut interpreter.gas))
                 }
                 // Return database error
                 Err(JournalLoadError::DBError(err)) => return Err(ContextError::Db(err)),
@@ -941,4 +942,28 @@ fn process_halt<CTX: ContextTr, INSP: Inspector<CTX>>(
         output: return_data,
         gas: frame.interpreter.gas,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preload_out_of_fuel_preserves_the_original_gas_tracker() {
+        let mut gas = Gas::new_with_regular_gas_and_reservoir(3_000, 500);
+        assert!(gas.record_regular_cost(2_100));
+        assert!(!gas.record_regular_cost(2_100));
+
+        let NextAction::Return(result) = out_of_fuel_with_current_gas(&mut gas) else {
+            panic!("out-of-fuel must return the current frame");
+        };
+
+        assert_eq!(
+            result.result,
+            instruction_result_from_exit_code(ExitCode::OutOfFuel, true)
+        );
+        assert_eq!(result.gas.limit(), 3_000);
+        assert_eq!(result.gas.remaining(), 0);
+        assert_eq!(result.gas.reservoir(), 500);
+    }
 }

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -196,6 +196,11 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
     }
 
     #[allow(clippy::int_plus_one)]
+    // Allocation safety invariant: ordinary rWASM modules reach `_exec` only after the
+    // translator-injected EXEC fuel procedure has charged the input length (including its
+    // quadratic bound). The system EVM runtime calls the lazy readers below only after the
+    // corresponding EVM call and memory costs have been charged. Keep these allocations behind
+    // those two metering points; moving them earlier would make an untrusted length unmetered.
     macro_rules! get_input_validated {
         (== $length:expr) => {{
             assert_halt!(

--- a/crates/runtime/src/syscall_handler/host/write_output.rs
+++ b/crates/runtime/src/syscall_handler/host/write_output.rs
@@ -8,6 +8,10 @@ pub fn syscall_write_output_handler(
     params: &[Value],
     _result: &mut [Value],
 ) -> Result<(), TrapCode> {
+    // Allocation safety invariant: the rWASM translator injects the `_write` linear fuel charge,
+    // including `length`, before this host handler can run. Each append is charged separately, so
+    // repeated writes are cumulatively bounded by the frame's remaining fuel. Keep the import's
+    // fuel procedure in sync with this allocation if the syscall is changed.
     let (offset, length) = (params[0].i32().unwrap(), params[1].i32().unwrap());
     let data = caller.memory_read_into_vec(offset as usize, length as usize)?;
     syscall_write_output_impl(caller.data_mut(), &data);

--- a/crates/sdk-derive/derive-core/src/client.rs
+++ b/crates/sdk-derive/derive-core/src/client.rs
@@ -274,7 +274,7 @@ impl<T: MethodLike> Client<T> {
                 self.sdk.static_call(
                     contract_address,
                     &input,
-                    Some(gas_limit),
+                    Some(fuel_limit),
                 )
             }
         } else {
@@ -289,7 +289,7 @@ impl<T: MethodLike> Client<T> {
                     contract_address,
                     #value,
                     &input,
-                    Some(gas_limit),
+                    Some(fuel_limit),
                 )
             }
         };
@@ -314,6 +314,9 @@ impl<T: MethodLike> Client<T> {
                     }
                 }
 
+                let fuel_limit = gas_limit
+                    .checked_mul(fluentbase_sdk::FUEL_DENOM_RATE)
+                    .expect("gas limit is too large to convert to fuel");
                 let result = #host_call;
 
                 if !fluentbase_sdk::SyscallResult::is_ok(result.status) {
@@ -404,7 +407,7 @@ mod tests {
             let generated = generated_method(method);
 
             assert!(generated
-                .contains("self.sdk.static_call(contract_address,&input,Some(gas_limit),)"));
+                .contains("self.sdk.static_call(contract_address,&input,Some(fuel_limit),)"));
             assert!(!generated.contains("self.sdk.call("));
             // No value can be attached, and none has to be checked
             assert!(!generated.contains("value:fluentbase_sdk::U256"));
@@ -420,7 +423,7 @@ mod tests {
         });
 
         assert!(generated.contains(
-            "self.sdk.call(contract_address,fluentbase_sdk::U256::ZERO,&input,Some(gas_limit),)"
+            "self.sdk.call(contract_address,fluentbase_sdk::U256::ZERO,&input,Some(fuel_limit),)"
         ));
         assert!(!generated.contains("static_call"));
         assert!(!generated.contains("value:fluentbase_sdk::U256"));
@@ -443,9 +446,8 @@ mod tests {
             let generated = generated_method(method);
 
             assert!(generated.contains("value:fluentbase_sdk::U256,gas_limit:u64"));
-            assert!(
-                generated.contains("self.sdk.call(contract_address,value,&input,Some(gas_limit),)")
-            );
+            assert!(generated
+                .contains("self.sdk.call(contract_address,value,&input,Some(fuel_limit),)"));
             assert!(generated.contains("context.tx_value()<value"));
             assert!(!generated.contains("static_call"));
         }

--- a/crates/sdk-derive/derive-core/src/method.rs
+++ b/crates/sdk-derive/derive-core/src/method.rs
@@ -158,7 +158,10 @@ impl<T: MethodLike> ParsedMethod<T> {
         if let Some((attr, _)) = &attr {
             if !attr.is_validation_enabled() {
                 let function_id = attr.function_id_bytes()?;
-                let abi = sig.function_abi_with(resolver).ok();
+                let abi = sig.function_abi_with(resolver).ok().map(|mut abi| {
+                    abi.state_mutability = state_mutability;
+                    abi
+                });
                 let signature = attr
                     .signature()
                     .or_else(|| abi.as_ref().and_then(|abi| abi.signature().ok()))
@@ -175,7 +178,7 @@ impl<T: MethodLike> ParsedMethod<T> {
             }
         }
 
-        let abi = sig.function_abi_with(resolver).map_err(|error| {
+        let mut abi = sig.function_abi_with(resolver).map_err(|error| {
             let help = matches!(error, ABIError::StructResolution(_)).then_some(
                 "\nhelp: define the struct in this crate, or pin the selector with \
                  #[function_id(\"name((...))\")] using the components callers encode",
@@ -183,6 +186,7 @@ impl<T: MethodLike> ParsedMethod<T> {
 
             syn::Error::new(sig.span(), format!("{error}{}", help.unwrap_or_default()))
         })?;
+        abi.state_mutability = state_mutability;
         let signature = abi.signature()?;
         let function_id = abi.function_id()?;
 
@@ -220,7 +224,8 @@ impl<T: MethodLike> ParsedMethod<T> {
     pub fn new_constructor(inner: T, resolver: &StructResolver) -> syn::Result<Self> {
         let sig = ParsedSignature::new(inner.sig().clone());
         let state_mutability = inner.state_mutability()?;
-        let abi = sig.function_abi_with(resolver)?;
+        let mut abi = sig.function_abi_with(resolver)?;
+        abi.state_mutability = state_mutability;
         let signature = abi.signature()?;
 
         // For constructor, use zero function_id as it doesn't need a selector
@@ -755,6 +760,33 @@ mod tests {
         assert_eq!(constructor.parsed_signature().rust_name(), "constructor");
         // Constructor should have zero function_id
         assert_eq!(constructor.function_id(), [0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn test_function_abi_uses_resolved_state_mutability() {
+        let resolver = StructResolver::default();
+
+        let cases: [(ImplItemFn, StateMutability); 2] = [
+            (
+                parse_quote! {
+                    #[state_mutability("pure")]
+                    pub fn read(&self) {}
+                },
+                StateMutability::Pure,
+            ),
+            (
+                parse_quote! {
+                    #[state_mutability("payable")]
+                    pub fn deposit(&mut self) {}
+                },
+                StateMutability::Payable,
+            ),
+        ];
+
+        for (method, expected) in cases {
+            let method = ParsedMethod::new(method, &resolver).unwrap();
+            assert_eq!(method.function_abi().unwrap().state_mutability, expected);
+        }
     }
 
     #[test]

--- a/crates/sdk-derive/derive-core/src/method.rs
+++ b/crates/sdk-derive/derive-core/src/method.rs
@@ -5,7 +5,9 @@ use crate::{
         structs::StructResolver,
     },
     attr::{
-        function_id::FunctionID, state_mutability::resolve_state_mutability, FunctionIDAttribute,
+        function_id::FunctionID,
+        state_mutability::{resolve_state_mutability, StateMutabilityExt},
+        FunctionIDAttribute,
     },
     signature::ParsedSignature,
 };
@@ -295,6 +297,17 @@ impl<T: MethodLike> ParsedMethod<T> {
 
         let call_struct = format_ident!("ConstructorCall");
 
+        let value_guard = if self.state_mutability().allows_value() {
+            quote! {}
+        } else {
+            quote! {
+                use fluentbase_sdk::ContextReader as _;
+                if !self.sdk.context().contract_value().is_zero() {
+                    panic!("nonpayable constructor cannot receive value");
+                }
+            }
+        };
+
         // Generate parameter handling based on parameter count
         let param_handling = match param_count {
             0 => quote! {},
@@ -337,6 +350,7 @@ impl<T: MethodLike> ParsedMethod<T> {
 
         // Generate complete deploy body
         quote! {
+            #value_guard
             let input_length = self.sdk.input_size();
             let mut call_data = alloc::vec![0u8; input_length as usize];
             self.sdk.read(&mut call_data, 0);

--- a/crates/sdk-derive/derive-core/src/router.rs
+++ b/crates/sdk-derive/derive-core/src/router.rs
@@ -1,6 +1,6 @@
 use crate::{
     abi::structs::StructResolver,
-    attr::{mode::Mode, STATE_MUTABILITY_ATTR},
+    attr::{mode::Mode, state_mutability::StateMutabilityExt, STATE_MUTABILITY_ATTR},
     codec::CodecGenerator,
     method::{combine_errors, MethodCollector, ParsedMethod},
 };
@@ -374,6 +374,17 @@ impl Router {
         let param_count = params.len();
         let return_type_count = route.parsed_signature().return_type().len();
 
+        let value_guard = if route.state_mutability().allows_value() {
+            quote! {}
+        } else {
+            quote! {
+                use fluentbase_sdk::ContextReader as _;
+                if !self.sdk.context().contract_value().is_zero() {
+                    panic!("nonpayable method cannot receive value");
+                }
+            }
+        };
+
         // Generate parameter handling based on parameter count
         let param_handling = match param_count {
             0 => quote! {},
@@ -439,6 +450,7 @@ impl Router {
 
         Ok(quote! {
             [#(#function_id),*] => {
+                #value_guard
                 #param_handling
                 #result_handling
             }
@@ -718,5 +730,38 @@ mod b {
         let formatted = prettyplease::unparse(&file);
 
         assert_snapshot!("constructor_two_params", formatted);
+    }
+
+    #[test]
+    fn test_nonpayable_routes_and_constructor_reject_value() {
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                #[state_mutability("nonpayable")]
+                pub fn constructor(&mut self) {}
+
+                #[state_mutability("nonpayable")]
+                pub fn mutate(&mut self) {}
+
+                #[state_mutability("payable")]
+                pub fn deposit(&mut self) {}
+            }
+        };
+
+        let router = process_router(quote! { mode = "solidity" }, impl_block.into_token_stream())
+            .expect("Failed to process router");
+        let generated = router
+            .generate()
+            .expect("Failed to generate router code")
+            .to_string()
+            .chars()
+            .filter(|c| !c.is_whitespace())
+            .collect::<String>();
+
+        assert_eq!(
+            generated
+                .matches("if!self.sdk.context().contract_value().is_zero()")
+                .count(),
+            2
+        );
     }
 }

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__client__tests__generate_client.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__client__tests__generate_client.snap
@@ -174,7 +174,10 @@ impl<SDK: fluentbase_sdk::SharedAPI> TestContractClient<SDK> {
                 ::core::panic!("Insufficient gas limit for transaction");
             }
         }
-        let result = self.sdk.static_call(contract_address, &input, Some(gas_limit));
+        let fuel_limit = gas_limit
+            .checked_mul(fluentbase_sdk::FUEL_DENOM_RATE)
+            .expect("gas limit is too large to convert to fuel");
+        let result = self.sdk.static_call(contract_address, &input, Some(fuel_limit));
         if !fluentbase_sdk::SyscallResult::is_ok(result.status) {
             ::core::panic!("Contract call failed");
         }
@@ -195,7 +198,10 @@ impl<SDK: fluentbase_sdk::SharedAPI> TestContractClient<SDK> {
                 ::core::panic!("Insufficient gas limit for transaction");
             }
         }
-        let result = self.sdk.static_call(contract_address, &input, Some(gas_limit));
+        let fuel_limit = gas_limit
+            .checked_mul(fluentbase_sdk::FUEL_DENOM_RATE)
+            .expect("gas limit is too large to convert to fuel");
+        let result = self.sdk.static_call(contract_address, &input, Some(fuel_limit));
         if !fluentbase_sdk::SyscallResult::is_ok(result.status) {
             ::core::panic!("Contract call failed");
         }

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__router__tests__constructor_no_params.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__router__tests__constructor_no_params.snap
@@ -166,6 +166,10 @@ impl<SDK: SharedAPI> App<SDK> {
         let (selector, params) = call_data.split_at(4);
         match [selector[0], selector[1], selector[2], selector[3]] {
             [32u8, 150u8, 82u8, 85u8] => {
+                use fluentbase_sdk::ContextReader as _;
+                if !self.sdk.context().contract_value().is_zero() {
+                    panic!("nonpayable method cannot receive value");
+                }
                 let output = self.get_value();
                 let encoded_output = GetValueReturn::new((output,)).encode();
                 self.sdk.write(&encoded_output);

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__router__tests__constructor_single_param.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__router__tests__constructor_single_param.snap
@@ -166,6 +166,10 @@ impl<SDK: SharedAPI> App<SDK> {
         let (selector, params) = call_data.split_at(4);
         match [selector[0], selector[1], selector[2], selector[3]] {
             [32u8, 150u8, 82u8, 85u8] => {
+                use fluentbase_sdk::ContextReader as _;
+                if !self.sdk.context().contract_value().is_zero() {
+                    panic!("nonpayable method cannot receive value");
+                }
                 let output = self.get_value();
                 let encoded_output = GetValueReturn::new((output,)).encode();
                 self.sdk.write(&encoded_output);

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__router__tests__constructor_two_params.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__router__tests__constructor_two_params.snap
@@ -244,6 +244,10 @@ impl<SDK: SharedAPI> App<SDK> {
         let (selector, params) = call_data.split_at(4);
         match [selector[0], selector[1], selector[2], selector[3]] {
             [112u8, 160u8, 130u8, 49u8] => {
+                use fluentbase_sdk::ContextReader as _;
+                if !self.sdk.context().contract_value().is_zero() {
+                    panic!("nonpayable method cannot receive value");
+                }
                 let param0 = match BalanceOfCall::decode(&params) {
                     Ok(decoded) => decoded.0.0,
                     Err(err) => {

--- a/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__router__tests__trait_router_generation.snap
+++ b/crates/sdk-derive/derive-core/src/snapshots/fluentbase_sdk_derive_core__router__tests__trait_router_generation.snap
@@ -171,6 +171,10 @@ impl<SDK: SharedAPI> App<SDK> {
         let (selector, params) = call_data.split_at(4);
         match [selector[0], selector[1], selector[2], selector[3]] {
             [68u8, 97u8, 93u8, 234u8] => {
+                use fluentbase_sdk::ContextReader as _;
+                if !self.sdk.context().contract_value().is_zero() {
+                    panic!("nonpayable method cannot receive value");
+                }
                 let (param0, param1, param2) = match GreetingCall::decode(&params) {
                     Ok(decoded) => (decoded.0.0, decoded.0.1, decoded.0.2),
                     Err(err) => {
@@ -182,6 +186,10 @@ impl<SDK: SharedAPI> App<SDK> {
                 self.sdk.write(&encoded_output);
             }
             [54u8, 184u8, 58u8, 154u8] => {
+                use fluentbase_sdk::ContextReader as _;
+                if !self.sdk.context().contract_value().is_zero() {
+                    panic!("nonpayable method cannot receive value");
+                }
                 let param0 = match CustomGreetingCall::decode(&params) {
                     Ok(decoded) => decoded.0.0,
                     Err(err) => {

--- a/crates/sdk-derive/derive-core/src/sol_input.rs
+++ b/crates/sdk-derive/derive-core/src/sol_input.rs
@@ -629,7 +629,7 @@ library SomeLibrary {
         ));
         assert_eq!(
             generated
-                .matches("self.sdk.static_call(contract_address,&input,Some(gas_limit),)")
+                .matches("self.sdk.static_call(contract_address,&input,Some(fuel_limit),)")
                 .count(),
             2
         );
@@ -639,12 +639,14 @@ library SomeLibrary {
             "pubfnreset(&mutself,contract_address:fluentbase_sdk::Address,gas_limit:u64,)"
         ));
         assert!(generated.contains(
-            "self.sdk.call(contract_address,fluentbase_sdk::U256::ZERO,&input,Some(gas_limit),)"
+            "self.sdk.call(contract_address,fluentbase_sdk::U256::ZERO,&input,Some(fuel_limit),)"
         ));
         assert!(generated.contains(
             "pubfndeposit(&mutself,contract_address:fluentbase_sdk::Address,value:fluentbase_sdk::U256,gas_limit:u64,)"
         ));
-        assert!(generated.contains("self.sdk.call(contract_address,value,&input,Some(gas_limit),)"));
+        assert!(
+            generated.contains("self.sdk.call(contract_address,value,&input,Some(fuel_limit),)")
+        );
     }
 
     #[test]
@@ -658,7 +660,7 @@ library SomeLibrary {
         );
 
         assert!(
-            generated.contains("self.sdk.static_call(contract_address,&input,Some(gas_limit),)")
+            generated.contains("self.sdk.static_call(contract_address,&input,Some(fuel_limit),)")
         );
         assert!(!generated.contains("self.sdk.call("));
     }

--- a/crates/sdk/src/allocator.rs
+++ b/crates/sdk/src/allocator.rs
@@ -9,7 +9,7 @@ pub use self::{block_list::BlockListAllocator, heap_base::HeapBaseAllocator};
 #[inline(always)]
 pub fn alloc_ptr_unaligned(len: usize) -> *mut u8 {
     if len == 0 {
-        return core::ptr::null_mut();
+        return core::ptr::NonNull::<u8>::dangling().as_ptr();
     }
     let layout = core::alloc::Layout::from_size_align(len, 1).unwrap();
     unsafe { alloc::alloc::alloc(layout) }
@@ -35,4 +35,14 @@ fn test_pages_needed() {
     assert_eq!(calc_pages_needed(1, 65535), 0);
     assert_eq!(calc_pages_needed(1, 65536 + 65536), 1);
     assert_eq!(calc_pages_needed(5, 327680), 0);
+}
+
+#[test]
+fn zero_sized_allocation_returns_a_valid_slice_pointer() {
+    let ptr = alloc_ptr_unaligned(0);
+    assert!(!ptr.is_null());
+
+    // SAFETY: `ptr` is non-null and aligned, and a zero-length slice accesses no memory.
+    let slice = unsafe { core::slice::from_raw_parts(ptr, 0) };
+    assert!(slice.is_empty());
 }

--- a/crates/sdk/src/storage/bytes.rs
+++ b/crates/sdk/src/storage/bytes.rs
@@ -46,11 +46,21 @@ impl StorageBytes {
 
         if last_byte & 1 == 0 {
             // Short form
-            Ok(((last_byte / 2) as usize, false))
+            let len = (last_byte / 2) as usize;
+            if len > 31 {
+                return Err(ExitCode::InputOutputOutOfBounds);
+            }
+            Ok((len, false))
         } else {
             // Long form
             let len = U256::from_be_bytes(word.0) / U256::from(2);
-            Ok((len.try_into().unwrap_or(0), true))
+            if len < U256::from(32) {
+                return Err(ExitCode::InputOutputOutOfBounds);
+            }
+            let len = len
+                .try_into()
+                .map_err(|_| ExitCode::InputOutputOutOfBounds)?;
+            Ok((len, true))
         }
     }
 
@@ -62,7 +72,9 @@ impl StorageBytes {
     /// Load entire byte array.
     pub fn load<S: StorageAPI>(&self, sdk: &S) -> Result<Vec<u8>, ExitCode> {
         let (len, is_long) = self.read_metadata(sdk)?;
-        let mut result = Vec::with_capacity(len);
+        // Grow after each metered storage read instead of trusting an attacker-controlled length
+        // for one large allocation up front.
+        let mut result = Vec::new();
 
         if !is_long {
             // Short form
@@ -455,5 +467,24 @@ mod tests {
         // Verify it's in long form
         let base_value = sdk.get_slot(U256::from(500));
         assert_eq!(base_value, U256::from(65)); // 32*2+1
+    }
+
+    #[test]
+    fn malformed_storage_lengths_are_rejected() {
+        let slot = U256::from(600);
+        let bytes = StorageBytes::new(slot);
+        let mut sdk = MockStorage::new();
+
+        // Even metadata is short form and can encode at most 31 bytes.
+        sdk.storage.insert(slot, U256::from(64));
+        assert_eq!(bytes.load(&sdk), Err(ExitCode::InputOutputOutOfBounds));
+
+        // Odd metadata is long form and must encode at least 32 bytes.
+        sdk.storage.insert(slot, U256::from(3));
+        assert_eq!(bytes.load(&sdk), Err(ExitCode::InputOutputOutOfBounds));
+
+        // A valid U256 length that does not fit in host usize must not wrap or become zero.
+        sdk.storage.insert(slot, U256::MAX);
+        assert_eq!(bytes.load(&sdk), Err(ExitCode::InputOutputOutOfBounds));
     }
 }


### PR DESCRIPTION
## Summary

- document the pre-dispatch fuel invariants that bound deferred `_exec` input and `_write` output allocations
- preserve REVM gas accounting on preload exhaustion and harden SDK allocation/storage handling
- correct generated client gas-to-fuel conversion, nonpayable value enforcement, and published ABI mutability
- validate generated dynamic-struct and singleton-tuple offsets before slicing decoder input

Each audit follow-up is kept in its own Conventional Commit. The final `style(build)` commit contains only the rustfmt adjustment required by `cargo fmt --check`.

## Validation

- `cargo fmt --check`
- `RUSTC_WRAPPER= cargo test -p fluentbase-codec -p fluentbase-codec-derive -p fluentbase-sdk -p fluentbase-sdk-derive-core -p fluentbase-build -p fluentbase-runtime -p fluentbase-revm`
- `RUSTC_WRAPPER= cargo clippy -p fluentbase-codec -p fluentbase-codec-derive -p fluentbase-sdk -p fluentbase-sdk-derive-core -p fluentbase-build -p fluentbase-runtime -p fluentbase-revm --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo check --manifest-path=./contracts/Cargo.toml --workspace --all-targets`

Docker-backed tests remain ignored by their existing test annotations because they require a Docker daemon and network access.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved `payable`, `pure`, and `view` behavior in generated contract interfaces and constructors.
  * Non-payable calls and constructors now reject transferred value.
  * Malformed ABI data now returns clear decoding errors instead of risking invalid memory access.
  * Improved handling of insufficient gas and host-call fuel conversion.
  * Added validation for malformed storage metadata and safer incremental loading.
  * Zero-sized allocations now produce valid non-null pointers.
* **Tests**
  * Added regression coverage for malformed offsets, mutability handling, gas tracking, and storage metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->