### PR TITLE
ci: improve coverage generation and reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: self-hosted
-    if: github.event_name == 'workflow_dispatch'
+    timeout-minutes: 180
+    # Full coverage is expensive, so refresh the base branches automatically and keep
+    # pull requests on the existing parallel test matrix.
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -213,6 +216,7 @@ jobs:
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: stable
+          components: llvm-tools-preview
 
       - name: Install wasm32 target
         run: rustup target list --installed | grep -q '^wasm32-unknown-unknown$' || rustup target add wasm32-unknown-unknown
@@ -231,25 +235,27 @@ jobs:
       - name: Prefetch deps (root)
         run: cargo fetch --locked
 
-      - name: Run cargo check (offline)
-        run: cargo check --locked
+      - name: Install coverage tools
+        run: |
+          cargo install cargo-nextest@0.9.130 --locked
+          cargo install cargo-llvm-cov@0.8.4 --locked
 
       - name: Generate code coverage
-        run: |
-          cargo install cargo-tarpaulin
-          cargo tarpaulin --verbose --timeout 120 --out xml
+        run: make coverage
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-root.lcov,./coverage-contracts.lcov,./coverage-examples-deps.lcov,./coverage-evm-e2e-deps.lcov
+          disable_search: true
           fail_ci_if_error: true
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: code-coverage-report
-          path: cobertura.xml
+          path: coverage-*.lcov
 
   rust-fmt-lint:
     name: Lint

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 all: check build
 
 CARGO_LOCKED_FLAGS ?= --locked
+COVERAGE_TARGET ?= $(shell rustc -vV | sed -n 's/^host: //p')
+COVERAGE_IGNORE_FILENAME_REGEX ?= (^|/)(tests?|benches?|examples?|e2e|evm-e2e)(/|$$)|(^|/)crates/testing(/|$$)|/(tests|.*_tests)\.rs$$
+EXAMPLES_COVERAGE_DEPENDENCIES ?= fluentbase-build,fluentbase-evm,fluentbase-sdk
+EVM_E2E_COVERAGE_DEPENDENCIES ?= fluentbase-genesis,fluentbase-revm,fluentbase-runtime,fluentbase-sdk
 
 .PHONY: check
 check:
@@ -58,6 +62,77 @@ test:
 	$(MAKE) run-e2e-tests TEST_FEATURES=std,wasmtime TEST_PROFILE=--release
 	# devnet/mainnet: rwasm case
 	$(MAKE) run-e2e-tests TEST_FEATURES=std TEST_PROFILE=--release
