### PR TITLE
fix(codec): bound decoder reads by the readable chunk, not just remaining

### DIFF
--- a/crates/codec/src/encoder.rs
+++ b/crates/codec/src/encoder.rs
@@ -252,11 +252,28 @@ pub fn read_u32_aligned<B: ByteOrder, const ALIGN: usize>(
         ));
     }
 
-    if is_big_endian::<B>() {
-        Ok(B::read_u32(&buf.chunk()[end_offset - 4..end_offset]))
+    // The check above bounds the read against `remaining()`, but the word is read out of
+    // `chunk()`, which is only the *current* contiguous segment. For a segmented `Buf` such as
+    // `Chain` or a partially consumed reader, `chunk().len() < remaining()`, so the check can
+    // pass on a range the chunk does not hold. Slice through the checked helper so that case
+    // returns `BufferTooSmall` rather than panicking on an out-of-range index.
+    let word = if is_big_endian::<B>() {
+        checked_decode_slice(
+            buf,
+            end_offset - 4,
+            4,
+            "aligned u32 spans beyond the readable chunk",
+        )?
     } else {
-        Ok(B::read_u32(&buf.chunk()[offset..offset + 4]))
-    }
+        checked_decode_slice(
+            buf,
+            offset,
+            4,
+            "aligned u32 spans beyond the readable chunk",
+        )?
+    };
+
+    Ok(B::read_u32(word))
 }
 
 /// Returns a contiguous range from a decoder buffer without allowing attacker-controlled offsets

--- a/crates/codec/src/evm.rs
+++ b/crates/codec/src/evm.rs
@@ -1,7 +1,10 @@
 use crate::{
     alloc::string::ToString,
     bytes_codec::{read_bytes, read_bytes_header, write_bytes},
-    encoder::{align_up, get_aligned_slice, is_big_endian, write_u32_aligned, Encoder},
+    encoder::{
+        align_up, checked_decode_slice, get_aligned_slice, is_big_endian, write_u32_aligned,
+        Encoder,
+    },
     error::{CodecError, DecodingError},
 };
 use alloc::string::String;
@@ -168,7 +171,13 @@ impl<const N: usize, B: ByteOrder, const ALIGN: usize, const IS_STATIC: bool>
                 msg: "Buffer too small to decode FixedBytes".to_string(),
             }));
         }
-        let data = buf.chunk()[offset..offset + N].to_vec();
+        let data = checked_decode_slice(
+            buf,
+            offset,
+            N,
+            "fixed-size value exceeds the readable chunk",
+        )?
+        .to_vec();
         Ok(FixedBytes::from_slice(&data))
     }
 
@@ -208,7 +217,13 @@ impl<const N: usize, B: ByteOrder, const ALIGN: usize, const IS_STATIC: bool>
                 msg: "Buffer too small to decode FixedBytes".to_string(),
             }));
         }
-        let data = buf.chunk()[offset..offset + N].to_vec();
+        let data = checked_decode_slice(
+            buf,
+            offset,
+            N,
+            "fixed-size value exceeds the readable chunk",
+        )?
+        .to_vec();
         Ok(FixedBytes::from_slice(&data))
     }
 
@@ -246,7 +261,13 @@ macro_rules! impl_evm_fixed {
                         msg: "Buffer too small to decode fixed bytes".to_string(),
                     }));
                 }
-                let data = buf.chunk()[offset..offset + size].to_vec();
+                let data = checked_decode_slice(
+                    buf,
+                    offset,
+                    size,
+                    "fixed-size value exceeds the readable chunk",
+                )?
+                .to_vec();
                 Ok(<$type>::from_slice(&data))
             }
 
@@ -291,7 +312,13 @@ macro_rules! impl_evm_fixed {
                         msg: "Buffer too small to decode fixed bytes".to_string(),
                     }));
                 }
-                let data = buf.chunk()[offset + 32 - size..offset + 32].to_vec();
+                let data = checked_decode_slice(
+                    buf,
+                    offset + 32 - size,
+                    size,
+                    "fixed-size value exceeds the readable chunk",
+                )?
+                .to_vec();
                 Ok(<$type>::from_slice(&data))
             }
 
@@ -347,7 +374,12 @@ impl<
             }));
         }
 
-        let chunk = &buf.chunk()[offset..offset + word_size];
+        let chunk = checked_decode_slice(
+            buf,
+            offset,
+            word_size,
+            "fixed-size value exceeds the readable chunk",
+        )?;
         let value_slice = &chunk[..Self::BYTES];
 
         let value = if is_big_endian::<B>() {
@@ -401,7 +433,12 @@ impl<
             }));
         }
 
