### PR TITLE
fix(runtime): bound system runtime envelope decoding

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -659,17 +659,21 @@ pub(crate) fn process_runtime_execution_outcome<CTX: ContextTr>(
         return Ok(());
     }
 
-    // Try to decode output params (in some cases it's not possible because output might be corrupted,
-    // so instead of print warning into output and return Ok w/o state commitment, there is nothing we can
-    // do here, it's a trap)
+    // Decode the entire envelope before applying any effects. Invalid lengths are rejected
+    // against the encoded body before allocation and must halt the frame deterministically.
     let Ok((runtime_output, _)): Result<(RuntimeExecutionOutcomeV1, usize), _> =
         bincode::decode_from_bytes(return_data.clone(), bincode::config::legacy())
     else {
-        #[cfg(feature = "std")]
-        eprintln!(
-            "WARN: failed to decode structured runtime execution outcome: exit_code={}",
-            exit_code
+        warn!(
+            ?exit_code,
+            "revm: failed to decode structured runtime execution outcome, halting frame"
         );
+        // A runtime trap (for example out of fuel) may leave no envelope. Preserve its
+        // existing failure reason; only a successful runtime exit needs to become a halt.
+        if exit_code.is_ok() {
+            *exit_code = ExitCode::MalformedBuiltinParams;
+        }
+        *return_data = Bytes::new();
         return Ok(());
     };
 

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -1213,4 +1213,97 @@ mod resume_boundary_tests {
 
         assert_eq!(exit_code, ExitCode::UnknownError);
     }
+
+    #[test]
+    fn malformed_runtime_outcome_halts_before_applying_effects() {
+        use fluentbase_sdk::system::JournalLog;
+
+        let mut ctx = new_context();
+        let target = Address::repeat_byte(0x22);
+        let mut gas = Gas::new(100_000);
+        let mut exit_code = ExitCode::Ok;
+        let outcome = RuntimeExecutionOutcomeV1 {
+            output: bytes!("112233"),
+            storage: Some([(U256::from(1), U256::from(2))].into()),
+            logs: vec![JournalLog {
+                topics: vec![B256::repeat_byte(3)],
+                data: bytes!("445566"),
+            }],
+            new_metadata: Some(bytes!("778899")),
+            touched_storage_slots: Some(vec![U256::from(1)]),
+            ..Default::default()
+        };
+        let mut encoded = outcome.encode();
+        let transfers_offset = encoded.len() - 4;
+        encoded[transfers_offset..].copy_from_slice(&u32::MAX.to_le_bytes());
+        let mut return_data: Bytes = encoded.into();
+
+        process_runtime_execution_outcome(
+            &target,
+            &mut ctx,
+            &mut gas,
+            &mut return_data,
+            &mut exit_code,
+            None,
+            Some(&[(U256::from(9), 2_100)]),
+        )
+        .unwrap();
+
+        assert_eq!(exit_code, ExitCode::MalformedBuiltinParams);
+        assert!(return_data.is_empty());
+        assert!(ctx.journaled_state.inner.state.is_empty());
+        assert!(ctx.journaled_state.inner.logs.is_empty());
+        assert_eq!(gas.remaining(), 100_000);
+    }
+
+    #[test]
+    fn overflowing_runtime_log_count_halts_without_panicking() {
+        let mut ctx = new_context();
+        let mut frame = RwasmFrame::default();
+        frame.interpreter.gas = Gas::new(100_000);
+        frame.interpreter.input.target_address = PRECOMPILE_EVM_RUNTIME;
+        let mut encoded = RuntimeExecutionOutcomeV1::default().encode();
+        encoded[16..24].copy_from_slice(&u64::MAX.to_le_bytes());
+
+        let next_action = process_exec_result::<_, NoOpInspector>(
+            &mut frame,
+            &mut ctx,
+            None,
+            ExitCode::Ok.into_i32(),
+            encoded.into(),
+            None,
+        )
+        .unwrap();
+
+        let NextAction::Return(result) = next_action else {
+            panic!("expected a returned halt");
+        };
+        assert_eq!(result.result, InstructionResult::MalformedBuiltinParams);
+        assert!(result.output.is_empty());
+    }
+
+    #[test]
+    fn malformed_runtime_outcome_preserves_existing_failure_reason() {
+        for original_exit in [ExitCode::OutOfFuel, ExitCode::Panic, ExitCode::UnknownError] {
+            let mut ctx = new_context();
+            let mut gas = Gas::new(100_000);
+            let mut exit_code = original_exit;
+            let mut return_data = bytes!("deadbeef");
+
+            process_runtime_execution_outcome(
+                &Address::ZERO,
+                &mut ctx,
+                &mut gas,
+                &mut return_data,
+                &mut exit_code,
+                None,
+                None,
+            )
+            .unwrap();
+
+            assert_eq!(exit_code, original_exit);
+            assert!(return_data.is_empty());
+            assert_eq!(gas.remaining(), 100_000);
+        }
+    }
 }

