### PR TITLE
docs(revm): document accepted buffered effect gas policy

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -726,6 +726,11 @@ pub(crate) fn process_runtime_execution_outcome<CTX: ContextTr>(
         ctx.journal_mut().sstore(*target_address, k, v)?;
     }
 
+    // KNOWN LIMITATION (FLU-1306): buffered logs do not pay the LOG base/topic/data gas
+    // charged by the direct EMIT_LOG syscall. This underpricing is accepted to preserve
+    // existing network execution. Adding charges can change transaction success, gas usage,
+    // and resulting state; any repricing requires a coordinated network fork with the old
+    // rules retained for historical replay. Preserve the current policy here.
     for JournalLog { topics, data } in logs {
         ctx.journal_mut().log(Log {
             address: *target_address,
@@ -734,6 +739,9 @@ pub(crate) fn process_runtime_execution_outcome<CTX: ContextTr>(
     }
 
     if let Some(new_metadata) = new_metadata {
+        // Code-deposit gas is already charged by the EVM and Universal Token constructors
+        // before they emit new_metadata. EVM charges canonical runtime bytecode; Universal
+        // Token charges its metadata payload. Charging deposit here would charge it twice.
         // Safety: `new_metadata` should only be set by ownable accounts. If a non-ownable system
         // contract sets it, that indicates a severe invariant break; fail the frame
         // deterministically instead of panicking (with `panic = "abort"` a panic kills the node).
@@ -752,6 +760,10 @@ pub(crate) fn process_runtime_execution_outcome<CTX: ContextTr>(
     }
 
     if let Some(transfers) = transfers {
+        // KNOWN LIMITATION (FLU-1306): buffered native transfers do not pay CALL-style
+        // account-access, value-transfer, or new-account gas. As with buffered logs above,
+        // this underpricing is accepted for existing networks. Preserve these semantics
+        // until repricing is explicitly activated by a coordinated network fork.
         // Make sure contract can't overspend its balance
         let balance_required = transfers.iter().fold(U256::ZERO, |result, (_, amount)| {
             result.saturating_add(*amount)

--- a/docs/04-gas-and-fuel.md
+++ b/docs/04-gas-and-fuel.md
@@ -71,6 +71,25 @@ Universal Token runtime is currently in engine-metered set.
 
 ---
 
+## Buffered system-runtime effects
+
+The buffered `RuntimeExecutionOutcomeV1` commit path has accepted gas-pricing limitations:
+
+- Storage writes pay the SLOAD-priced preload but omit dynamic SSTORE write costs (FLU-1160).
+- Buffered logs omit the LOG base/topic/data gas charged by the direct `EMIT_LOG` syscall (FLU-1306).
+- Buffered native transfers omit CALL-style account-access, value-transfer, and new-account gas
+  (FLU-1306).
+
+Preserve this policy for existing networks. Repricing affects calls to already-deployed contracts
+and can change gas usage, transaction success, and resulting state. It requires a coordinated
+network fork that retains the previous execution rules before activation and during historical replay.
+
+Metadata deposit is already charged by the EVM and Universal Token constructors before they emit
+`new_metadata`. EVM charges canonical runtime bytecode; Universal Token charges its metadata payload.
+The host must not charge that deposit again.
+
+---
+
 ## Ethereum compatibility: transaction gas and calldata
 
 [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825) caps the gas limit declared by an Ethereum


### PR DESCRIPTION
Document the existing buffered system-runtime gas policy for [FLU-1306](https://linear.app/fluentlabs-xyz/issue/FLU-1306/medium-system-runtime-buffered-envelope-commits-log-metadata-deposit). The underpricing is accepted to preserve execution on existing networks; repricing requires a coordinated fork with the previous rules retained for historical replay.

- Add comments at the buffered log and native-transfer commit paths explaining their omitted gas charges and the fork requirement.
- Explain that EVM and Universal Token constructors already pay metadata deposit gas, so charging again in the host would duplicate it.
- Record the existing policy in `docs/04-gas-and-fuel.md`, alongside the accepted FLU-1160 storage-write limitation.

This PR changes only Rust line comments and Markdown documentation. Executable code, tests, gas accounting, journal behavior, and runtime/genesis artifacts match `devel`.

Validation: a source comparison against `origin/devel` confirmed that removing Rust line comments makes the executor identical and that the test files are byte-for-byte unchanged. The final diff contains only 12 comment lines and 19 documentation lines.

```sh
rustfmt +nightly --check --edition 2021 --config skip_children=true crates/revm/src/executor.rs
git diff --check
```

Both checks passed. Runtime suites were not rerun because this revision changes no executable code. Two separate GPG-signed Conventional Commits cover the source comments and gas guide. Remote CI status is tracked in the PR checks.

@dmitry123
