### PR TITLE
fix(codec): encode zero-valued ABI integers canonically

### DIFF
--- a/crates/codec/src/primitive.rs
+++ b/crates/codec/src/primitive.rs
@@ -124,9 +124,8 @@ macro_rules! impl_int {
 
                 B::$write_method(&mut buf[start..end], *self);
 
-                // Fill the rest of the buffer with 0x00 or 0xFF depending on the sign of the
-                // integer
-                let fill_val = if *self > 0 { 0x00 } else { 0xFF };
+                // Only negative integers sign-extend; zero and positive integers zero-extend.
+                let fill_val = if self.cmp(&0).is_lt() { 0xFF } else { 0x00 };
 
                 for i in offset..start {
                     buf[i] = fill_val;

--- a/crates/codec/tests/integer_padding.rs
+++ b/crates/codec/tests/integer_padding.rs
@@ -1,0 +1,47 @@
+use alloy_sol_types::{sol, SolType};
+use bytes::BytesMut;
+use fluentbase_codec::SolidityABI;
+
+macro_rules! test_integer_padding {
+    ($name:ident, $sol_type:ty, $values:expr) => {
+        #[test]
+        fn $name() {
+            for value in $values {
+                let expected = <$sol_type>::abi_encode(&value);
+                for (offset, mut buf) in
+                    [(0, BytesMut::new()), (32, BytesMut::from(&[0xA5; 96][..]))]
+                {
+                    SolidityABI::encode(&value, &mut buf, offset).unwrap();
+                    let encoded = &buf[offset..offset + 32];
+                    assert_eq!(encoded, expected, "value {value}, offset {offset}");
+                    assert_eq!(
+                        <$sol_type>::abi_decode_validate(encoded).unwrap(),
+                        value,
+                        "value {value}, offset {offset}",
+                    );
+                    assert!(buf[..offset].iter().all(|byte| *byte == 0xA5));
+                    assert!(buf[offset + 32..].iter().all(|byte| *byte == 0xA5));
+                }
+            }
+        }
+    };
+}
+
+test_integer_padding!(solidity_u16_padding, sol!(uint16), [0u16, 1, u16::MAX]);
+test_integer_padding!(solidity_u32_padding, sol!(uint32), [0u32, 1, u32::MAX]);
+test_integer_padding!(solidity_u64_padding, sol!(uint64), [0u64, 1, u64::MAX]);
+test_integer_padding!(
+    solidity_i16_padding,
+    sol!(int16),
+    [0i16, 1, -1, i16::MIN, i16::MAX]
+);
+test_integer_padding!(
+    solidity_i32_padding,
+    sol!(int32),
+    [0i32, 1, -1, i32::MIN, i32::MAX]
+);
+test_integer_padding!(
+    solidity_i64_padding,
+    sol!(int64),
+    [0i64, 1, -1, i64::MIN, i64::MAX]
+);


### PR DESCRIPTION
Zero-valued `u16/u32/u64` and `i16/i32/i64` currently receive `0xFF` padding in aligned ABI words. The codec's own decoder discards that padding, so internal round trips conceal the incompatibility with Solidity ABI consumers. Only negative integers now sign-extend; zero and positive values zero-extend.

Adds six Alloy `sol!` parity tests covering zero, positive values, unsigned maxima, signed extrema, and negative sign extension. They compare exact bytes and validate decoding in Alloy, using both fresh buffers and prefilled buffers at a nonzero offset. All six tests failed on zero before the fix and pass afterward.

The fix and regression tests are separate GPG-signed Conventional Commits, with signatures verified locally. Existing contract artifacts must be rebuilt and deployed/upgraded to incorporate the codec change.

Validation:

- `RUSTC_WRAPPER= cargo test -p fluentbase-codec --locked` — 117 tests and 2 doctests passed.
- `RUSTC_WRAPPER= cargo clippy -p fluentbase-codec --all-targets --locked -- -D warnings` — passed.
- `RUSTC_WRAPPER= cargo check -p fluentbase-codec --no-default-features --locked` — passed.
- `cargo fmt --check --package fluentbase-codec` and `git diff origin/devel...HEAD --check` — passed.

Full workspace, contracts, and EVM fixture suites were not run locally; validation was scoped to the changed codec crate. The PR CI runs the broader suites.

Fixes [FLU-1330](https://linear.app/fluentlabs-xyz/issue/FLU-1330).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected integer encoding so zero and positive values use zero-filled alignment padding, while negative values retain sign-extension padding.

* **Tests**
  * Added coverage for signed and unsigned integer encoding and decoding across multiple integer widths.
  * Verified that surrounding buffer data remains unchanged during encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->