-        let chunk = &buf.chunk()[offset..offset + 32];
+        let chunk = checked_decode_slice(
+            buf,
+            offset,
+            32,
+            "fixed-size value exceeds the readable chunk",
+        )?;
         let value_slice = &chunk[32 - Self::BYTES..];
 
         let value = if is_big_endian::<B>() {
@@ -456,7 +493,12 @@ impl<
             }));
         }
 
-        let chunk = &buf.chunk()[offset..offset + word_size];
+        let chunk = checked_decode_slice(
+            buf,
+            offset,
+            word_size,
+            "fixed-size value exceeds the readable chunk",
+        )?;
         let value_slice = &chunk[..Self::BYTES];
 
         let value = if is_big_endian::<B>() {
@@ -518,7 +560,12 @@ impl<
             }));
         }
 
-        let chunk = &buf.chunk()[offset..offset + 32];
+        let chunk = checked_decode_slice(
+            buf,
+            offset,
+            32,
+            "fixed-size value exceeds the readable chunk",
+        )?;
         let value_slice = &chunk[32 - Self::BYTES..];
 
         let value = if is_big_endian::<B>() {

--- a/crates/codec/src/primitive.rs
+++ b/crates/codec/src/primitive.rs
@@ -1,8 +1,8 @@
 use crate::{
     alloc::string::ToString,
     encoder::{
-        align_up, checked_decode_slice, get_aligned_indices, get_aligned_slice, is_big_endian,
-        Encoder,
+        align_up, checked_decode_slice, checked_decode_slice_from, get_aligned_indices,
+        get_aligned_slice, is_big_endian, Encoder,
     },
     error::{CodecError, DecodingError},
 };
@@ -233,14 +233,26 @@ where
             }));
         }
 
-        let chunk = &buf.chunk()[offset..];
-        let option_flag = if is_big_endian::<B>() {
-            chunk[aligned_header - 1]
+        let flag_index = if is_big_endian::<B>() {
+            aligned_header - 1
         } else {
-            chunk[0]
+            0
         };
+        let option_flag = checked_decode_slice(
+            buf,
+            offset,
+            aligned_header,
+            "option flag exceeds the readable chunk",
+        )?[flag_index];
 
-        let chunk = &buf.chunk()[offset + ALIGN..];
+        let payload_offset = offset
+            .checked_add(ALIGN)
+            .ok_or(CodecError::Decoding(DecodingError::Overflow))?;
+        let chunk = checked_decode_slice_from(
+            buf,
+            payload_offset,
+            "option body exceeds the readable chunk",
+        )?;
 
         if option_flag != 0 {
             let inner_value = T::decode(&chunk, 0)?;
@@ -262,14 +274,22 @@ where
             }));
         }
 
-        let chunk = &buf.chunk()[offset..];
-        let option_flag = if is_big_endian::<B>() {
-            chunk[ALIGN - 1]
-        } else {
-            chunk[0]
-        };
+        let flag_index = if is_big_endian::<B>() { ALIGN - 1 } else { 0 };
+        let option_flag = checked_decode_slice(
+            buf,
+            offset,
+            aligned_header,
+            "option flag exceeds the readable chunk",
+        )?[flag_index];
 