+
+.PHONY: coverage coverage-root coverage-contracts coverage-examples-deps coverage-evm-e2e-deps
+coverage: coverage-root coverage-contracts coverage-examples-deps coverage-evm-e2e-deps
+
+coverage-root:
+	@test -n "$(COVERAGE_TARGET)"
+	cargo llvm-cov clean --manifest-path=./Cargo.toml --workspace
+	cargo llvm-cov nextest --manifest-path=./Cargo.toml --workspace --release \
+		--no-default-features --features std --no-fail-fast --locked --no-report \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only
+	cargo llvm-cov nextest --manifest-path=./Cargo.toml --workspace --release \
+		--no-default-features --features std,wasmtime --no-fail-fast --locked --no-report \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only
+	cargo llvm-cov report --manifest-path=./Cargo.toml --workspace --release \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only --lcov \
+		--output-path coverage-root.lcov \
+		--ignore-filename-regex "$(COVERAGE_IGNORE_FILENAME_REGEX)"
+
+coverage-contracts:
+	@test -n "$(COVERAGE_TARGET)"
+	cargo llvm-cov clean --manifest-path=./contracts/Cargo.toml --workspace
+	cargo llvm-cov nextest --manifest-path=./contracts/Cargo.toml --workspace --release \
+		--no-default-features --features std --no-fail-fast --locked --no-report \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only
+	cargo llvm-cov report --manifest-path=./contracts/Cargo.toml --workspace --release \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only --lcov \
+		--output-path coverage-contracts.lcov \
+		--ignore-filename-regex "$(COVERAGE_IGNORE_FILENAME_REGEX)"
+
+coverage-examples-deps:
+	@test -n "$(COVERAGE_TARGET)"
+	cargo llvm-cov clean --manifest-path=./examples/Cargo.toml --workspace
+	cargo llvm-cov nextest --manifest-path=./examples/Cargo.toml --workspace --release \
+		--no-default-features --features std --no-fail-fast --locked --no-report \
+		--dep-coverage "$(EXAMPLES_COVERAGE_DEPENDENCIES)" \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only
+	cargo llvm-cov report --manifest-path=./examples/Cargo.toml --workspace --release \
+		--dep-coverage "$(EXAMPLES_COVERAGE_DEPENDENCIES)" \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only --lcov \
+		--output-path coverage-examples-deps.lcov \
+		--ignore-filename-regex "$(COVERAGE_IGNORE_FILENAME_REGEX)"
+
+coverage-evm-e2e-deps:
+	@test -n "$(COVERAGE_TARGET)"
+	$(MAKE) -C evm-e2e sync_tests
+	cargo llvm-cov clean --manifest-path=./evm-e2e/Cargo.toml --workspace
+	cargo llvm-cov nextest --manifest-path=./evm-e2e/Cargo.toml --release \
+		--no-default-features --features std --package evm-e2e --bin evm-e2e \
+		--no-fail-fast --locked --no-report \
+		--dep-coverage "$(EVM_E2E_COVERAGE_DEPENDENCIES)" \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only tests::good_coverage_tests
+	cargo llvm-cov nextest --manifest-path=./evm-e2e/Cargo.toml --release \
+		--no-default-features --features std,wasmtime --package evm-e2e --bin evm-e2e \
+		--no-fail-fast --locked --no-report \
+		--dep-coverage "$(EVM_E2E_COVERAGE_DEPENDENCIES)" \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only tests::good_coverage_tests
+	cargo llvm-cov nextest --manifest-path=./evm-e2e/Cargo.toml --release \
+		--no-default-features --features std --package evm-e2e --bin evm-e2e \
+		--no-fail-fast --locked --no-report \
+		--dep-coverage "$(EVM_E2E_COVERAGE_DEPENDENCIES)" \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only fixture
+	cargo llvm-cov nextest --manifest-path=./evm-e2e/Cargo.toml --release \
+		--no-default-features --features std,wasmtime --package evm-e2e --bin evm-e2e \
+		--no-fail-fast --locked --no-report \
+		--dep-coverage "$(EVM_E2E_COVERAGE_DEPENDENCIES)" \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only fixture
+	cargo llvm-cov report --manifest-path=./evm-e2e/Cargo.toml --release \
+		--dep-coverage "$(EVM_E2E_COVERAGE_DEPENDENCIES)" \
+		--target "$(COVERAGE_TARGET)" --coverage-target-only --lcov \
+		--output-path coverage-evm-e2e-deps.lcov \
+		--ignore-filename-regex "$(COVERAGE_IGNORE_FILENAME_REGEX)"
 .PHONY: test-debug
 test-debug:
 	# devnet/mainnet: contracts unit tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,11 @@
 ignore:
-  - "crates/build"  # build crate
-  - "crates/rwasm/e2e"  # rwasm e2e testing suite
-  - "e2e" # e2e tests for runtime
-  - "examples" # examples
-  - "revm/e2e" # revm e2e testing suite
+  # Test and benchmark code should collect hits without becoming part of the
+  # production coverage denominator.
+  - "**/tests/**"
+  - "**/benches/**"
+  - "**/src/tests.rs"
+  - "**/src/**/*_tests.rs"
+  - "crates/testing/**"
+  - "e2e/**"
+  - "evm-e2e/**"
+  - "examples/**"


### PR DESCRIPTION
## Summary

- Run coverage automatically outside pull requests with a three-hour timeout.
- Replace Tarpaulin with `cargo-llvm-cov` and `cargo-nextest`.
- Add Makefile targets for root, contracts, examples dependencies, and EVM end-to-end coverage.
- Upload separate LCOV reports to Codecov and archive them as CI artifacts.
- Refine Codecov exclusions to omit tests, benchmarks, examples, and E2E code from production coverage.

## Testing

Not run (not requested).