### PR TITLE
fix(runtime): recover module cache from poisoned lock instead of panicking

### DIFF
--- a/crates/runtime/src/executor.rs
+++ b/crates/runtime/src/executor.rs
@@ -358,13 +358,27 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
             BytecodeOrHash::Hash(_) => None,
         };
 
-        // If we have a cached module, then use it, otherwise create a new one and cache
-        let module = self.module_factory.get_module_or_init(bytecode_or_hash);
-
-        // If there is no cached store, then construct a new one (slow)
         let fuel_limit_value = ctx.fuel_limit;
         let fuel_limit = Some(fuel_limit_value);
 
+        // If we have a cached module, then use it, otherwise create a new one and cache.
+        //
+        // Only a hash-only lookup can miss: nothing warmed the module, or the LRU evicted it.
+        // That depends on this node's cache rather than on the input, so it must not become a
+        // contract revert that other nodes would not produce. Fail the frame as a host fault.
+        let Some(module) = self.module_factory.get_module_or_init(bytecode_or_hash) else {
+            let result = ExecutionResult {
+                exit_code: ExitCode::UnexpectedFatalExecutionFailure.into_i32(),
+                fuel_consumed: fuel_limit_value,
+                fuel_refunded: 0,
+                output: vec![],
+                return_data: vec![],
+            };
+            metrics::record_execution(RuntimeModeLabel::Contract, state, &timer, &result);
+            return result;
+        };
+
+        // If there is no cached store, then construct a new one (slow)
         let mut exec_mode = if let Some((address, code_hash)) = system_runtime_params {
             let consume_fuel = fluentbase_types::is_engine_metered_precompile(&address);
             let runtime = SystemRuntime::new(
@@ -507,7 +521,9 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
     }
 
     fn warmup(&mut self, bytecode: RwasmModule, hash: B256, address: Address) {
-        self.module_factory
+        // A bytecode-carrying lookup always yields a module; only hash-only lookups can miss.
+        let _ = self
+            .module_factory
             .get_module_or_init(BytecodeOrHash::Bytecode {
                 bytecode,
                 hash,
@@ -611,6 +627,25 @@ mod tests {
 
         assert_eq!(result.exit_code, ExitCode::UnknownError.into_i32());
         assert_eq!(result.fuel_consumed, 100);
+        assert_eq!(result.fuel_refunded, 0);
+        assert!(result.output.is_empty());
+        assert!(result.return_data.is_empty());
+    }
+
+    #[test]
+    fn execute_by_hash_without_cached_module_fails_as_host_fault() {
+        let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
+        // Nothing ever warmed this hash, so the shared cache cannot serve it.
+        let result = executor.execute(
+            BytecodeOrHash::Hash(B256::repeat_byte(0xD1)),
+            RuntimeContext::default().with_fuel_limit(1_000),
+        );
+
+        assert_eq!(
+            result.exit_code,
+            ExitCode::UnexpectedFatalExecutionFailure.into_i32()
+        );
+        assert_eq!(result.fuel_consumed, 1_000);
         assert_eq!(result.fuel_refunded, 0);
         assert!(result.output.is_empty());
         assert!(result.return_data.is_empty());

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -180,6 +180,22 @@ pub fn record_system_runtime_cache_invalidation(
     .increment(1);
 }
 
+/// Records that the compiled-module cache was discarded after a panic poisoned its lock.
+pub fn record_module_cache_reset() {
+    #[cfg(feature = "std")]
+    metrics::counter!("fluentbase_module_cache_resets_total").increment(1);
+}
+
+/// Records a hash-only module lookup that found no cached module.
+pub fn record_module_cache_hash_miss(reason: &'static str) {
+    #[cfg(feature = "std")]
+    metrics::counter!(
+        "fluentbase_module_cache_hash_misses_total",
+        "reason" => reason,
+    )
+    .increment(1);
+}
+
 /// Exposes the active cache-key version for operational dashboards.
 pub fn set_compilation_cache_fingerprint_version() {
     #[cfg(feature = "std")]

--- a/crates/runtime/src/module_factory.rs
+++ b/crates/runtime/src/module_factory.rs
@@ -1,3 +1,4 @@
+use crate::metrics;
 use fluentbase_types::{
     BytecodeOrHash, CompilationBackend, CompilationConfigFingerprint, CompiledModuleCacheKey, B256,
 };
@@ -23,9 +24,23 @@ impl ModuleFactory {
         INSTANCE.clone()
     }
 
+    /// Creates a factory with its own cache instead of the process-wide one.
+    #[cfg(test)]
+    pub(crate) fn isolated(max_bytes: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(ModuleFactoryInner::with_size_limit(max_bytes))),
+        }
+    }
+
     /// Returns a cached module for the given bytecode or compiles and caches it on first use.
-    pub fn get_module_or_init(&mut self, bytecode_or_hash: BytecodeOrHash) -> RwasmModule {
-        let mut ctx = self.inner.lock().unwrap();
+    ///
+    /// Returns `None` only for a hash-only lookup whose module is not cached, either because
+    /// nothing warmed it up or because the LRU evicted it. That is a node-local condition, not a
+    /// property of the input, so the caller must fail the execution as a host fault rather than
+    /// as a contract revert. Nothing in here panics: this lock is shared by every execution
+    /// thread, and a panic while holding it would poison it for all of them.
+    pub fn get_module_or_init(&mut self, bytecode_or_hash: BytecodeOrHash) -> Option<RwasmModule> {
+        let mut ctx = self.lock_cache();
         let code_hash = bytecode_or_hash.code_hash();
         let module_key = match &bytecode_or_hash {
             BytecodeOrHash::Bytecode { address, .. } => CompiledModuleCacheKey::new(
@@ -40,27 +55,49 @@ impl ModuleFactory {
                 // Hash-only lookups are only valid after an earlier bytecode warmup. Keep this
                 // deterministic by resolving through the explicit code-hash index.
                 let Some(module_key) = ctx.module_keys_by_code_hash.get(&code_hash).copied() else {
-                    panic!("runtime: can't compile just by hash")
+                    metrics::record_module_cache_hash_miss("never_warmed");
+                    return None;
                 };
                 module_key
             }
         };
 
         if let Some(entry) = ctx.cached_modules.get(&module_key) {
-            return entry.clone();
+            return Some(entry.clone());
         }
 
         let rwasm_module = match bytecode_or_hash {
             BytecodeOrHash::Bytecode { bytecode, .. } => bytecode,
             BytecodeOrHash::Hash(_hash) => {
-                // TODO(dmitry123): Do we want to have lock here until resources are warmed up?
-                panic!("runtime: can't compile just by hash")
+                // The index outlived the module: the LRU evicted it. Drop the stale index entry
+                // so the next bytecode-carrying call re-warms it cleanly.
+                ctx.module_keys_by_code_hash.remove(&code_hash);
+                metrics::record_module_cache_hash_miss("evicted");
+                return None;
             }
         };
 
         ctx.module_keys_by_code_hash.insert(code_hash, module_key);
         ctx.cached_modules.insert(module_key, rwasm_module.clone());
-        rwasm_module
+        Some(rwasm_module)
+    }
+
+    /// Locks the cache, recovering from a poisoned lock by discarding the cached contents.
+    ///
+    /// A poisoned lock means some other thread panicked while holding it. The cache is pure
+    /// (bytecode in, compiled module out), so throwing it away is always safe and only costs
+    /// recompilation. Propagating the poison instead would make every later execution on every
+    /// thread fail at this lock, leaving the node alive but unable to execute anything.
+    fn lock_cache(&self) -> std::sync::MutexGuard<'_, ModuleFactoryInner> {
+        self.inner.lock().unwrap_or_else(|poisoned| {
+            let mut guard = poisoned.into_inner();
+            *guard = ModuleFactoryInner::default();
+            // `into_inner` leaves the poison flag set; without clearing it every later lock
+            // would land here and discard the cache again.
+            self.inner.clear_poison();
+            metrics::record_module_cache_reset();
+            guard
+        })
     }
 }
 
@@ -76,14 +113,18 @@ struct ModuleFactoryInner {
 /// not the hash table overhead (which is negligible for typical workloads).
 pub const CACHED_MODULES_SIZE_LIMIT: usize = 1024 * 1024 * 1024;
 
-impl Default for ModuleFactoryInner {
-    fn default() -> Self {
+impl ModuleFactoryInner {
+    fn with_size_limit(max_bytes: usize) -> Self {
         Self {
-            cached_modules: LruMap::new(ModuleMemoryLimiter::<RwasmModule>::new(
-                CACHED_MODULES_SIZE_LIMIT,
-            )),
+            cached_modules: LruMap::new(ModuleMemoryLimiter::<RwasmModule>::new(max_bytes)),
             module_keys_by_code_hash: std::collections::HashMap::new(),
         }
+    }
+}
+
+impl Default for ModuleFactoryInner {
+    fn default() -> Self {
+        Self::with_size_limit(CACHED_MODULES_SIZE_LIMIT)
     }
 }
 
@@ -562,5 +603,87 @@ mod tests {
         assert!(cache.get(&cache_key(0)).is_some());
         assert!(cache.get(&cache_key(250)).is_some());
         assert!(cache.get(&cache_key(499)).is_some());
+    }
+
+    // ==================== Factory Lookups ====================
+
+    fn bytecode(id: u16, hint_size: usize) -> BytecodeOrHash {
+        BytecodeOrHash::Bytecode {
+            bytecode: module(hint_size),
+            hash: key(id),
+            address: fluentbase_types::Address::repeat_byte(id as u8),
+        }
+    }
+
+    #[test]
+    fn hash_lookup_without_warmup_misses_instead_of_panicking() {
+        let mut factory = ModuleFactory::isolated(1000);
+
+        assert!(factory
+            .get_module_or_init(BytecodeOrHash::Hash(key(1)))
+            .is_none());
+    }
+
+    #[test]
+    fn hash_lookup_after_warmup_hits() {
+        let mut factory = ModuleFactory::isolated(1000);
+
+        assert!(factory.get_module_or_init(bytecode(1, 100)).is_some());
+        assert!(factory
+            .get_module_or_init(BytecodeOrHash::Hash(key(1)))
+            .is_some());
+    }
+
+    #[test]
+    fn hash_lookup_after_eviction_misses_and_drops_stale_index_entry() {
+        // Room for a single module: warming the second evicts the first.
+        let mut factory = ModuleFactory::isolated(100);
+        factory.get_module_or_init(bytecode(1, 100));
+        factory.get_module_or_init(bytecode(2, 100));
+
+        assert!(factory
+            .get_module_or_init(BytecodeOrHash::Hash(key(1)))
+            .is_none());
+        assert!(
+            !factory
+                .inner
+                .lock()
+                .unwrap()
+                .module_keys_by_code_hash
+                .contains_key(&key(1)),
+            "stale index entry must be dropped"
+        );
+
+        // Re-warming with bytecode restores the hash path.
+        factory.get_module_or_init(bytecode(1, 100));
+        assert!(factory
+            .get_module_or_init(BytecodeOrHash::Hash(key(1)))
+            .is_some());
+    }
+
+    #[test]
+    fn poisoned_lock_is_recovered_by_discarding_the_cache() {
+        let mut factory = ModuleFactory::isolated(1000);
+        factory.get_module_or_init(bytecode(1, 100));
+
+        // Poison the lock the way a panicking execution thread would: unwind while holding it.
+        let inner = factory.inner.clone();
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = inner.lock().unwrap();
+            panic!("simulated panic while holding the module cache lock");
+        }));
+        assert!(inner.is_poisoned());
+
+        // The cache is usable again and its contents were discarded rather than trusted.
+        assert!(factory
+            .get_module_or_init(BytecodeOrHash::Hash(key(1)))
+            .is_none());
+        assert!(!inner.is_poisoned(), "recovery must clear the poison flag");
+
+        // Re-warming works and is not thrown away on the next lock.
+        assert!(factory.get_module_or_init(bytecode(1, 100)).is_some());
+        assert!(factory
+            .get_module_or_init(BytecodeOrHash::Hash(key(1)))
+            .is_some());
     }
 }

--- a/docs/05-security-invariants.md
+++ b/docs/05-security-invariants.md
@@ -115,6 +115,10 @@ with `panic = "abort"`. Consensus behavior must not depend on which profile buil
   boundaries provide that safety.
 - Reserve panics for genuine programmer invariants that cannot be reached from transaction, block,
   runtime, or other externally influenced input.
+- Process-wide caches must survive a panic on another thread. The compiled-module cache recovers
+  from a poisoned lock by discarding its contents, and a hash-only module lookup that misses
+  returns `UnexpectedFatalExecutionFailure` instead of panicking, so one failed execution cannot
+  wedge every later one on a node that keeps running.
 
 Why it matters: the same deterministic input must not become a node-crash or chain-liveness vector,
 and panic-profile differences must not change consensus outcomes.


### PR DESCRIPTION
The compiled-module cache is a process-wide std mutex locked with
`unwrap()`. A panic on any execution thread while holding it poisoned the
lock, and every later contract execution on every thread then panicked at
the same lock. On a validator that left the process alive but unable to
build a block, so supervision never restarted it.

Both panics inside the critical section were the hash-only miss. That miss
is reachable in production: the native SDK executes syscalls and delegated
calls by code hash alone, the LRU evicts modules past its memory budget,
and the code-hash index next to it was never pruned.

- Recover from a poisoned lock by discarding the cache and clearing the
  poison flag. The cache is pure (bytecode in, compiled module out), so
  throwing it away only costs recompilation.
- Never panic under the lock. A hash-only miss returns `None`, and a stale
  index entry left behind by eviction is dropped so the next
  bytecode-carrying call re-warms it cleanly.
- The executor turns a hash-only miss into
  `UnexpectedFatalExecutionFailure` with full fuel consumption. A cache miss
  is node-local, so it must fail the frame as a host fault rather than as a
  contract revert other nodes would not produce.
- Add `fluentbase_module_cache_resets_total` and
  `fluentbase_module_cache_hash_misses_total{reason}` counters, and record
  the invariant in the panic policy doc.

This keeps `panic = "unwind"` for shipped nodes: the validator's block
production already retries on failure, and a panicking execution can no
longer wedge the ones that follow.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when compiled modules are missing from the cache.
  * Hash-only lookups now return a deterministic execution failure instead of triggering a panic.
  * Cache recovery now handles interrupted operations by safely resetting affected cache contents, allowing subsequent executions to continue.

* **Documentation**
  * Expanded security guidance covering cache recovery and behavior when module lookups fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->