### PR TITLE
fix: prepare Fluentscan verification for v1.4.0

### DIFF
--- a/scripts/verify-fluentscan-contracts.bash
+++ b/scripts/verify-fluentscan-contracts.bash
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 FLUENTSCAN_API_BASE_URL="${FLUENTSCAN_API_BASE_URL:-https://api.fluentscan.xyz}"
-GENESIS_VERSION="${GENESIS_VERSION:-v1.2.0}"
+GENESIS_VERSION="${GENESIS_VERSION:-v1.4.0}"
 RUST_TOOLCHAIN="${RUST_TOOLCHAIN:-1.93.1}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DRY_RUN="${DRY_RUN:-false}"
@@ -84,6 +84,7 @@ PY
   fi
 
   require_command curl
+  curl -fsS "${FLUENTSCAN_API_BASE_URL}/api/v2/smart-contracts/${address}" >/dev/null
   curl -fsS "${FLUENTSCAN_API_BASE_URL}/api/v2/smart-contracts/${address}/verification/via/fluent" \
     -H 'content-type: application/json' \
     --data-raw "$payload"


### PR DESCRIPTION
## Summary

- update the default genesis version used for Fluentscan verification to `v1.4.0`
- warm each contract endpoint before submitting verification while preserving configured API endpoints and offline dry runs

## Validation

- `bash -n scripts/verify-fluentscan-contracts.bash`
- `DRY_RUN=true bash scripts/verify-fluentscan-contracts.bash`
- `git diff --check`

## Skipped

- `shellcheck` (not installed in the local environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the default Genesis SDK version to v1.4.0.
  - Added an endpoint availability check before submitting smart-contract verification requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->