### PR TITLE
fix(ci): remove unsupported coverage report flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ coverage-root:
 	cargo llvm-cov nextest --manifest-path=./Cargo.toml --workspace --release \
 		--no-default-features --features std,wasmtime --no-fail-fast --locked --no-report \
 		--target "$(COVERAGE_TARGET)" --coverage-target-only
-	cargo llvm-cov report --manifest-path=./Cargo.toml --workspace --release \
+	cargo llvm-cov report --manifest-path=./Cargo.toml --release \
 		--target "$(COVERAGE_TARGET)" --coverage-target-only --lcov \
 		--output-path coverage-root.lcov \
 		--ignore-filename-regex "$(COVERAGE_IGNORE_FILENAME_REGEX)"
@@ -86,7 +86,7 @@ coverage-contracts:
 	cargo llvm-cov nextest --manifest-path=./contracts/Cargo.toml --workspace --release \
 		--no-default-features --features std --no-fail-fast --locked --no-report \
 		--target "$(COVERAGE_TARGET)" --coverage-target-only
-	cargo llvm-cov report --manifest-path=./contracts/Cargo.toml --workspace --release \
+	cargo llvm-cov report --manifest-path=./contracts/Cargo.toml --release \
 		--target "$(COVERAGE_TARGET)" --coverage-target-only --lcov \
 		--output-path coverage-contracts.lcov \
 		--ignore-filename-regex "$(COVERAGE_IGNORE_FILENAME_REGEX)"
@@ -98,7 +98,7 @@ coverage-examples-deps:
 		--no-default-features --features std --no-fail-fast --locked --no-report \
 		--dep-coverage "$(EXAMPLES_COVERAGE_DEPENDENCIES)" \
 		--target "$(COVERAGE_TARGET)" --coverage-target-only
-	cargo llvm-cov report --manifest-path=./examples/Cargo.toml --workspace --release \
+	cargo llvm-cov report --manifest-path=./examples/Cargo.toml --release \
 		--dep-coverage "$(EXAMPLES_COVERAGE_DEPENDENCIES)" \
 		--target "$(COVERAGE_TARGET)" --coverage-target-only --lcov \
 		--output-path coverage-examples-deps.lcov \


### PR DESCRIPTION
## Summary
- remove the unsupported `--workspace` flag from all `cargo llvm-cov report` commands
- retain workspace selection for coverage collection and cleaning, where the flag is supported

## Failure
The coverage job in https://github.com/fluentlabs-xyz/fluentbase/actions/runs/33499044859/job/99827838582 failed after 704 root tests passed because `cargo llvm-cov report` rejects `--workspace`.

## Validation
- focused release `cargo llvm-cov nextest` run: 9/9 passed
- corrected release `cargo llvm-cov report` command generated a non-empty LCOV report with 12 source files
- `make -n MAKE=: coverage`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage reporting to generate results for the specified project manifest only, rather than the entire workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->