--- a/crates/types/src/bincode.rs
+++ b/crates/types/src/bincode.rs
@@ -5,6 +5,7 @@ pub use ::bincode::{
     error::DecodeError,
     *,
 };
+use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -57,6 +58,46 @@ impl BytesReader {
     pub fn new(bytes: Bytes) -> Self {
         Self { bytes }
     }
+
+    /// Check the encoded body before allocating or iterating over a declared collection.
+    pub(crate) fn ensure_collection_body(
+        &self,
+        len: usize,
+        min_element_bytes: usize,
+    ) -> Result<(), DecodeError> {
+        let required = len
+            .checked_mul(min_element_bytes)
+            .ok_or(DecodeError::LimitExceeded)?;
+        if required > self.bytes.len() {
+            return Err(DecodeError::UnexpectedEnd {
+                additional: required - self.bytes.len(),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Decode a collection whose element count is bounded by the remaining encoded body.
+/// This also honors a caller's bincode limit, but does not require one for allocation safety.
+pub(crate) fn decode_vec<D: Decoder<R = BytesReader>, T>(
+    decoder: &mut D,
+    len: usize,
+    min_element_bytes: usize,
+    mut decode_item: impl FnMut(&mut D) -> Result<T, DecodeError>,
+) -> Result<Vec<T>, DecodeError> {
+    decoder
+        .reader()
+        .ensure_collection_body(len, min_element_bytes)?;
+    decoder.claim_container_read::<T>(len)?;
+    let mut values = Vec::new();
+    values
+        .try_reserve_exact(len)
+        .map_err(|_| DecodeError::Other("failed to reserve decoded collection"))?;
+    for _ in 0..len {
+        decoder.unclaim_bytes_read(core::mem::size_of::<T>());
+        values.push(decode_item(decoder)?);
+    }
+    Ok(values)
 }
 
 /// Extension methods for a Reader that is backed by `Bytes`.

--- a/crates/types/src/system/journal_storage.rs
+++ b/crates/types/src/system/journal_storage.rs
@@ -215,6 +215,33 @@ mod tests {
     use super::*;
 
     #[test]
+    fn generic_log_decode_rejects_unbacked_lengths() {
+        for (topics, data_len) in [(u32::MAX, 0u64), (0, u64::MAX)] {
+            let mut encoded = topics.to_le_bytes().to_vec();
+            encoded.extend_from_slice(&data_len.to_le_bytes());
+            assert!(bincode::decode_from_slice::<JournalLog, _>(
+                &encoded,
+                bincode::config::legacy()
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn generic_log_decode_preserves_data_across_chunks() {
+        let log = JournalLog {
+            topics: vec![B256::repeat_byte(1), B256::repeat_byte(2)],
+            data: vec![3; 2050].into(),
+        };
+        let config = bincode::config::legacy().with_limit::<4096>();
+        let encoded = bincode::encode_to_vec(&log, config).unwrap();
+        let (decoded, consumed) =
+            bincode::decode_from_slice::<JournalLog, _>(&encoded, config).unwrap();
+        assert_eq!(decoded, log);
+        assert_eq!(consumed, encoded.len());
+    }
+
+    #[test]
     fn storage_reads_base_and_dirty() {
         let mut base = BTreeMap::new();
         base.insert(U256::from(1u64), U256::from(10u64));

--- a/crates/types/src/system/journal_storage.rs
+++ b/crates/types/src/system/journal_storage.rs
@@ -1,10 +1,13 @@
-use crate::{Bytes, B256, U256};
+use crate::{
+    bincode::{decode_vec, BytesReader, DecodeBytes, ZeroCopyBytes},
+    Bytes, B256, U256,
+};
 use alloc::{
     collections::{BTreeMap, BTreeSet},
     vec::Vec,
 };
 use bincode::{
-    de::Decoder,
+    de::{read::Reader, Decoder},
     enc::Encoder,
     error::{DecodeError, EncodeError},
 };
@@ -39,13 +42,49 @@ impl bincode::Encode for JournalLog {
 impl<C> bincode::Decode<C> for JournalLog {
     fn decode<D: Decoder<Context = C>>(d: &mut D) -> Result<Self, DecodeError> {
         let topics_len: u32 = bincode::Decode::decode(d)?;
-        let mut topics = Vec::with_capacity(topics_len as usize);
+        d.claim_container_read::<B256>(topics_len as usize)?;
+        // Generic readers need not support lookahead. Grow only after reading each topic,
+        // so even an unlimited decoder cannot reserve memory from a forged length alone.
+        let mut topics = Vec::new();
         for _ in 0..topics_len {
+            d.unclaim_bytes_read(core::mem::size_of::<B256>());
             let topic: [u8; 32] = bincode::Decode::decode(d)?;
+            topics
+                .try_reserve(1)
+                .map_err(|_| DecodeError::Other("failed to reserve log topics"))?;
             topics.push(B256::new(topic));
         }
-        let data: Vec<u8> = bincode::Decode::decode(d)?;
+        let data_len: u64 = bincode::Decode::decode(d)?;
+        let data_len =
+            usize::try_from(data_len).map_err(|_| DecodeError::OutsideUsizeRange(data_len))?;
+        d.claim_container_read::<u8>(data_len)?;
+        let mut data = Vec::new();
+        let mut buffer = [0u8; 1024];
+        while data.len() < data_len {
+            let len = (data_len - data.len()).min(buffer.len());
+            d.reader().read(&mut buffer[..len])?;
+            data.try_reserve(len)
+                .map_err(|_| DecodeError::Other("failed to reserve log data"))?;
+            data.extend_from_slice(&buffer[..len]);
+        }
         Ok(JournalLog {
+            topics,
+            data: data.into(),
+        })
+    }
+}
+
+impl<C> DecodeBytes<C> for JournalLog {
+    fn decode_bytes<D: Decoder<Context = C, R = BytesReader>>(
+        d: &mut D,
+    ) -> Result<Self, DecodeError> {
+        let topics_len: u32 = bincode::Decode::decode(d)?;
+        let topics = decode_vec(d, topics_len as usize, 32, |d| {
+            let topic: [u8; 32] = bincode::Decode::decode(d)?;
+            Ok(B256::new(topic))
+        })?;
+        let data: ZeroCopyBytes = DecodeBytes::decode_bytes(d)?;
+        Ok(Self {
             topics,
             data: data.into(),
         })

--- a/crates/types/src/system/new_frame_input.rs
+++ b/crates/types/src/system/new_frame_input.rs
@@ -252,6 +252,154 @@ mod tests {
     }
 
     #[test]
+    fn runtime_outcome_rejects_overflowing_log_count() {
+        let mut encoded = RuntimeExecutionOutcomeV1::default().encode();
+        // exit code (4), output length (8), storage count (4), then log count (8).
+        encoded[16..24].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert!(decode::<RuntimeExecutionOutcomeV1>(encoded.into()).is_err());
+    }
+
+    #[test]
+    fn runtime_outcome_rejects_lengths_without_bodies() {
+        let empty = RuntimeExecutionOutcomeV1::default().encode();
+        // All these prefixes fit in a few bytes. None may allocate based on the count.
+        for len in [1_000_000, u32::MAX as u64, u64::MAX] {
+            for (name, offset) in [("output", 4), ("logs", 16)] {
+                let mut encoded = empty[..offset].to_vec();
+                encoded.extend_from_slice(&len.to_le_bytes());
+                assert!(
+                    decode::<RuntimeExecutionOutcomeV1>(encoded.into()).is_err(),
+                    "{name}: {len}"
+                );
+            }
+        }
+        for (name, offset) in [("storage", 12), ("touched slots", 25), ("transfers", 29)] {
+            let mut encoded = empty[..offset].to_vec();
+            encoded.extend_from_slice(&u32::MAX.to_le_bytes());
+            assert!(
+                decode::<RuntimeExecutionOutcomeV1>(encoded.into()).is_err(),
+                "{name}"
+            );
+        }
+
+        let mut encoded = empty[..24].to_vec();
+        encoded.push(1); // Some(new_metadata)
+        encoded.extend_from_slice(&u64::MAX.to_le_bytes());
+        assert!(decode::<RuntimeExecutionOutcomeV1>(encoded.into()).is_err());
+
+        for (topics, data_len) in [(u32::MAX, 0u64), (0, u64::MAX)] {
+            let mut encoded = empty[..16].to_vec();
+            encoded.extend_from_slice(&1u64.to_le_bytes()); // One log.
+            encoded.extend_from_slice(&topics.to_le_bytes());
+            encoded.extend_from_slice(&data_len.to_le_bytes());
+            assert!(decode::<RuntimeExecutionOutcomeV1>(encoded.into()).is_err());
+        }
+    }
+
+    #[test]
+    fn runtime_new_frame_rejects_storage_without_body() {
+        let mut encoded = encode(&RuntimeNewFrameInputV1::default()).unwrap();
+        encoded[24..28].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(decode::<RuntimeNewFrameInputV1>(encoded.into()).is_err());
+    }
+
+    #[test]
+    fn runtime_outcome_preserves_legacy_trailing_fields() {
+        let empty = RuntimeExecutionOutcomeV1::default();
+        let encoded = empty.encode();
+        // Before touched slots, before transfers, and the current format.
+        for len in [25, 29, 33] {
+            let (decoded, consumed) =
+                decode::<RuntimeExecutionOutcomeV1>(encoded[..len].to_vec().into()).unwrap();
+            assert_eq!(decoded, empty);
+            assert_eq!(consumed, len);
+        }
+        for len in [26, 27, 28, 30, 31, 32] {
+            assert!(decode::<RuntimeExecutionOutcomeV1>(encoded[..len].to_vec().into()).is_err());
+        }
+    }
+
+    #[test]
+    fn runtime_outcome_checks_truncated_collection_elements() {
+        let outcome = RuntimeExecutionOutcomeV1 {
+            output: bytes!("1122"),
+            storage: Some([(U256::from(1), U256::from(2))].into()),
+            logs: vec![JournalLog {
+                topics: vec![B256::repeat_byte(3)],
+                data: bytes!("445566"),
+            }],
+            new_metadata: Some(bytes!("7788")),
+            touched_storage_slots: Some(vec![U256::from(1)]),
+            transfers: Some(vec![(Address::repeat_byte(4), U256::from(5))]),
+            ..Default::default()
+        };
+        let encoded = outcome.encode();
+        // Only complete legacy envelopes ending just before an optional field are valid.
+        let before_transfers = encoded.len() - 4 - 52;
+        let before_touched = before_transfers - 4 - 32;
+        for len in 0..encoded.len() {
+            let result = decode::<RuntimeExecutionOutcomeV1>(encoded[..len].to_vec().into());
+            assert_eq!(
+                result.is_ok(),
+                len == before_touched || len == before_transfers,
+                "truncated at {len}"
+            );
+        }
+        assert_eq!(
+            RuntimeExecutionOutcomeV1::decode(encoded.into()),
+            Some(outcome)
+        );
+    }
+
+    #[test]
+    fn runtime_outcome_log_data_remains_zero_copy() {
+        let outcome = RuntimeExecutionOutcomeV1 {
+            logs: vec![JournalLog {
+                topics: vec![B256::repeat_byte(3)],
+                data: bytes!("445566"),
+            }],
+            ..Default::default()
+        };
+        let encoded: Bytes = outcome.encode().into();
+        let (decoded, consumed) = decode::<RuntimeExecutionOutcomeV1>(encoded.clone()).unwrap();
+        assert_eq!(decoded, outcome);
+        assert_eq!(consumed, encoded.len());
+        let data_start = 4 + 8 + 4 + 8 + 4 + 32 + 8;
+        assert_eq!(
+            decoded.logs[0].data.as_ptr(),
+            encoded[data_start..].as_ptr()
+        );
+    }
+
+    #[test]
+    fn runtime_outcome_supports_variable_integer_encoding_and_limits() {
+        let outcome = RuntimeExecutionOutcomeV1 {
+            logs: vec![JournalLog::default(); 10],
+            touched_storage_slots: Some(vec![U256::from(1)]),
+            transfers: Some(vec![(Address::ZERO, U256::from(2))]),
+            ..Default::default()
+        };
+        let config = bincode::config::standard();
+        let encoded: Bytes = bincode::encode_to_vec(&outcome, config).unwrap().into();
+        let (decoded, consumed) =
+            decode_from_bytes::<RuntimeExecutionOutcomeV1, _>(encoded.clone(), config).unwrap();
+        assert_eq!(decoded, outcome);
+        assert_eq!(consumed, encoded.len());
+        assert!(decode_from_bytes::<RuntimeExecutionOutcomeV1, _>(
+            encoded.clone(),
+            config.with_limit::<64>()
+        )
+        .is_err());
+        let (decoded, consumed) = decode_from_bytes::<RuntimeExecutionOutcomeV1, _>(
+            encoded.clone(),
+            config.with_limit::<1024>(),
+        )
+        .unwrap();
+        assert_eq!(decoded, outcome);
+        assert_eq!(consumed, encoded.len());
+    }
+
+    #[test]
     fn test_runtime_new_frame_input_v1_encode_decode() {
         let mut storage = BTreeMap::new();
         let mut v = RuntimeNewFrameInputV1 {

--- a/crates/types/src/system/new_frame_input.rs
+++ b/crates/types/src/system/new_frame_input.rs
@@ -1,11 +1,15 @@
 use crate::{
-    bincode::{decode_from_bytes, BytesReader, DecodeBytes, ZeroCopyBytes},
+    bincode::{decode_from_bytes, decode_vec, BytesReader, DecodeBytes, ZeroCopyBytes},
     system::JournalLog,
     ExitCode,
 };
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloy_primitives::{Address, Bytes, U256};
-use bincode::de::{read::Reader, Decoder};
+use bincode::{
+    config::{Config, IntEncoding},
+    de::{read::Reader, Decoder},
+    error::DecodeError,
+};
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct RuntimeNewFrameInputV1 {
@@ -48,6 +52,8 @@ impl<Context> DecodeBytes<Context> for RuntimeNewFrameInputV1 {
         let input: ZeroCopyBytes = DecodeBytes::<Context>::decode_bytes(d)?;
         let context: ZeroCopyBytes = DecodeBytes::<Context>::decode_bytes(d)?;
         let storage_len: u32 = bincode::Decode::decode(d)?;
+        d.reader()
+            .ensure_collection_body(storage_len as usize, 64)?;
         let storage = if storage_len > 0 {
             let mut storage = BTreeMap::<U256, U256>::new();
             for _ in 0..storage_len {
@@ -149,6 +155,8 @@ impl<Context> DecodeBytes<Context> for RuntimeExecutionOutcomeV1 {
         let exit_code: i32 = bincode::Decode::decode(d)?;
         let output: ZeroCopyBytes = DecodeBytes::decode_bytes(d)?;
         let storage_len: u32 = bincode::Decode::decode(d)?;
+        d.reader()
+            .ensure_collection_body(storage_len as usize, 64)?;
         let storage = if storage_len > 0 {
             let mut storage = BTreeMap::<U256, U256>::new();
             for _ in 0..storage_len {
@@ -160,18 +168,25 @@ impl<Context> DecodeBytes<Context> for RuntimeExecutionOutcomeV1 {
         } else {
             None
         };
-        let logs: Vec<JournalLog> = bincode::Decode::decode(d)?;
+        let logs_len: u64 = bincode::Decode::decode(d)?;
+        let logs_len =
+            usize::try_from(logs_len).map_err(|_| DecodeError::OutsideUsizeRange(logs_len))?;
+        // Even an empty log encodes a u32 topic count and a u64 data length.
+        let min_log_bytes = match d.config().int_encoding() {
+            IntEncoding::Fixed => 12,
+            _ => 2,
+        };
+        let logs = decode_vec(d, logs_len, min_log_bytes, JournalLog::decode_bytes)?;
         let new_metadata: Option<ZeroCopyBytes> = DecodeBytes::decode_bytes(d)?;
 
         // Backward compatibility: older outcomes do not have this trailing field.
         let touched_storage_slots = if d.reader().peek_read(1).is_some() {
             let touched_slots_len: u32 = bincode::Decode::decode(d)?;
             if touched_slots_len > 0 {
-                let mut touched_storage_slots = Vec::with_capacity(touched_slots_len as usize);
-                for _ in 0..touched_slots_len {
+                let touched_storage_slots = decode_vec(d, touched_slots_len as usize, 32, |d| {
                     let slot: [u8; 32] = bincode::Decode::decode(d)?;
-                    touched_storage_slots.push(U256::from_le_bytes(slot));
-                }
+                    Ok(U256::from_le_bytes(slot))
+                })?;
                 Some(touched_storage_slots)
             } else {
                 None
@@ -184,12 +199,11 @@ impl<Context> DecodeBytes<Context> for RuntimeExecutionOutcomeV1 {
         let transfers = if d.reader().peek_read(1).is_some() {
             let transfers_len: u32 = bincode::Decode::decode(d)?;
             if transfers_len > 0 {
-                let mut transfers = Vec::with_capacity(transfers_len as usize);
-                for _ in 0..transfers_len {
+                let transfers = decode_vec(d, transfers_len as usize, 52, |d| {
                     let recipient: [u8; 20] = bincode::Decode::decode(d)?;
                     let amount: [u8; 32] = bincode::Decode::decode(d)?;
-                    transfers.push((Address::from(recipient), U256::from_le_bytes(amount)));
-                }
+                    Ok((Address::from(recipient), U256::from_le_bytes(amount)))
+                })?;
                 Some(transfers)
             } else {
                 None

--- a/docs/07-rwasm-integration.md
+++ b/docs/07-rwasm-integration.md
@@ -46,6 +46,18 @@ Fluentbase runtime executor owns:
 
 This is the concrete runtime-host handshake point used in every interruption cycle.
 
+Structured system-runtime outcomes are decoded completely before the host applies their effects.
+Collection counts must fit the remaining encoded body before reservation or iteration; byte payloads
+use checked zero-copy slices. These input-derived bounds also apply with bincode's legacy configuration,
+so safety does not depend on a fixed envelope-size cap. Generic log readers without lookahead grow
+their buffers only after reading the corresponding data. Existing envelope encodings, including
+outcomes without the optional trailing touched-slot or transfer fields, remain supported.
+
+An invalid envelope after a successful runtime exit halts the frame with `MalformedBuiltinParams`
+and clears the raw envelope from return data. If execution already failed (for example, out of fuel),
+the host preserves that failure reason. No buffered effects or preload refunds are applied on decode
+failure; the existing frame rollback path handles any earlier execution effects.
+
 ---
 
 ## Why version bumps are risky


### PR DESCRIPTION
A malformed system-runtime outcome could declare `u64::MAX` logs and panic the host with `capacity overflow`. Other collection lengths could reserve memory before their bodies were present, and decode failures could leave a successful frame status unchanged.

This bounds storage, logs, topics, touched slots, and transfers by the remaining encoded bytes before allocation or iteration. Log data uses checked zero-copy slices; generic log readers grow buffers only after reading data. Invalid envelopes halt otherwise-successful frames with `MalformedBuiltinParams`, clear raw return data, and apply no buffered effects or preload refunds. Existing runtime failure codes and legacy envelopes without trailing fields remain supported.

The allocation bound is derived from the actual input, rather than an arbitrary fixed envelope-size limit. It works with the existing legacy bincode configuration and still honors explicitly limited configurations. Valid wire encodings are unchanged. No generated contract or genesis artifacts are included.

Refs [FLU-1307](https://linear.app/fluentlabs-xyz/issue/FLU-1307). @dmitry123

Separate GPG-signed Conventional Commits:
- `fix(runtime): bound system runtime envelope decoding`
- `test(runtime): cover malformed system runtime envelopes`

Validation:
- Reproduced the original `capacity overflow` with the new regression before applying the fix.
- `RUSTC_WRAPPER= cargo test -p fluentbase-types -p fluentbase-revm --lib --release --locked --no-default-features --features std`: 70 passed.
- Same command with `--features std,wasmtime`: 70 passed. The final host-result regression also passed separately under both configurations.
- `RUSTC_WRAPPER= cargo clippy -p fluentbase-types -p fluentbase-revm --all-targets --locked --no-default-features --features std,wasmtime -- -D warnings`: passed.
- `RUSTC_WRAPPER= cargo check -p fluentbase-types --no-default-features --locked`: passed.
- `cargo +nightly fmt --check -p fluentbase-types -p fluentbase-revm` and `git diff --check`: passed.
- `RUSTC_WRAPPER= cargo test -p fluentbase-e2e --lib --release --locked --no-default-features --features std`: 122 passed, 9 ignored.
- Same end-to-end command with `--features std,wasmtime`: 122 passed, 9 ignored.
- Full `make pr` / EVM fixture suites were not rerun locally; the PR CI matrix covers those broader checks. Remote CI is still pending, with no failures observed.

The frame-failure change applies to malformed outcomes from a buggy or upgraded trusted system runtime. It changes their prior success handling and should be included in the coordinated node upgrade. It does not change gas pricing or valid envelope formats.
