### PR TITLE
fix(build): enforce abort panic policy for shipped nodes

### DIFF
--- a/.github/scripts/check-panic-policy.py
+++ b/.github/scripts/check-panic-policy.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Check the documented Cargo panic policies, including profile inheritance."""
+
+from pathlib import Path
+import re
+import sys
+import tomllib
+
+
+def panic_strategy(profiles, name, visiting=()):
+    if name in visiting:
+        raise ValueError(f"cyclic profile inheritance: {' -> '.join((*visiting, name))}")
+    profile = profiles.get(name, {})
+    if "panic" in profile:
+        return profile["panic"]
+    if "inherits" in profile:
+        return panic_strategy(profiles, profile["inherits"], (*visiting, name))
+    if name in ("dev", "release"):
+        return "unwind"  # Cargo's default for these built-in profiles.
+    raise ValueError(f"profile {name!r} is missing or has no inherits setting")
+
+
+def check_policy(root):
+    manifest = tomllib.loads((root / "Cargo.toml").read_text())
+    profiles = manifest["profile"]
+    docs = (root / "docs/05-security-invariants.md").read_text()
+    panic_section = docs.split("## 9) Panic policy\n", 1)[1].split("\n## ", 1)[0]
+    documented = dict(
+        re.findall(r"^\| `(\w+)` \| `(abort|unwind)` \|", panic_section, re.MULTILINE)
+    )
+
+    for name in ("release", "maxperf", "reproducible"):
+        actual = panic_strategy(profiles, name)
+        if name in ("maxperf", "reproducible") and actual != "abort":
+            raise ValueError(f"production profile {name!r} must abort, found {actual!r}")
+        if documented.get(name) != actual:
+            raise ValueError(
+                f"profile {name!r}: Cargo uses {actual!r}, "
+                f"docs record {documented.get(name)!r}"
+            )
+        print(f"{name}: panic = {actual} (matches docs)")
+
+
+if __name__ == "__main__":
+    root = Path(__file__).resolve().parents[2]
+    try:
+        check_policy(root)
+    except (KeyError, IndexError, ValueError) as error:
+        sys.exit(f"panic policy check failed: {error}")

--- a/.github/workflows/panic-policy.yml
+++ b/.github/workflows/panic-policy.yml
@@ -1,0 +1,20 @@
+name: Panic policy
+
+on:
+  push:
+    branches: [ main, devel, "release/*" ]
+  pull_request:
+    branches: [ main, devel, "release/*" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  panic-policy:
+    name: Shipped panic policy
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Check production profiles and security documentation
+        run: python3 .github/scripts/check-panic-policy.py

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -370,6 +370,8 @@ lto = "thin"
 
 [profile.maxperf]
 inherits = "release"
+# Shipped nodes must not continue with poisoned global state after a host panic.
+panic = "abort"
 lto = "fat"
 codegen-units = 1
 

--- a/docs/05-security-invariants.md
+++ b/docs/05-security-invariants.md
@@ -105,8 +105,22 @@ Why it matters: mismatch can mint/burn/settle wrong amounts.
 
 ## 9) Panic policy
 
-The default release profile uses `panic = "unwind"`; the reproducible release profile overrides it
-with `panic = "abort"`. Consensus behavior must not depend on which profile built the binary.
+Cargo profiles have the following panic strategies. CI checks this table against `Cargo.toml`,
+including inherited settings, with `.github/scripts/check-panic-policy.py`.
+
+| Profile | Panic strategy | Build path |
+| --- | --- | --- |
+| `release` | `unwind` | Default local release builds |
+| `maxperf` | `abort` | Published `fluent` / `fluent-rwasm` binaries and Docker images |
+| `reproducible` | `abort` | Opt-in reproducible node builds |
+
+An unexpected host panic in a shipped node terminates the process immediately, so a poisoned global
+module-cache mutex cannot be reused by later tasks. Operators must supervise the process and restart
+it after a failure. Restarting does not fix the underlying invariant violation: the same input may
+fail again and require a software fix. Abort does not run destructors or drain in-flight tasks.
+
+Consensus behavior must not depend on which profile built the binary. The panic strategy is a last
+resort for unexpected host failures; it does not implement the guest-trap containment policy in §5.
 
 - A panic is not a transaction or block rollback mechanism.
 - Consensus-reachable failures must return deterministic frame, transaction, or block errors.


### PR DESCRIPTION
Published nodes use the `maxperf` profile, which inherited `panic = "unwind"` and could leave later tasks reusing a poisoned global module-cache mutex after a host panic. Set `maxperf` explicitly to `panic = "abort"`, document the supervised-restart requirement, and add a CI guard that resolves profile inheritance and compares it with the documented panic strategies. The guard also runs for documentation-only changes.

Implements [FLU-1309](https://linear.app/fluentlabs-xyz/issue/FLU-1309) in two signed Conventional Commits: the profile fix, then the documentation and CI guard.

Validation:
- `python3 .github/scripts/check-panic-policy.py` passes; it rejected the original `maxperf = unwind` configuration.
- Eight policy regression cases pass, including removed overrides, stale documentation, inherited abort, and cyclic inheritance.
- An isolated Cargo binary using the repository's profile definitions confirms `maxperf` and `reproducible` terminate on panic with SIGABRT; `release` retains unwind behavior.
- Workflow YAML / Python syntax and `git diff --check origin/devel...HEAD` pass.
- `RUSTC_WRAPPER= cargo check -p fluent --profile maxperf --locked --offline` passes (3m 29s).
- GitHub: Shipped panic policy and Release supply-chain guard pass; test, Clippy, and benchmark jobs remain queued.

Operational limit: abort skips destructors and task draining. Operators must supervise and restart the process, and repeated failure on the same input still requires a software fix. This change does not implement the separate guest-trap containment work in FLU-1302 or replace journal rollback and typed execution errors. Full local runtime suites were not run because this changes build policy and CI/documentation only.

Review: @dmitry123.