-        let chunk = &buf.chunk()[offset + ALIGN..];
+        let payload_offset = offset
+            .checked_add(ALIGN)
+            .ok_or(CodecError::Decoding(DecodingError::Overflow))?;
+        let chunk = checked_decode_slice_from(
+            buf,
+            payload_offset,
+            "option body exceeds the readable chunk",
+        )?;
 
         if option_flag != 0 {
             let (_, inner_size) = T::partial_decode(&chunk, 0)?;

--- a/crates/codec/src/tests.rs
+++ b/crates/codec/src/tests.rs
@@ -618,3 +618,54 @@ fn test_map_wasm_nested() {
     let decoded = CompactABI::<HashMap<u32, HashMap<u32, u32>>>::decode(&encoded, 0).unwrap();
     assert_eq!(decoded, test_value, "Round-trip encoding/decoding failed");
 }
+
+/// Decoding must stay bounded when the input is a valid but *segmented* `Buf`.
+///
+/// The decoders check the requested range against `Buf::remaining()` and then read out of
+/// `Buf::chunk()`, which only exposes the current contiguous segment. For a `Chain` (or any
+/// partially consumed reader) `chunk().len() < remaining()`, so the check can pass on a range
+/// the chunk does not hold. That used to index out of range and panic; it must return a
+/// decoding error instead.
+#[cfg(test)]
+mod segmented_buf {
+    use crate::{
+        encoder::{read_u32_aligned, Encoder},
+        error::{CodecError, DecodingError},
+    };
+    use alloy_primitives::U256;
+    use byteorder::{BigEndian, LittleEndian};
+    use bytes::{Buf, Bytes};
+
+    /// Two 8-byte segments: `remaining() == 16` while `chunk().len() == 8`.
+    fn segmented() -> impl Buf {
+        Bytes::from_static(&[0u8; 8]).chain(Bytes::from_static(&[1, 0, 0, 0, 0, 0, 0, 0]))
+    }
+
+    #[test]
+    fn read_u32_aligned_reports_a_short_chunk_instead_of_panicking() {
+        let buf = segmented();
+        assert!(buf.chunk().len() < buf.remaining(), "buf must be segmented");
+
+        let error = read_u32_aligned::<LittleEndian, 4>(&buf, 8)
+            .expect_err("a word beyond the current chunk must not be read");
+        assert!(matches!(
+            error,
+            CodecError::Decoding(DecodingError::BufferTooSmall { .. })
+        ));
+
+        // A word fully inside the first chunk still decodes.
+        assert_eq!(read_u32_aligned::<LittleEndian, 4>(&buf, 0).unwrap(), 0);
+    }
+
+    #[test]
+    fn fixed_size_decode_reports_a_short_chunk_instead_of_panicking() {
+        let buf = segmented();
+
+        let error = <U256 as Encoder<BigEndian, 32, true, false>>::decode(&buf, 0)
+            .expect_err("a 32-byte word cannot come from an 8-byte chunk");
+        assert!(matches!(
+            error,
+            CodecError::Decoding(DecodingError::BufferTooSmall { .. })
+        ));
+    }
+}

--- a/crates/codec/src/tuple.rs
+++ b/crates/codec/src/tuple.rs
@@ -228,9 +228,9 @@ macro_rules! impl_encoder_for_tuple {
                             msg: "buf too small to take dynamic offset".to_string(),
                         }));
                     }
-                    &buf.chunk()[dynamic_offset..]
+                    checked_decode_slice_from(buf, dynamic_offset, "tuple body exceeds the readable chunk")?
                 } else {
-                    &buf.chunk()[offset..]
+                    checked_decode_slice_from(buf, offset, "tuple head exceeds the readable chunk")?
                 };
 
                 let mut _current_offset = 0;


### PR DESCRIPTION
## Summary

Decoders validated a requested range against `Buf::remaining()` and then read it out of `Buf::chunk()`. `chunk()` only exposes the current contiguous segment, so for a segmented `Buf` — `Chain`, `Cursor`, a partially consumed reader — `chunk().len() < remaining()` and the check could pass on a range the chunk does not hold, indexing out of range and panicking.

The public signatures take `&impl Buf`, so this is an API-contract violation rather than caller misuse.

## Why it has not fired

Every host-side call site happens to pass a contiguous `&[u8]`, including the attacker-facing path `crates/revm/src/executor.rs` → `erc20_compute_storage_keys` → `SolidityABI::decode`. Note that `fluentbase-codec` *is* linked into the node binary and *is* reached with untrusted calldata — the safety property here is call-site discipline, not sandbox isolation, and nothing enforces it. A future caller wrapping input in a `Chain` would make this a host-side panic, which `panic = "abort"` in the `reproducible` profile turns node-fatal.

## Change

Route the reads through the existing `checked_decode_slice` / `checked_decode_slice_from` helpers so an out-of-chunk range returns `BufferTooSmall`:

- `encoder.rs` — `read_u32_aligned`
- `tuple.rs` — tuple head and dynamic body
- `primitive.rs` — `Option` flag and payload, in both `decode` and `partial_decode`
- `evm.rs` — `FixedBytes`, `Uint` and `Signed` fixed-size reads, compact and Solidity

Offset arithmetic on those paths is now checked too. **No unguarded `buf.chunk()[..]` indexing remains in the crate.**

## Tests

Two tests in `crates/codec/src/tests.rs` using a real segmented `Chain` (`remaining() == 16`, `chunk().len() == 8`):

- `read_u32_aligned_reports_a_short_chunk_instead_of_panicking` — returns `BufferTooSmall`; a word fully inside the first chunk still decodes
- `fixed_size_decode_reports_a_short_chunk_instead_of_panicking` — a 32-byte `U256` word from an 8-byte chunk errors

`cargo test -p fluentbase-codec` 78 + 19 + 14 + 2 passed; `cargo test -p fluentbase-sdk --lib` 82 passed; clippy and rustfmt clean.

## Reviewer note

This touches the codec that both the EVM shim and the universal token decode with. Worth a full `cargo test --workspace` before merge — I verified the two directly affected crates only.

Refs FLU-1221