### PR TITLE
fix(node): prevent silent RPC consensus follower stalls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4894,6 +4894,7 @@ dependencies = [
  "fluentbase-revm",
  "fluentbase-runtime",
  "fluentbase-types",
+ "jsonrpsee",
  "reth-chainspec",
  "reth-cli",
  "reth-cli-runner",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -81,6 +81,9 @@ eyre = { workspace = true }
 directories = { workspace = true }
 flate2 = { workspace = true }
 
+[dev-dependencies]
+jsonrpsee = { version = "0.26.0", features = ["server"] }
+
 [features]
 default = ["std"]
 std = [

--- a/crates/node/src/launcher.rs
+++ b/crates/node/src/launcher.rs
@@ -20,6 +20,9 @@ use std::{future::Future, time::Duration};
 use tokio::{sync::mpsc, task::JoinHandle, time::Interval};
 use tracing::{error, info};
 
+#[cfg(test)]
+mod tests;
+
 pub async fn launch_consensus_validator<N, AddOns: RethRpcAddOns<N>, B>(
     handle: &NodeHandle<N, AddOns>,
     block_time: Duration,

--- a/crates/node/src/launcher.rs
+++ b/crates/node/src/launcher.rs
@@ -1,9 +1,9 @@
 //! This is temporary single-node consensus that is used for block production for Fluent,
 //! it will be replaced with DPoS consensus later.
-use alloy_network::AnyNetwork;
+use alloy_network::Ethereum;
 use alloy_primitives::B256;
 use alloy_rpc_types_engine::ForkchoiceState;
-use eyre::OptionExt;
+use eyre::{OptionExt, WrapErr};
 use reth_consensus_debug_client::{BlockProvider, RpcBlockProvider};
 use reth_engine_primitives::ConsensusEngineHandle;
 use reth_node_api::FullNodeComponents;
@@ -15,9 +15,9 @@ use reth_payload_primitives::{
 };
 use reth_primitives_traits::{HeaderTy, NodePrimitives, SealedBlock, SealedHeaderFor};
 use reth_storage_api::BlockReader;
-use reth_tasks::shutdown::GracefulShutdown;
-use std::{sync::Arc, time::Duration};
-use tokio::{sync::mpsc, time::Interval};
+use reth_tasks::{shutdown::GracefulShutdown, TaskExecutor};
+use std::{future::Future, time::Duration};
+use tokio::{sync::mpsc, task::JoinHandle, time::Interval};
 use tracing::{error, info};
 
 pub async fn launch_consensus_validator<N, AddOns: RethRpcAddOns<N>, B>(
@@ -173,52 +173,99 @@ pub async fn launch_consensus_node<Node, AddOns: RethRpcAddOns<Node>>(
     consensus_url: String,
 ) -> eyre::Result<()>
 where
-    Node: FullNodeComponents<Types: DebugNode<Node>>,
+    Node: FullNodeComponents<Types: DebugNode<Node, RpcBlock = alloy_rpc_types_eth::Block>>,
 {
     info!(target: "reth::cli", "Using RPC consensus client: {}", consensus_url);
 
-    let block_provider =
-        RpcBlockProvider::<AnyNetwork, _>::new(consensus_url.as_str(), |block_response| {
-            let json =
-                serde_json::to_value(block_response).expect("Block serialization cannot fail");
-            let rpc_block =
-                serde_json::from_value(json).expect("Block deserialization cannot fail");
-            Node::Types::rpc_to_primitive_block(rpc_block)
-        })
-        .await?;
+    // Decode directly into the supported RPC block type. Unsupported transaction types now
+    // become provider errors, which the subscription logs before continuing, not panics in
+    // an infallible AnyNetwork-to-Ethereum conversion callback.
+    let block_provider = RpcBlockProvider::<Ethereum, _>::new(
+        consensus_url.as_str(),
+        Node::Types::rpc_to_primitive_block,
+    )
+    .await?;
 
     let beacon_engine_handle = handle.node.add_ons_handle.beacon_engine_handle.clone();
-    handle
-        .node
-        .task_executor
-        .spawn_critical_task("consensus node worker", async move {
-            new_block_fetcher(beacon_engine_handle, Arc::new(block_provider)).await
-        });
+    spawn_consensus_follower(
+        &handle.node.task_executor,
+        beacon_engine_handle,
+        block_provider,
+    );
     Ok(())
 }
 
+fn spawn_consensus_follower<
+    P: BlockProvider,
+    T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives: NodePrimitives<Block = P::Block>>>,
+>(
+    task_executor: &TaskExecutor,
+    engine_handle: ConsensusEngineHandle<T>,
+    block_provider: P,
+) -> JoinHandle<()> {
+    let executor = task_executor.clone();
+    task_executor.spawn_critical_with_graceful_shutdown_signal(
+        "consensus node worker",
+        move |shutdown| async move {
+            if let Err(err) =
+                new_block_fetcher(engine_handle, block_provider, shutdown.ignore_guard()).await
+            {
+                error!(target: "engine::local", %err, "Consensus follower failed; shutting down node");
+                if let Err(err) = executor.initiate_graceful_shutdown() {
+                    error!(target: "engine::local", %err, "Failed to request node shutdown");
+                }
+            }
+        },
+    )
+}
+
 async fn new_block_fetcher<
-    P: BlockProvider + Clone,
+    P: BlockProvider,
     T: PayloadTypes<BuiltPayload: BuiltPayload<Primitives: NodePrimitives<Block = P::Block>>>,
 >(
     engine_handle: ConsensusEngineHandle<T>,
     block_provider: P,
-) {
-    let mut block_stream = {
-        let (tx, rx) = mpsc::channel::<P::Block>(64);
-        let block_provider = block_provider.clone();
-        tokio::spawn(async move {
-            block_provider.subscribe_blocks(tx).await;
-        });
-        rx
-    };
+    shutdown: impl Future<Output = ()>,
+) -> eyre::Result<()> {
+    let (tx, mut block_stream) = mpsc::channel::<P::Block>(64);
+    // Poll the subscription in this critical worker so a panic cannot be swallowed by a
+    // detached task. Dropping the worker also cancels the subscription.
+    let subscription = block_provider.subscribe_blocks(tx);
+    tokio::pin!(subscription, shutdown);
 
-    while let Some(block) = block_stream.recv().await {
-        let payload = T::block_to_payload(SealedBlock::new_unhashed(block));
-        let block_hash = payload.block_hash();
-        // Send new events to execution client
-        let _ = engine_handle.new_payload(payload).await;
-        let state = ForkchoiceState::same_hash(block_hash);
-        let _ = engine_handle.fork_choice_updated(state, None).await;
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = &mut shutdown => {
+                info!(target: "engine::local", "Shutting down consensus node worker");
+                return Ok(());
+            }
+            _ = &mut subscription => {
+                eyre::bail!("Consensus block subscription ended unexpectedly");
+            }
+            block = block_stream.recv() => {
+                let block = block.ok_or_eyre("Consensus block stream closed unexpectedly")?;
+                let payload = T::block_to_payload(SealedBlock::new_unhashed(block));
+                let block_hash = payload.block_hash();
+                // Once processing starts, finish the payload/FCU pair before observing shutdown.
+                // SYNCING/ACCEPTED are allowed: the engine may need to fetch missing ancestors.
+                let status = engine_handle
+                    .new_payload(payload)
+                    .await
+                    .wrap_err("Failed to submit consensus payload")?;
+                if status.is_invalid() {
+                    eyre::bail!("Invalid consensus payload {block_hash}: {status:?}");
+                }
+                let state = ForkchoiceState::same_hash(block_hash);
+                let result = engine_handle
+                    .fork_choice_updated(state, None)
+                    .await
+                    .wrap_err("Failed to update consensus fork choice")?;
+                if result.is_invalid() {
+                    eyre::bail!("Invalid consensus fork choice {block_hash}: {result:?}");
+                }
+            }
+        }
     }
 }

--- a/crates/node/src/launcher/tests.rs
+++ b/crates/node/src/launcher/tests.rs
@@ -1,0 +1,298 @@
+use super::*;
+use alloy_network::AnyRpcBlock;
+use alloy_rpc_types_engine::{PayloadStatus, PayloadStatusEnum};
+use jsonrpsee::{server::ServerBuilder, RpcModule};
+use reth_engine_primitives::{BeaconEngineMessage, OnForkChoiceUpdated};
+use reth_ethereum_engine_primitives::EthEngineTypes;
+use reth_ethereum_primitives::Block;
+use reth_tasks::shutdown;
+use serde_json::json;
+use std::{
+    future::pending,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
+use tokio::time::timeout;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy)]
+enum Subscription {
+    Pending,
+    End,
+    CloseChannel,
+    Panic,
+    Block,
+}
+
+struct MockProvider {
+    subscription: Subscription,
+    dropped: Arc<AtomicBool>,
+}
+
+struct DropGuard(Arc<AtomicBool>);
+
+impl Drop for DropGuard {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+impl MockProvider {
+    fn new(subscription: Subscription) -> Self {
+        Self {
+            subscription,
+            dropped: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+impl BlockProvider for MockProvider {
+    type Block = Block;
+
+    async fn subscribe_blocks(&self, tx: mpsc::Sender<Block>) {
+        let _guard = DropGuard(self.dropped.clone());
+        match self.subscription {
+            Subscription::End => return,
+            Subscription::CloseChannel => drop(tx),
+            Subscription::Panic => panic!("mock subscription panic"),
+            Subscription::Block => {
+                tx.send(Block::default()).await.unwrap();
+                pending::<()>().await;
+            }
+            Subscription::Pending => {
+                pending::<()>().await;
+            }
+        }
+        pending::<()>().await;
+    }
+
+    async fn get_block(&self, _: u64) -> eyre::Result<Block> {
+        eyre::bail!("not used by the follower")
+    }
+}
+
+fn engine() -> (
+    ConsensusEngineHandle<EthEngineTypes>,
+    mpsc::UnboundedReceiver<BeaconEngineMessage<EthEngineTypes>>,
+) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (ConsensusEngineHandle::new(tx), rx)
+}
+
+#[tokio::test]
+async fn unknown_rpc_transaction_returns_error_and_next_block_is_decodable() {
+    let mut block = serde_json::to_value(<alloy_rpc_types_eth::Block>::default()).unwrap();
+    block["transactions"] = json!([{
+        "type": "0x7e",
+        "hash": B256::ZERO,
+        "from": alloy_primitives::Address::ZERO,
+        "gas": "0x5208",
+        "nonce": "0x0",
+        "value": "0x0",
+        "input": "0x"
+    }]);
+    // This shape passed the old AnyNetwork decoder, then panicked in the conversion callback.
+    assert!(serde_json::from_value::<AnyRpcBlock>(block.clone()).is_ok());
+
+    let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", server.local_addr().unwrap());
+    let mut module = RpcModule::new(block);
+    module
+        .register_method("eth_getBlockByNumber", |params, bad_block, _| {
+            let (number, full): (String, bool) = params.parse().unwrap();
+            assert!(full);
+            if number == "0x1" {
+                bad_block.clone()
+            } else {
+                serde_json::to_value(<alloy_rpc_types_eth::Block>::default()).unwrap()
+            }
+        })
+        .unwrap();
+    let server = server.start(module);
+    let provider = RpcBlockProvider::<Ethereum, _>::new(&url, |block| -> Block {
+        block.into_consensus().convert_transactions()
+    })
+    .await
+    .unwrap();
+
+    let result = timeout(TIMEOUT, provider.get_block(1)).await.unwrap();
+    assert!(
+        result.is_err(),
+        "unknown transaction type must be a provider error"
+    );
+    assert!(timeout(TIMEOUT, provider.get_block(2))
+        .await
+        .unwrap()
+        .is_ok());
+    server.stop().unwrap();
+    server.stopped().await;
+}
+
+#[tokio::test]
+async fn subscription_end_or_closed_channel_requests_node_shutdown() {
+    for subscription in [Subscription::End, Subscription::CloseChannel] {
+        let executor = TaskExecutor::test();
+        let manager = executor.take_task_manager_handle().unwrap();
+        let (engine, _rx) = engine();
+        let provider = MockProvider::new(subscription);
+        let dropped = provider.dropped.clone();
+        let worker = spawn_consensus_follower(&executor, engine, provider);
+
+        timeout(TIMEOUT, executor.on_shutdown_signal().clone())
+            .await
+            .unwrap();
+        worker.await.unwrap();
+        assert!(manager.await.unwrap().is_ok());
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+}
+
+#[tokio::test]
+async fn subscription_panic_reaches_critical_task_manager() {
+    let executor = TaskExecutor::test();
+    let manager = executor.take_task_manager_handle().unwrap();
+    let (engine, _rx) = engine();
+    let worker =
+        spawn_consensus_follower(&executor, engine, MockProvider::new(Subscription::Panic));
+
+    let error = timeout(TIMEOUT, manager)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(error.to_string().contains("consensus node worker"));
+    worker.await.unwrap();
+}
+
+#[tokio::test]
+async fn unavailable_engine_returns_error() {
+    let (engine, rx) = engine();
+    drop(rx);
+    let error = timeout(
+        TIMEOUT,
+        new_block_fetcher(engine, MockProvider::new(Subscription::Block), pending()),
+    )
+    .await
+    .unwrap()
+    .unwrap_err();
+    assert!(error
+        .to_string()
+        .contains("Failed to submit consensus payload"));
+}
+
+#[tokio::test]
+async fn invalid_payload_never_advances_fork_choice() {
+    let (engine, mut rx) = engine();
+    let worker = tokio::spawn(new_block_fetcher(
+        engine,
+        MockProvider::new(Subscription::Block),
+        pending(),
+    ));
+    let BeaconEngineMessage::NewPayload { tx, .. } = rx.recv().await.unwrap() else {
+        panic!("expected new payload");
+    };
+    tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Invalid {
+        validation_error: "invalid test block".into(),
+    })))
+    .unwrap();
+
+    let error = timeout(TIMEOUT, worker)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap_err();
+    assert!(error.to_string().contains("Invalid consensus payload"));
+    assert!(
+        rx.recv().await.is_none(),
+        "invalid payload must not be followed by FCU"
+    );
+}
+
+#[tokio::test]
+async fn fork_choice_errors_are_propagated() {
+    for invalid_status in [false, true] {
+        let (engine, mut rx) = engine();
+        let worker = tokio::spawn(new_block_fetcher(
+            engine,
+            MockProvider::new(Subscription::Block),
+            pending(),
+        ));
+        let BeaconEngineMessage::NewPayload { tx, .. } = rx.recv().await.unwrap() else {
+            panic!("expected new payload");
+        };
+        tx.send(Ok(PayloadStatus::from_status(PayloadStatusEnum::Valid)))
+            .unwrap();
+        let BeaconEngineMessage::ForkchoiceUpdated { tx, .. } = rx.recv().await.unwrap() else {
+            panic!("expected fork choice update");
+        };
+        if invalid_status {
+            tx.send(Ok(OnForkChoiceUpdated::with_invalid(
+                PayloadStatus::from_status(PayloadStatusEnum::Invalid {
+                    validation_error: "invalid test fork".into(),
+                }),
+            )))
+            .unwrap();
+        } else {
+            drop(tx);
+        }
+        let error = timeout(TIMEOUT, worker)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap_err();
+        let expected = if invalid_status {
+            "Invalid consensus fork choice"
+        } else {
+            "Failed to update consensus fork choice"
+        };
+        assert!(error.to_string().contains(expected), "{error:?}");
+    }
+}
+
+#[tokio::test]
+async fn shutdown_finishes_in_flight_payload_and_allows_syncing() {
+    for status in [
+        PayloadStatusEnum::Valid,
+        PayloadStatusEnum::Syncing,
+        PayloadStatusEnum::Accepted,
+    ] {
+        let (engine, mut rx) = engine();
+        let (signal, shutdown) = shutdown::signal();
+        let provider = MockProvider::new(Subscription::Block);
+        let dropped = provider.dropped.clone();
+        let worker = tokio::spawn(new_block_fetcher(engine, provider, shutdown));
+
+        let BeaconEngineMessage::NewPayload { payload, tx } = rx.recv().await.unwrap() else {
+            panic!("expected new payload");
+        };
+        signal.fire();
+        assert!(!worker.is_finished());
+        tx.send(Ok(PayloadStatus::from_status(status))).unwrap();
+        let BeaconEngineMessage::ForkchoiceUpdated { state, tx, .. } = rx.recv().await.unwrap()
+        else {
+            panic!("expected fork choice update even after shutdown");
+        };
+        assert_eq!(state, ForkchoiceState::same_hash(payload.block_hash()));
+        tx.send(Ok(OnForkChoiceUpdated::syncing())).unwrap();
+
+        timeout(TIMEOUT, worker).await.unwrap().unwrap().unwrap();
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+}
+
+#[tokio::test]
+async fn normal_shutdown_is_successful() {
+    let executor = TaskExecutor::test();
+    let manager = executor.take_task_manager_handle().unwrap();
+    let (engine, _rx) = engine();
+    let worker =
+        spawn_consensus_follower(&executor, engine, MockProvider::new(Subscription::Pending));
+    let shutdown = executor.initiate_graceful_shutdown().unwrap();
+
+    drop(timeout(TIMEOUT, shutdown).await.unwrap());
+    worker.await.unwrap();
+    assert!(manager.await.unwrap().is_ok());
+}


### PR DESCRIPTION
An RPC block containing an unsupported transaction type could panic a detached subscription task. The outer critical worker then returned normally, leaving the node running without further block ingestion.

This change decodes blocks directly as Ethereum RPC responses so malformed or unsupported blocks return provider errors and the subscription continues. It polls the subscription inside the critical worker, reports unexpected stream termination, and requests graceful node shutdown on follower or engine failures. Invalid payloads never advance fork choice; `SYNCING`/`ACCEPTED` responses remain supported. Shutdown waits for an in-flight payload/fork-choice pair to finish.

Implementation and regression coverage are separate, GPG-signed Conventional Commits. Changes are limited to the node launcher, its tests, and an existing JSON-RPC dependency enabled for tests; no dependency versions or runtime/genesis artifacts change.

Validation (Cargo checks run with `RUSTC_WRAPPER=`):

- `cargo fmt --check --package fluentbase-node`
- `cargo check -p fluentbase-node --locked`
- `cargo test -p fluentbase-node --lib --locked` — 10 passed, including 8 new regressions covering unsupported RPC transactions, subscription termination/panic, engine failures, invalid payload/FCU status, and graceful shutdown.
- `cargo check -p fluent --locked`
- `cargo clippy -p fluentbase-node --all-targets --locked -- -D warnings`
- `git diff --check`

Full workspace, contracts, examples, and EVM fixture suites are left to CI; the behavioral change is in the node follower.

Fixes [FLU-1308](https://linear.app/fluentlabs-xyz/issue/FLU-1308). Related: FLU-1061. @dmitry123
