### PR TITLE
fix: harden latent host panic paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,8 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 directories = "6.0.0"
 
 # sp1
-sp1-curves = { version = "5.2.4" }
+# Re-audit off-curve syscall inputs before changing this pin; see docs/07-rwasm-integration.md.
+sp1-curves = { version = "=5.2.4" }
 generic-array = { version = "=1.1.0", default-features = false, features = ["alloc"] }
 
 num-derive = { version = "0.4" }

--- a/crates/evm/src/metadata.rs
+++ b/crates/evm/src/metadata.rs
@@ -25,10 +25,9 @@ impl EthereumMetadata {
             return None;
         }
         Some(match B256::from_slice(&metadata[0..32]) {
-            ETHEREUM_METADATA_VERSION_ANALYZED => Self::Analyzed(
-                AnalyzedBytecode::deserialize(&metadata[32..])
-                    .unwrap_or_else(|_| unreachable!("failed to deserialize analyzed bytecode")),
-            ),
+            ETHEREUM_METADATA_VERSION_ANALYZED => {
+                Self::Analyzed(AnalyzedBytecode::deserialize(&metadata[32..]).ok()?)
+            }
             hash => {
                 let bytecode = metadata.slice(32..);
                 Self::Legacy(LegacyBytecode { hash, bytecode })
@@ -75,6 +74,49 @@ impl EthereumMetadata {
         match self {
             EthereumMetadata::Legacy(bytecode) => bytecode.bytecode.clone(),
             EthereumMetadata::Analyzed(bytecode) => bytecode.bytecode.slice(0..bytecode.len()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_truncated_analyzed_metadata() {
+        let metadata = EthereumMetadata::new_analyzed(Bytes::from_static(&[0x60, 0x00, 0x5b]))
+            .write_to_bytes();
+        for len in 0..metadata.len() {
+            assert!(
+                EthereumMetadata::read_from_bytes(&metadata.slice(..len)).is_none(),
+                "accepted metadata truncated to {len} bytes"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_analyzed_metadata_with_invalid_code_length() {
+        let mut metadata = EthereumMetadata::new_analyzed(Bytes::from_static(&[0x00]))
+            .write_to_bytes()
+            .to_vec();
+        // The original code length follows the version and code hash.
+        metadata[64..72].copy_from_slice(&u64::MAX.to_le_bytes());
+        assert!(EthereumMetadata::read_from_bytes(&metadata.into()).is_none());
+    }
+
+    #[test]
+    fn valid_metadata_preserves_code_queries() {
+        for code in [Bytes::new(), Bytes::from_static(&[0x60, 0x00, 0x5b])] {
+            for metadata in [
+                EthereumMetadata::new_legacy(code.clone()),
+                EthereumMetadata::new_analyzed(code.clone()),
+            ] {
+                let decoded =
+                    EthereumMetadata::read_from_bytes(&metadata.write_to_bytes()).unwrap();
+                assert_eq!(decoded.code_size(), code.len());
+                assert_eq!(decoded.code_copy(), code);
+                assert_eq!(decoded.code_hash(), crypto_keccak256(&code));
+            }
         }
     }
 }

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -414,6 +414,7 @@ mod code_copy_tests {
 #[cfg(test)]
 mod code_hash_tests {
     use super::*;
+    use fluentbase_sdk::syscall::SYSCALL_ID_CODE_SIZE;
     use revm::handler::system_interruption::SystemInterruptionInputs;
 
     fn execute_syscall(
@@ -458,6 +459,50 @@ mod code_hash_tests {
         input[20..28].copy_from_slice(&0u64.to_le_bytes());
         input[28..36].copy_from_slice(&1u64.to_le_bytes());
         input.into()
+    }
+
+    #[test]
+    fn malformed_analyzed_metadata_uses_empty_code_fallbacks() {
+        let target = Address::from([0x43; 20]);
+        let metadata = EthereumMetadata::new_analyzed(bytes!("00"))
+            .write_to_bytes()
+            .slice(..32);
+        let account_bytecode = Bytecode::new_ownable_account(PRECOMPILE_EVM_RUNTIME, metadata);
+        let mut db = InMemoryDB::default();
+        db.insert_account_info(
+            target,
+            AccountInfo {
+                nonce: 1,
+                code_hash: account_bytecode.hash_slow(),
+                code: Some(account_bytecode),
+                ..Default::default()
+            },
+        );
+        let mut ctx = RwasmContext::new(db, RwasmSpecId::PRAGUE);
+        let mut frame = RwasmFrame::default();
+
+        for (syscall, input, expected) in [
+            (
+                SYSCALL_ID_CODE_SIZE,
+                code_hash_input(target),
+                Bytes::from(vec![0; 32]),
+            ),
+            (
+                SYSCALL_ID_CODE_HASH,
+                code_hash_input(target),
+                Bytes::copy_from_slice(revm::primitives::KECCAK_EMPTY.as_slice()),
+            ),
+            (
+                SYSCALL_ID_CODE_COPY,
+                code_copy_input(target),
+                Bytes::from(vec![0]),
+            ),
+        ] {
+            assert_eq!(
+                execute_syscall(&mut ctx, &mut frame, syscall, input),
+                expected
+            );
+        }
     }
 
     #[test]

--- a/crates/runtime/src/executor.rs
+++ b/crates/runtime/src/executor.rs
@@ -470,7 +470,7 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         metrics::set_recoverable_runtimes(self.recoverable_runtimes.len());
         let (mode, state) = runtime_labels(&runtime);
         let mut fuel_remaining = runtime.remaining_fuel();
-        let resume_inner = |runtime: &mut ExecutionMode| {
+        let mut resume_inner = |runtime: &mut ExecutionMode| {
             // Copy return data into return data
             runtime.context_mut().execution_result.return_data = return_data.to_vec();
             if fuel16_ptr > 0 {
@@ -479,17 +479,32 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
                 LittleEndian::write_i64(&mut buffer[8..], fuel_refunded);
                 runtime.memory_write(fuel16_ptr as usize, &buffer)?;
             }
-            runtime.resume(exit_code, fuel_consumed)
+            // Check the child charge before resuming, independently of backend behavior.
+            // Memory-write failures above have not charged the child and must keep the old baseline.
+            let adjusted_fuel = fuel_remaining
+                .map(|remaining| {
+                    remaining
+                        .checked_sub(fuel_consumed)
+                        .ok_or(TrapCode::OutOfFuel)
+                })
+                .transpose()?;
+            let result = runtime.resume(exit_code, fuel_consumed);
+            if result != Err(TrapCode::OutOfFuel) {
+                fuel_remaining = adjusted_fuel;
+            }
+            result
         };
-        let result = resume_inner(&mut runtime);
-        // We need to adjust the fuel limit because `fuel_consumed` should not be included into spent.
-        if result != Err(TrapCode::OutOfFuel) {
-            // Safety: We can safely unwrap here, because `OutOfFuel` check we did in `resume_inner` and the result is ok.
-            fuel_remaining = fuel_remaining.map(|v| v.checked_sub(fuel_consumed).unwrap());
-        }
-        let fuel_consumed = runtime
-            .remaining_fuel()
-            .and_then(|remaining_fuel| Some(fuel_remaining? - remaining_fuel));
+        let mut result = resume_inner(&mut runtime);
+        let fuel_consumed = fuel_remaining
+            .zip(runtime.remaining_fuel())
+            .map(|(before, after)| {
+                before.checked_sub(after).unwrap_or_else(|| {
+                    // A backend that resets fuel or omits the child charge violates the resume
+                    // contract. Halt deterministically instead of wrapping the reported usage.
+                    result = Err(TrapCode::OutOfFuel);
+                    before
+                })
+            });
         let runtime_result =
             self.handle_execution_result(result, fuel_consumed, runtime.context_mut());
         let result = self.try_remember_runtime(runtime_result, runtime);
@@ -557,7 +572,9 @@ fn runtime_labels(runtime: &ExecutionMode) -> (RuntimeModeLabel, &'static str) {
 mod tests {
     use crate::{
         executor::{ExecutionInterruption, RuntimeExecutor, RuntimeFactoryExecutor, RuntimeResult},
-        runtime::{test_contract_module_with_memory, ContractRuntime, ExecutionMode},
+        runtime::{
+            test_contract_module_with_memory, ContractRuntime, ExecutionMode, SystemRuntime,
+        },
         RuntimeContext,
     };
     use fluentbase_types::{
@@ -565,8 +582,8 @@ mod tests {
         MAX_IN_FLIGHT_MEMORY_BYTES,
     };
     use rwasm::{
-        ExecutionEngine, RwasmModule, StrategyDefinition, TrapCode, N_BYTES_PER_MEMORY_PAGE,
-        N_DEFAULT_MAX_MEMORY_PAGES,
+        CompilationConfig, ExecutionEngine, RwasmModule, RwasmModuleInner, StrategyDefinition,
+        TrapCode, N_BYTES_PER_MEMORY_PAGE, N_DEFAULT_MAX_MEMORY_PAGES,
     };
 
     #[test]
@@ -624,6 +641,114 @@ mod tests {
         let result = executor.memory_read(42, 0, &mut buffer);
 
         assert_eq!(result, Err(TrapCode::MemoryOutOfBounds));
+    }
+
+    fn interrupted_contract(executor: &mut RuntimeFactoryExecutor) -> u32 {
+        let wasm = wat::parse_str(
+            r#"(module
+                (import "fluentbase_v1preview" "_exec"
+                    (func $exec (param i32 i32 i32 i32 i32) (result i32)))
+                (memory (export "memory") 1)
+                (func (export "main")
+                    i32.const 0 i32.const 0 i32.const 0 i32.const 0 i32.const 0
+                    call $exec
+                    drop))"#,
+        )
+        .unwrap();
+        let config = CompilationConfig::default()
+            .with_entrypoint_name("main".into())
+            .with_import_linker(executor.import_linker.clone());
+        let (module, _) = RwasmModule::compile(config, &wasm).unwrap();
+        let result = executor.execute(
+            BytecodeOrHash::Bytecode {
+                bytecode: module,
+                hash: B256::with_last_byte(0x36),
+                address: Address::ZERO,
+            },
+            RuntimeContext::default()
+                .with_fuel_limit(100_000)
+                .with_call_depth(1),
+        );
+        assert!(result.exit_code > 0, "contract must interrupt: {result:?}");
+        result.exit_code as u32
+    }
+
+    #[test]
+    fn resume_memory_error_does_not_subtract_uncharged_child_fuel() {
+        for child_fuel in [100, u64::MAX] {
+            let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
+            let call_id = interrupted_contract(&mut executor);
+            let result = executor.resume(call_id, &[], u32::MAX, child_fuel, 0, 0);
+
+            assert_eq!(result.exit_code, ExitCode::MemoryOutOfBounds.into_i32());
+            assert_eq!(result.fuel_consumed, 0);
+            assert!(executor.recoverable_runtimes.is_empty());
+        }
+    }
+
+    #[test]
+    fn resume_contract_excludes_child_fuel_from_reported_usage() {
+        let mut usage = vec![];
+        for child_fuel in [0, 100] {
+            let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
+            let call_id = interrupted_contract(&mut executor);
+            let result = executor.resume(call_id, &[], 64, child_fuel, 0, 0);
+
+            assert_eq!(result.exit_code, ExitCode::Ok.into_i32());
+            assert!(executor.recoverable_runtimes.is_empty());
+            usage.push(result.fuel_consumed);
+        }
+        assert_eq!(usage[0], usage[1]);
+    }
+
+    #[test]
+    fn resume_contract_rejects_excessive_child_fuel() {
+        let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
+        let call_id = interrupted_contract(&mut executor);
+        let result = executor.resume(call_id, &[], 0, u64::MAX, 0, 0);
+
+        assert_eq!(result.exit_code, ExitCode::OutOfFuel.into_i32());
+        assert!(result.fuel_consumed <= 100_000);
+        assert!(executor.recoverable_runtimes.is_empty());
+    }
+
+    #[test]
+    fn resume_system_rejects_inconsistent_child_fuel_accounting() {
+        // Model an engine-metered system runtime becoming resumable after an upgrade.
+        // Its current resume implementation re-enters execution without charging child fuel.
+        for child_fuel in [100, u64::MAX] {
+            SystemRuntime::reset_cached_runtimes();
+            let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
+            let module = RwasmModuleInner {
+                hint_section: wat::parse_str(
+                    r#"(module
+                        (memory (export "memory") 1)
+                        (func (export "main") (param i32 i32) (result i32) i32.const 0))"#,
+                )
+                .unwrap(),
+                ..Default::default()
+            }
+            .into();
+            let mut runtime = SystemRuntime::new(
+                module,
+                executor.import_linker.clone(),
+                B256::with_last_byte(0x37),
+                Address::ZERO,
+                RuntimeContext::default().with_fuel_limit(100_000),
+                true,
+            );
+            runtime.execute().unwrap();
+            executor
+                .recoverable_runtimes
+                .insert(1, ExecutionMode::System(runtime));
+
+            let result = executor.resume(1, &[], 0, child_fuel, 0, 0);
+
+            assert_eq!(result.exit_code, ExitCode::OutOfFuel.into_i32());
+            assert!(result.fuel_consumed <= 100_000);
+            assert!(executor.recoverable_runtimes.is_empty());
+            SystemRuntime::reset_cached_runtimes();
+        }
     }
 
     /// Initial pages the Rust/Wasm toolchain emits for a contract that allocates nothing of its

--- a/crates/runtime/src/syscall_handler/weierstrass.rs
+++ b/crates/runtime/src/syscall_handler/weierstrass.rs
@@ -4,3 +4,29 @@ mod weierstrass_add;
 pub use weierstrass_add::*;
 mod weierstrass_decompress;
 pub use weierstrass_decompress::*;
+
+#[cfg(test)]
+mod tests {
+    use super::{syscall_secp256k1_add_impl, syscall_secp256k1_double_impl};
+    use sp1_curves::{params::FieldParameters, weierstrass::secp256k1::Secp256k1BaseField};
+
+    #[test]
+    fn secp256k1_off_curve_inputs_preserve_arithmetic_without_panicking() {
+        // (0, 1) and (1, 1) are reduced field coordinates, but neither satisfies
+        // y^2 = x^3 + 7. These raw syscalls currently permit off-curve inputs.
+        let mut p = [0u8; 64];
+        p[32] = 1;
+        let mut q = p;
+        q[0] = 1;
+
+        let minus_one = (Secp256k1BaseField::modulus() - 1u32).to_bytes_le();
+        let mut expected_sum = [0u8; 64];
+        expected_sum[..32].copy_from_slice(&minus_one);
+        expected_sum[32..].copy_from_slice(&minus_one);
+        assert_eq!(syscall_secp256k1_add_impl(p, q), Ok(expected_sum));
+
+        let mut expected_double = [0u8; 64];
+        expected_double[32..].copy_from_slice(&minus_one);
+        assert_eq!(syscall_secp256k1_double_impl(p), Ok(expected_double));
+    }
+}

--- a/docs/07-rwasm-integration.md
+++ b/docs/07-rwasm-integration.md
@@ -77,3 +77,24 @@ A dependency bump can silently change any of these.
 6. update docs in same PR.
 
 If one of these steps is skipped, regressions can escape into consensus path.
+
+## Curve dependency upgrades
+
+`sp1-curves` is pinned to `=5.2.4`. The raw Weierstrass add/double syscalls validate
+coordinate bounds, but do not require curve membership. Version 5.2.4 uses generic
+field arithmetic for secp256k1; version 6.1.0 switches to `k256` point conversion and
+unwraps the result in `sw_add_k256` and `sw_double_k256`. Reduced off-curve coordinates
+that reach these syscalls can therefore panic the host after an unchecked upgrade.
+
+Before changing the pin:
+
+- Inspect the resolved implementation of curve addition, doubling and decompression
+  for panics on off-curve points, infinity, equal points and unreduced coordinates.
+- Run the runtime Weierstrass tests in release mode with both `std` and `std,wasmtime`.
+  Keep `secp256k1_off_curve_inputs_preserve_arithmetic_without_panicking` passing;
+  it covers reduced off-curve inputs that coordinate-bound checks permit today.
+- Patch an incompatible dependency before adopting it. Rejecting previously accepted
+  inputs is a protocol behavior change and requires explicit compatibility review,
+  including proof/runtime agreement; a dependency bump must not silently introduce it.
+- Recheck all workspace lockfiles and record the version and regression results in
+  the upgrade PR.


### PR DESCRIPTION
Fixes [FLU-1336](https://linear.app/fluentlabs-xyz/issue/FLU-1336).

Resume accounting and malformed analyzed EVM metadata can panic the host when cross-boundary invariants fail. This PR handles those failures deterministically and guards against a curve dependency upgrade introducing another panic path.

Three separate signed commits:

- `fix(runtime): halt on invalid resume fuel accounting` — check the child fuel charge before resuming, keep the original fuel baseline when writing the result to guest memory fails, and halt with `OutOfFuel` if backend fuel accounting would underflow. Regression tests cover memory errors, excessive charges, valid contract resumption, and a simulated engine-metered system-runtime resumption.
- `fix(evm): reject malformed analyzed metadata without panicking` — return `None` on analyzed-bytecode decode errors. Tests cover every truncated prefix, invalid code lengths, valid legacy/analyzed round-trips, and the existing empty-code fallbacks through native CODE_SIZE/CODE_HASH/CODE_COPY syscalls.
- `chore(deps): guard sp1-curves upgrades against host panics` — pin the currently resolved version to `=5.2.4`, add an off-curve secp256k1 add/double regression, and document the upgrade checks. The locally inspected 6.1.0 implementation unwraps failed point conversions. No lockfile or generated artifact changes.

The resume and metadata regressions failed on the original implementation. This is defensive hardening of the task's documented latent paths; it does not establish a new exploit against a shipped system runtime. Valid-input fuel accounting, metadata queries, and current raw curve arithmetic are preserved by regression tests.

Validation passed (Cargo build/check commands used `RUSTC_WRAPPER=` and the existing shared `CARGO_TARGET_DIR`):

```sh
cargo test --locked --release -p fluentbase-runtime -p fluentbase-evm --lib --no-default-features --features std
cargo test --locked --release -p fluentbase-revm --lib --no-default-features --features std
cargo test --locked --release -p fluentbase-runtime -p fluentbase-evm -p fluentbase-revm --lib --no-default-features --features std,wasmtime
cargo clippy --locked -p fluentbase-runtime -p fluentbase-evm -p fluentbase-revm --all-targets --no-default-features --features std,wasmtime -- -D warnings
cargo check --locked -p fluentbase-evm --no-default-features --target wasm32-unknown-unknown
cargo fmt --check -p fluentbase-runtime -p fluentbase-evm -p fluentbase-revm
git diff --check
git verify-commit HEAD HEAD~1 HEAD~2
```

Release suites: 132 tests passed with `std`, 134 with `std,wasmtime`. The existing test that allocates about 1.5 GiB remains ignored. Full workspace, contract/example, and EVM fixture suites are left to CI because the local changes are scoped to these crates. CI is pending: the release guard is running and broader test, Clippy, and benchmark jobs are queued. CI completion and maintainer review remain merge blockers.

A native `--no-default-features` check was also attempted and is intentionally unsupported by `fluentbase-crypto`; the supported no_std target is wasm32.

@dmitry123
