### PR TITLE
docs: clarify rWasm trap handling and panic invariants

### DIFF
--- a/docs/05-security-invariants.md
+++ b/docs/05-security-invariants.md
@@ -55,6 +55,23 @@ For system runtimes:
 - storage/log/metadata effects are committed only on successful runtime exit,
 - fatal exits must not be interpreted as normal structured outcomes.
 
+An unexpected trap means that the current system-runtime invocation cannot continue. The host must:
+
+1. discard the runtime output without decoding or applying its structured envelope,
+2. evict the trapped runtime instance so its stack and linear memory are never reused,
+3. return a deterministic exceptional halt and revert the active REVM journal checkpoint, including
+   value transfers and effects committed by nested frames.
+
+Halting the frame or transaction does not continue from corrupted guest state. The runtime instance
+is discarded, and journal rollback protects user storage and balances. Normal failed-transaction
+effects, such as gas payment and nonce consumption, still follow the transaction rules.
+
+A sandboxed guest trap alone is not evidence that host memory or persistent state was corrupted, so
+it must not become an incidental process panic. If a particular invariant requires rejecting the
+whole block rather than halting one transaction, propagate a typed block-execution error. Reserve
+process termination for failures where host integrity cannot be trusted or safe rollback cannot be
+established.
+
 Why it matters: envelope mis-handling can commit invalid side effects.
 
 ---
@@ -88,10 +105,19 @@ Why it matters: mismatch can mint/burn/settle wrong amounts.
 
 ## 9) Panic policy
 
-Release profile is `panic = "abort"`.
-Do not rely on unwind recovery for consensus-critical paths.
+The default release profile uses `panic = "unwind"`; the reproducible release profile overrides it
+with `panic = "abort"`. Consensus behavior must not depend on which profile built the binary.
 
-Why it matters: abort behavior must be anticipated in error-handling design.
+- A panic is not a transaction or block rollback mechanism.
+- Consensus-reachable failures must return deterministic frame, transaction, or block errors.
+- Do not rely on catching an unwind: another production profile may abort instead.
+- Do not rely on an abort for state safety: journal checkpoints and explicit database commit
+  boundaries provide that safety.
+- Reserve panics for genuine programmer invariants that cannot be reached from transaction, block,
+  runtime, or other externally influenced input.
+
+Why it matters: the same deterministic input must not become a node-crash or chain-liveness vector,
+and panic-profile differences must not change consensus outcomes.
 
 ---
 

--- a/docs/07-rwasm-integration.md
+++ b/docs/07-rwasm-integration.md
@@ -71,8 +71,9 @@ A dependency bump can silently change any of these.
    (`crates/revm/src/executor.rs`: `execute_rwasm_resume`, `process_exec_result`,
    `process_runtime_execution_outcome`; `crates/runtime/src/executor.rs`: `resume`,
    `memory_read`) — an upgrade that changes trap/interruption behavior may make these
-   deterministic `UnknownError` halts reachable, and they must stay halts, not panics
-   (release profile is `panic = "abort"`),
+   deterministic `UnknownError` halts reachable, and they must stay typed deterministic halts or
+   block-execution errors, not panics. The default release profile unwinds while the reproducible
+   profile aborts, so consensus behavior cannot rely on either panic strategy,
 6. update docs in same PR.
 
 If one of these steps is skipped, regressions can escape into consensus path.


### PR DESCRIPTION
## Summary

- Define deterministic handling for unexpected rWasm traps, including instance eviction and REVM journal rollback.
- Clarify that sandboxed guest traps must not cause incidental process panics.
- Document panic-profile-independent consensus behavior and typed error requirements.

## Testing

Not run (documentation-only changes).