### PR TITLE
fix(sdk): propagate storage read failures from StorageVec checked APIs

### DIFF
--- a/crates/sdk/src/storage/vec.rs
+++ b/crates/sdk/src/storage/vec.rs
@@ -132,10 +132,13 @@ where
     }
 
     pub fn grow_checked<S: StorageAPI>(&self, sdk: &mut S) -> Result<T::Accessor, ExitCode> {
-        let current_len = self.len(sdk);
+        let current_len = self.len_checked(sdk)?;
 
-        // Update length
-        let new_len = current_len + 1;
+        // Update length. Contracts build with `overflow-checks = false`, so the increment is
+        // checked explicitly rather than relying on a debug-only panic.
+        let new_len = current_len
+            .checked_add(1)
+            .ok_or(ExitCode::IntegerOverflow)?;
         let mut len_bytes = [0u8; 32];
         len_bytes[24..32].copy_from_slice(&new_len.to_be_bytes());
         sdk.sstore(self.base_slot, B256::from(len_bytes))?;
@@ -154,7 +157,7 @@ where
         &self,
         sdk: &mut S,
     ) -> Result<Option<T::Accessor>, ExitCode> {
-        let current_len = self.len(sdk);
+        let current_len = self.len_checked(sdk)?;
         if current_len == 0 {
             return Ok(None);
         }
@@ -380,6 +383,67 @@ mod tests {
         assert_addresses_monotonic(&StorageVec::<StorageArray<StorageU256, 7>>::new(
             U256::from(405),
         ));
+    }
+
+    /// A storage backend whose reads always fail, mirroring the `MissingStorageSlot` a system
+    /// runtime returns for a slot the executor did not preload.
+    #[derive(Default)]
+    struct UnreadableStorage;
+
+    impl StorageAPI for UnreadableStorage {
+        fn write_storage(&mut self, _slot: U256, _value: U256) -> crate::SyscallResult<()> {
+            crate::SyscallResult::new((), 0, 0, ExitCode::Ok)
+        }
+
+        fn storage(&self, _slot: &U256) -> crate::SyscallResult<U256> {
+            crate::SyscallResult::new(U256::ZERO, 0, 0, ExitCode::MissingStorageSlot)
+        }
+    }
+
+    /// The `_checked` family must surface a failing read to the caller. It used to route through
+    /// the panicking `len`, so an unreadable length slot aborted the frame instead of returning.
+    #[test]
+    fn test_checked_growth_propagates_storage_read_failure() {
+        let vec = StorageVec::<StorageU256>::new(U256::from(600));
+        let mut sdk = UnreadableStorage;
+
+        assert_eq!(
+            vec.grow_checked(&mut sdk).err(),
+            Some(ExitCode::MissingStorageSlot)
+        );
+        assert_eq!(
+            vec.push_checked(&mut sdk, U256::from(1)),
+            Err(ExitCode::MissingStorageSlot)
+        );
+    }
+
+    #[test]
+    fn test_checked_shrink_propagates_storage_read_failure() {
+        let vec = StorageVec::<StorageU256>::new(U256::from(601));
+        let mut sdk = UnreadableStorage;
+
+        assert_eq!(
+            vec.shrink_checked(&mut sdk).err(),
+            Some(ExitCode::MissingStorageSlot)
+        );
+        assert_eq!(
+            vec.pop_checked(&mut sdk).err(),
+            Some(ExitCode::MissingStorageSlot)
+        );
+    }
+
+    /// A vector already at `u64::MAX` must not wrap its length back to zero and alias element
+    /// zero, which is what the unchecked increment did with `overflow-checks = false`.
+    #[test]
+    fn test_grow_checked_rejects_length_overflow() {
+        let mut sdk = MockStorage::new();
+        let vec = StorageVec::<StorageU256>::new(U256::from(602));
+        sdk.write_storage(U256::from(602), U256::from(u64::MAX));
+
+        assert_eq!(
+            vec.grow_checked(&mut sdk).err(),
+            Some(ExitCode::IntegerOverflow)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`StorageVec::grow_checked` and `shrink_checked` read the current length through the panicking `len` helper (`len_checked(..).unwrap()`). A failing SLOAD aborted the frame instead of returning the error, and the panic propagated to `push_checked` and `pop_checked` — so the entire `_checked` family broke the contract its name advertises.

Both now read through `len_checked` and surface the error as `Err(ExitCode)`.

The length increment in `grow_checked` is also explicitly checked. Contracts build with `overflow-checks = false`, so the previous `+ 1` would wrap a `u64::MAX` length back to zero and alias element zero rather than fail.

## Scope

No in-tree caller is affected. `contracts/runtime-upgrade` is the only in-tree `StorageVec` user and it calls the panicking `.push()` / `.pop()` deliberately; `PRECOMPILE_RUNTIME_UPGRADE` is also not in `EXECUTE_USING_SYSTEM_RUNTIME_ADDRESSES`, so it never takes the preloaded-storage path. This is a correctness fix for external SDK consumers.

## Tests

Three regression tests in `crates/sdk/src/storage/vec.rs`:

- `test_checked_growth_propagates_storage_read_failure` — `grow_checked` / `push_checked` return `MissingStorageSlot`
- `test_checked_shrink_propagates_storage_read_failure` — `shrink_checked` / `pop_checked` return `MissingStorageSlot`
- `test_grow_checked_rejects_length_overflow` — a `u64::MAX` length returns `IntegerOverflow` instead of wrapping

`cargo test -p fluentbase-sdk --lib` — 85 passed. `cargo clippy -p fluentbase-sdk --all-targets` clean.

Refs FLU-1220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when resizing vectors by safely handling storage read failures.
  - Prevented vector length overflow during growth and returned an appropriate error instead of aborting.
  - Added coverage for storage access failures and overflow conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->