### PR TITLE
docs(compatibility): document EIP-7825 divergence

### DIFF
--- a/crates/types/src/block_fuel.rs
+++ b/crates/types/src/block_fuel.rs
@@ -108,11 +108,11 @@ pub const BLS_G1_DECOMPRESS_COST: u32 = 600 * FUEL_DENOM_RATE as u32;
 pub const UINT256_MUL_MOD_COST: u32 = 8 * FUEL_DENOM_RATE as u32;
 pub const UINT256_X2048_MUL_COST: u32 = 5_000 * FUEL_DENOM_RATE as u32;
 
-/// Calldata surcharge threshold (128 KB).
+/// Calldata surcharge threshold (128 KiB).
 ///
-/// Ethereum L1 rejects transactions above this size at the RPC level.
-/// Fluent L2 accepts large calldata but applies a quadratic surcharge above this threshold
-/// to bound block data to L1 blob capacity.
+/// Geth's legacy transaction pool limits encoded transactions to 128 KiB, but Ethereum does not
+/// impose a protocol-level input-size limit at this threshold. Fluent L2 accepts larger input and
+/// applies a quadratic surcharge to the excess to bound block data to L1 blob capacity.
 pub const CALLDATA_QUADRATIC_THRESHOLD: u64 = 128 * 1024;
 
 /// Divisor in `surcharge = 3*words + words²/DIVISOR`.

--- a/docs/04-gas-and-fuel.md
+++ b/docs/04-gas-and-fuel.md
@@ -71,12 +71,33 @@ Universal Token runtime is currently in engine-metered set.
 
 ---
 
-## Calldata surcharge
+## Ethereum compatibility: transaction gas and calldata
 
-Large calldata gets extra quadratic surcharge above threshold.
-Purpose is practical block-data pressure control.
+[EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) caps the gas limit declared by an Ethereum
+transaction at `2^24` gas (16,777,216), independently of the block gas limit. Ethereum clients
+reject transactions above that cap from the transaction pool and reject blocks containing them.
 
-This is part of block economics, not only runtime internals.
+Fluentbase does not enforce this fixed per-transaction cap. WASM smart contracts can require more
+than `2^24` gas, so limiting every transaction to Ethereum's cap would prevent valid WASM execution.
+This does not make transaction execution literally unlimited: the transaction gas limit must still
+fit within the current block gas limit and pass the usual intrinsic-gas, balance, and fee checks.
+
+Fluentbase instead controls large transaction input through gas pricing. Input up to 128 KiB
+(131,072 bytes) receives no Fluent-specific surcharge beyond the normal intrinsic calldata gas.
+For larger input, only the excess is divided into 32-byte words and charged using:
+
+```text
+words = ceil((input_length - 128 KiB) / 32)
+surcharge = 3 * words + floor(words^2 / 30)
+```
+
+The transaction is rejected if its declared gas limit cannot cover the intrinsic gas plus this
+surcharge. This policy allows transactions above 128 KiB rather than imposing a protocol-level
+input-size limit, while the quadratic term constrains block-data pressure.
+
+Consequently, Ethereum tooling must not assume that Fluentbase applies EIP-7825: a transaction with
+a gas limit above `2^24` can be valid on Fluentbase if it satisfies the block-level and economic
+constraints above.
 
 ---
 


### PR DESCRIPTION
## Summary

- document why Fluentbase does not enforce EIP-7825's fixed 16,777,216 gas transaction cap for WASM contracts
- clarify that Fluentbase transactions remain bounded by the block gas limit and normal validation
- document the 128 KiB excess-input quadratic surcharge and correct the related source comment

## Research notes

- EIP-7825 caps the gas limit declared by a transaction, independently of the block gas limit
- Ethereum has no protocol-level 128 KiB transaction-input limit; Geth's legacy txpool has a 128 KiB encoded-transaction policy
- Fluentbase applies its surcharge only to input bytes above 131,072 bytes

## Validation

- `git diff --check`
- `cargo fmt --check --package fluentbase-types`
- `cargo test -p fluentbase-revm rejects_calldata_surcharge_that_exceeds_gas_limit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Ethereum transaction gas and calldata behavior.
  * Documented that Fluentbase does not enforce Ethereum’s fixed transaction gas cap.
  * Explained normal calldata pricing up to 128 KiB and surcharge calculations for larger input.
  * Clarified that transactions are rejected when their gas limit cannot cover intrinsic gas and applicable surcharges.
  * Noted that Ethereum tooling should not assume the fixed gas cap applies on Fluentbase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->