### PR TITLE
fix(evm-e2e): build fluentbase-genesis with one codegen unit

### DIFF
--- a/evm-e2e/Cargo.toml
+++ b/evm-e2e/Cargo.toml
@@ -50,3 +50,11 @@ wasmtime = [
     "fluentbase-revm/wasmtime",
     "fluentbase-runtime/wasmtime",
 ]
+
+# `fluentbase-genesis` embeds the ~130 MB `genesis-devnet.json` via `include_str!`.
+# With the default release profile's local ThinLTO, every one of the 16 codegen
+# units carries that constant and rustc peaks at ~16 GiB, which gets it OOM-killed
+# on the shared self-hosted runners (silent `exit status: 254` under sccache).
+# A single codegen unit keeps the same compile at ~1.6 GiB.
+[profile.release.package.fluentbase-genesis]
+codegen-units = 1


### PR DESCRIPTION
## Problem

The `evm-e2e` / `fixture` CI matrix entries keep dying on the self-hosted `hz02-*` runners while compiling `fluentbase-genesis`, with nothing but:

```
error: could not compile `fluentbase-genesis` (lib)
Caused by:
  process didn't exit successfully: `sccache .../rustc --crate-name fluentbase_genesis ...` (exit status: 254)
```

Recent occurrences (all `fluentbase-genesis`, all on `hz02-*`, none on `github-ephemeral-*`):

| Run | Job | Runner |
|---|---|---|
| [34124137556](https://github.com/fluentlabs-xyz/fluentbase/actions/runs/34124137556/job/101748709895) (PR #533) | fixture / std,wasmtime | hz02-1 |
| [34123063191](https://github.com/fluentlabs-xyz/fluentbase/actions/runs/34123063191) (devel) | fixture / std | hz02-2 |
| [34086425787](https://github.com/fluentlabs-xyz/fluentbase/actions/runs/34086425787) | fixture / std, fixture / std,wasmtime | hz02-1, hz02-5 |
| [34025339982](https://github.com/fluentlabs-xyz/fluentbase/actions/runs/34025339982) (devel) | evm-e2e / std | hz02-1 |

Exit status 254 is sccache's `-2`: the compiler child was killed by a signal. sccache prints `sccache: Compiler killed by signal N` to **stdout**, and nextest drops non-JSON stdout lines from `cargo test --no-run`, so the log stays silent. Cache stats in the failing job were fine (81% hits), so this is not a caching problem.

## Cause

`crates/genesis/src/lib.rs` does `include_str!("../genesis-devnet.json")`; that generated file is ~130 MB (hex-encoded rwasm for 34 accounts). `evm-e2e/Cargo.toml` is a standalone package with no `[profile]` section, so it builds the crate under cargo's default release profile, whose local ThinLTO carries the constant through all 16 codegen units.

Measured locally with the CI flags (`opt-level=3`, `lto=false`, `codegen-units=16`), rustc peak RSS for this one crate:

| Variant | Peak RSS |
|---|---|
| as on `devel` | **16.1 GiB** |
| JSON literal removed | 1.3 GiB |
| `black_box(include_str!(..))` | 16.9 GiB |
| module-level `static` | 15.2 GiB |
| `include_bytes!` + `from_utf8` | 8.8 GiB |
| **`codegen-units = 1` for this package** | **1.6 GiB** |
| root workspace profile (`lto = "thin"`) | 3.1 GiB |

`hz02-1..8` are containers on one host, and up to six of these compiles overlap when two runs are in flight, so rustc gets OOM-killed. The root workspace already uses `lto = "thin"` and sits at ~3 GiB, which is why the `root e2e` entries never failed.

## Fix

Per-package profile override in `evm-e2e/Cargo.toml`:

```toml
[profile.release.package.fluentbase-genesis]
codegen-units = 1
```

Verified from a standalone checkout that the override reaches the `fluentbase_genesis` rustc invocation (`-C codegen-units=1`) and that peak RSS drops to 1.6 GiB with the `evm-e2e` binary building normally.

## Follow-up (not in this PR)

The embedded JSON is only used by the node's local chainspec and one unit test; `e2e` and `evm-e2e` use only `BUILD_OUTPUTS`, which already contain the identical bytecode. Building the `Genesis` at runtime from those and keeping the JSON purely as a release artifact removes the 130 MB literal (and ~130 MB of rlib) entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
