### PR TITLE
fix(sdk-derive): map [u8; N] to uint8[N] and reject fixed bytes wider than bytes32

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
             features: std
             kind: workspace
             cache-key: root-e2e-std
+            # Doctests are not sharded across the matrix - one entry owns them.
+            doctests: true
 
           # ---------------------------
           # evm-e2e suite (good_coverage_tests)
@@ -160,6 +162,21 @@ jobs:
             --no-default-features \
             --features "${{ matrix.features }}" \
             --no-fail-fast \
+            --locked
+
+      # nextest does not run doctests, so a `compile_fail` doctest - the codec uses one to pin
+      # that a fixed-bytes type wider than bytes32 cannot be instantiated for the Solidity ABI -
+      # is not covered by the step above. Kept as its own step so a failure reads as "doctests".
+      - name: Run doctests (codec)
+        if: matrix.doctests
+        run: |
+          set -euxo pipefail
+          cargo test --doc \
+            --manifest-path=./Cargo.toml \
+            --package fluentbase-codec \
+            --release \
+            --no-default-features \
+            --features "${{ matrix.features }}" \
             --locked
 
       - name: Run ethereum tests (evm-e2e)

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,13 @@ run-e2e-tests:
 run-codec-conformance:
 	$(MAKE) -C codec-conformance all
 
+# nextest does not run doctests, so the codec's `compile_fail` doctest - which pins that a
+# fixed-bytes type wider than bytes32 cannot be instantiated for the Solidity ABI - needs its own
+# invocation to be covered at all.
+.PHONY: run-codec-doctests
+run-codec-doctests:
+	cargo test --doc --manifest-path=./Cargo.toml --package fluentbase-codec $(TEST_PROFILE) --no-default-features --features "$(TEST_FEATURES)"
+
 .PHONY: run-contracts-tests
 run-contracts-tests:
 	cargo nextest run --manifest-path=./contracts/Cargo.toml --workspace $(TEST_PROFILE) --no-default-features --features "$(TEST_FEATURES)"
@@ -71,6 +78,8 @@ test:
 	$(MAKE) run-e2e-tests TEST_FEATURES=std,wasmtime TEST_PROFILE=--release
 	# devnet/mainnet: rwasm case
 	$(MAKE) run-e2e-tests TEST_FEATURES=std TEST_PROFILE=--release
+	# doctests, which nextest does not run
+	$(MAKE) run-codec-doctests TEST_FEATURES=std TEST_PROFILE=--release
 
 .PHONY: coverage coverage-root coverage-contracts coverage-examples-deps coverage-evm-e2e-deps
 coverage: coverage-root coverage-contracts coverage-examples-deps coverage-evm-e2e-deps

--- a/crates/build/tests/abi_generation.rs
+++ b/crates/build/tests/abi_generation.rs
@@ -77,6 +77,43 @@ fn edge_cases_struct_abi() {
     });
 }
 
+/// `[u8; N]` is published as `uint8[N]` and `FixedBytes<N>` / `B*` as `bytesN`, because that is
+/// what the router encodes. `generate_abi` re-derives every selector from the published entry
+/// and checks it against the router's, so this also exercises that check for both layouts.
+#[test]
+fn byte_array_params_abi() {
+    let (_temp, project) = fixture_to_project("byte_array_params");
+    let abi = generate_abi(&project).expect("generate ABI");
+
+    let function = |name: &str| -> Value {
+        abi.iter()
+            .find(|entry| entry["name"] == name)
+            .unwrap_or_else(|| panic!("`{name}` is missing from the ABI"))
+            .clone()
+    };
+    let types = |params: &Value| -> Vec<String> {
+        params
+            .as_array()
+            .expect("parameters are an array")
+            .iter()
+            .map(|param| {
+                param["type"]
+                    .as_str()
+                    .expect("type is a string")
+                    .to_string()
+            })
+            .collect()
+    };
+
+    let set_tag = function("setTag");
+    assert_eq!(types(&set_tag["inputs"]), ["uint8[4]", "uint8[32]"]);
+    assert_eq!(types(&set_tag["outputs"]), ["uint8[32]"]);
+
+    let set_hash = function("setHash");
+    assert_eq!(types(&set_hash["inputs"]), ["bytes32", "bytes4"]);
+    assert_eq!(types(&set_hash["outputs"]), ["bytes32"]);
+}
+
 /// Root file of a crate whose modules both declare a `Config` struct
 const DUPLICATE_NAMES_ROOT: &str = r#"
 #![cfg_attr(target_arch = "wasm32", no_std)]

--- a/crates/build/tests/fixtures/byte_array_params.rs
+++ b/crates/build/tests/fixtures/byte_array_params.rs
@@ -1,0 +1,29 @@
+// tests/fixtures/byte_array_params.rs
+// Test case: byte arrays publish `uint8[N]`, fixed bytes publish `bytesN`
+
+#![cfg_attr(target_arch = "wasm32", no_std)]
+extern crate fluentbase_sdk;
+
+use fluentbase_sdk::{basic_entrypoint, derive::router, FixedBytes, SharedAPI, B256};
+
+#[derive(Default)]
+pub struct ByteArrayParams<SDK> {
+    sdk: SDK,
+}
+
+#[router(mode = "solidity")]
+impl<SDK: SharedAPI> ByteArrayParams<SDK> {
+    /// `[u8; N]` is encoded one word per element, so it is published as `uint8[N]`
+    pub fn set_tag(&mut self, tag: [u8; 4], payload: [u8; 32]) -> [u8; 32] {
+        let _ = tag;
+        payload
+    }
+
+    /// `FixedBytes<N>` and the `B*` aliases are one right-padded word: `bytesN`
+    pub fn set_hash(&mut self, hash: B256, short: FixedBytes<4>) -> B256 {
+        let _ = short;
+        hash
+    }
+}
+
+basic_entrypoint!(ByteArrayParams);

--- a/crates/codec/src/evm.rs
+++ b/crates/codec/src/evm.rs
@@ -201,19 +201,49 @@ impl<const N: usize, B: ByteOrder, const ALIGN: usize, const IS_STATIC: bool>
     }
 }
 
+/// Solidity-mode `bytesN`: one right-padded word.
+///
+/// The Solidity ABI has no fixed-bytes type wider than `bytes32`, so `N > 32` is rejected when
+/// this impl is instantiated: `HEADER_SIZE` asserts the width and every method reads it, which
+/// turns a wide `FixedBytes` bound for the Solidity ABI into a compile error instead of an inline
+/// blob no Solidity decoder can read. A wide value belongs in [`Bytes`] or, as `uint8[N]`, in a
+/// `[u8; N]`. [`CompactABI`](crate::CompactABI) is unaffected.
+///
+/// ```
+/// use fluentbase_codec::{bytes::BytesMut, SolidityABI};
+///
+/// let word = alloy_primitives::FixedBytes::<32>::repeat_byte(0xab);
+/// let mut buf = BytesMut::new();
+/// SolidityABI::encode(&word, &mut buf, 0).unwrap();
+/// assert_eq!(buf.len(), 32);
+/// ```
+///
+/// ```compile_fail
+/// use fluentbase_codec::{bytes::BytesMut, SolidityABI};
+///
+/// let wide = alloy_primitives::FixedBytes::<33>::repeat_byte(0xab);
+/// let mut buf = BytesMut::new();
+/// SolidityABI::encode(&wide, &mut buf, 0).unwrap();
+/// ```
 impl<const N: usize, B: ByteOrder, const ALIGN: usize, const IS_STATIC: bool>
     Encoder<B, ALIGN, true, IS_STATIC> for FixedBytes<N>
 {
     // One word in standard mode; the bare `N` bytes when ALIGN is 1, because packed encoding
     // concatenates short types without padding.
-    const HEADER_SIZE: usize = align_up::<ALIGN>(N);
+    const HEADER_SIZE: usize = {
+        assert!(
+            N <= 32,
+            "the Solidity ABI has no fixed-bytes type wider than bytes32; use `Bytes` or `[u8; N]`"
+        );
+        align_up::<ALIGN>(N)
+    };
     const IS_DYNAMIC: bool = false;
 
     /// Encode the fixed bytes into the buffer for Solidity mode.
     /// Writes the fixed bytes directly to the buffer at the given offset, zero-padding to the
     /// aligned width.
     fn encode(&self, buf: &mut BytesMut, offset: usize) -> Result<(), CodecError> {
-        let width = align_up::<ALIGN>(N);
+        let width = <Self as Encoder<B, ALIGN, true, IS_STATIC>>::HEADER_SIZE;
         let slice = get_aligned_slice::<B, ALIGN>(buf, offset, width);
         slice[..N].copy_from_slice(self.as_ref());
         // Zero-pad the rest
@@ -225,7 +255,7 @@ impl<const N: usize, B: ByteOrder, const ALIGN: usize, const IS_STATIC: bool>
     /// Reads the fixed bytes directly from the buffer at the given offset, assuming the value
     /// occupies its aligned width.
     fn decode(buf: &impl Buf, offset: usize) -> Result<Self, CodecError> {
-        let width = align_up::<ALIGN>(N);
+        let width = <Self as Encoder<B, ALIGN, true, IS_STATIC>>::HEADER_SIZE;
         if buf.remaining() < offset + width {
             return Err(CodecError::Decoding(DecodingError::BufferTooSmall {
                 expected: offset + width,
@@ -246,7 +276,10 @@ impl<const N: usize, B: ByteOrder, const ALIGN: usize, const IS_STATIC: bool>
     /// Partially decode the fixed bytes from the buffer for Solidity mode.
     /// Returns the data offset and size without reading the actual data.
     fn partial_decode(_buf: &impl Buf, offset: usize) -> Result<(usize, usize), CodecError> {
-        Ok((offset, align_up::<ALIGN>(N)))
+        Ok((
+            offset,
+            <Self as Encoder<B, ALIGN, true, IS_STATIC>>::HEADER_SIZE,
+        ))
     }
 }
 

--- a/crates/codec/src/evm.rs
+++ b/crates/codec/src/evm.rs
@@ -256,9 +256,17 @@ impl<const N: usize, B: ByteOrder, const ALIGN: usize, const IS_STATIC: bool>
     /// occupies its aligned width.
     fn decode(buf: &impl Buf, offset: usize) -> Result<Self, CodecError> {
         let width = <Self as Encoder<B, ALIGN, true, IS_STATIC>>::HEADER_SIZE;
-        if buf.remaining() < offset + width {
+        // `offset` comes from the caller, so the end of the field is checked arithmetic, or a
+        // wrapped sum would produce a bound small enough to pass. An overflow is its own error:
+        // there is no honest "expected" buffer size to report for it.
+        let end = offset.checked_add(width).ok_or_else(|| {
+            CodecError::Decoding(DecodingError::BufferOverflow {
+                msg: "Overflow occurred when calculating the end offset of FixedBytes".to_string(),
+            })
+        })?;
+        if buf.remaining() < end {
             return Err(CodecError::Decoding(DecodingError::BufferTooSmall {
-                expected: offset + width,
+                expected: end,
                 found: buf.remaining(),
                 msg: "Buffer too small to decode FixedBytes".to_string(),
             }));

--- a/crates/codec/tests/abi_conformance.rs
+++ b/crates/codec/tests/abi_conformance.rs
@@ -1120,6 +1120,21 @@ fn packed_mode_matches_the_specification() {
         "bytes32"
     );
 
+    // `[u8; N]` is `uint8[N]` here too, so packed encoding pads each byte to a word rather than
+    // concatenating the bytes the way `bytesN` does. The two stay distinct in packed mode.
+    packed_case!(
+        &mut r,
+        sol_data::FixedArray<sol_data::Uint<8>, 4>,
+        [1u8, 2, 3, 4],
+        "uint8[4], elements padded to a word"
+    );
+    packed_case!(
+        &mut r,
+        sol_data::FixedArray<sol_data::Uint<8>, 32>,
+        core::array::from_fn::<u8, 32, _>(|i| i as u8),
+        "uint8[32], elements padded to a word"
+    );
+
     // "array elements are padded, but still encoded in-place"
     packed_case!(
         &mut r,

--- a/crates/codec/tests/abi_conformance.rs
+++ b/crates/codec/tests/abi_conformance.rs
@@ -482,7 +482,61 @@ fn fixed_arrays_match_the_specification() {
         [Address::ZERO, Address::repeat_byte(9)]
     );
 
+    // `[u8; N]` is `uint8[N]` - one word per element - and not `bytesN`; the selector derived
+    // from a `[u8; N]` parameter says `uint8[N]` for exactly this reason.
+    case!(
+        &mut r,
+        sol_data::FixedArray<sol_data::Uint<8>, 4>,
+        [1u8, 2, 3, 4]
+    );
+    case!(
+        &mut r,
+        sol_data::FixedArray<sol_data::Uint<8>, 32>,
+        core::array::from_fn::<u8, 32, _>(|i| i as u8)
+    );
+
     r.assert_clean("fixed arrays");
+}
+
+/// `[u8; N]` and `FixedBytes<N>` are different Solidity types with different layouts: `uint8[N]`
+/// is one left-padded word per element, `bytesN` a single right-padded word. The router derives
+/// the selector from the Rust type and encodes the body with this codec, so a selector naming
+/// the wrong one accepts canonical calldata the contract cannot decode. Both layouts are checked
+/// against the specification at every width Solidity has.
+#[test]
+fn byte_arrays_and_fixed_bytes_match_the_specification_at_every_width() {
+    let mut r = Report::default();
+
+    macro_rules! at_width {
+        ($($n:literal),+ $(,)?) => {$({
+            let bytes: [u8; $n] = core::array::from_fn(|i| (i + 1) as u8);
+            case!(
+                &mut r,
+                sol_data::FixedArray<sol_data::Uint<8>, $n>,
+                bytes,
+                concat!("[u8; ", $n, "] as uint8[", $n, "]")
+            );
+            case!(
+                &mut r,
+                sol_data::FixedBytes<$n>,
+                FixedBytes::<$n>::new(bytes),
+                concat!("FixedBytes<", $n, "> as bytes", $n)
+            );
+            // The two are never interchangeable, not even at N = 1: `bytes1` puts the byte
+            // first, `uint8[1]` puts it last.
+            assert_ne!(
+                our_encoding(&bytes),
+                our_encoding(&FixedBytes::<$n>::new(bytes))
+            );
+        })+};
+    }
+
+    at_width!(
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        26, 27, 28, 29, 30, 31, 32
+    );
+
+    r.assert_clean("byte arrays and fixed bytes at every width");
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -766,6 +820,28 @@ fn function_arguments_match_the_specification() {
         (vec!["a".to_string(), String::new(), "ccc".to_string()],),
         "f(string[]) with three elements"
     );
+    // A byte array and fixed bytes of the same width side by side: N words, then one word.
+    function_args_case!(
+        &mut r,
+        (
+            sol_data::FixedArray<sol_data::Uint<8>, 4>,
+            sol_data::FixedBytes<4>
+        ),
+        ([1u8, 2, 3, 4], FixedBytes::<4>::new([1, 2, 3, 4])),
+        "f(uint8[4],bytes4)"
+    );
+    function_args_case!(
+        &mut r,
+        (
+            sol_data::FixedArray<sol_data::Uint<8>, 32>,
+            sol_data::FixedBytes<32>
+        ),
+        (
+            core::array::from_fn::<u8, 32, _>(|i| i as u8),
+            FixedBytes::<32>::repeat_byte(0xab)
+        ),
+        "f(uint8[32],bytes32)"
+    );
 
     r.assert_clean("function arguments");
 }
@@ -887,6 +963,27 @@ fn indexed_topics_match_the_specification() {
         sol_data::FixedArray<sol_data::Uint<64>, 3>,
         [0u64, 1, u64::MAX],
         "uint64[3] containing zero"
+    );
+
+    // `[u8; N]` is `uint8[N]`: a reference type hashed over one word per byte, not `bytesN`,
+    // which is a value type whose topic is the right-padded word itself.
+    topic_case!(
+        &mut r,
+        sol_data::FixedArray<sol_data::Uint<8>, 4>,
+        [1u8, 2, 3, 4],
+        "uint8[4]"
+    );
+    topic_case!(
+        &mut r,
+        sol_data::FixedArray<sol_data::Uint<8>, 32>,
+        core::array::from_fn::<u8, 32, _>(|i| i as u8),
+        "uint8[32]"
+    );
+    topic_case!(
+        &mut r,
+        sol_data::FixedBytes<32>,
+        FixedBytes::<32>::repeat_byte(0x11),
+        "bytes32"
     );
 
     // Tuples follow the struct rule: members concatenated in place, each padded to a word.

--- a/crates/codec/tests/topic.rs
+++ b/crates/codec/tests/topic.rs
@@ -203,6 +203,40 @@ fn indexed_fixed_array_is_hashed_rather_than_inlined() {
     );
 }
 
+/// `[u8; N]` is `uint8[N]`, so an indexed one is hashed over one word per byte. It is not
+/// `bytesN`: that is a value type whose topic is the right-padded word itself, and the two never
+/// coincide. The router advertises `uint8[N]` for a `[u8; N]` field for exactly this reason.
+#[test]
+fn indexed_byte_arrays_are_hashed_as_uint8_arrays_not_as_bytes_n() {
+    let bytes = [1u8, 2, 3, 4];
+    assert!(matches!(
+        encode_indexed_topic(&bytes).unwrap(),
+        IndexedTopic::Preimage(_)
+    ));
+    assert_eq!(preimage(&bytes).len(), 4 * 32);
+    assert_eq!(
+        topic(&bytes),
+        expected::<sol_data::FixedArray<sol_data::Uint<8>, 4>>(&bytes)
+    );
+
+    let word = FixedBytes::<4>::new(bytes);
+    assert!(matches!(
+        encode_indexed_topic(&word).unwrap(),
+        IndexedTopic::Word(_)
+    ));
+    assert_eq!(topic(&word), expected::<sol_data::FixedBytes<4>>(&word));
+    assert_ne!(topic(&bytes), topic(&word));
+
+    let hash: [u8; 32] = core::array::from_fn(|i| i as u8);
+    assert_eq!(
+        topic(&hash),
+        expected::<sol_data::FixedArray<sol_data::Uint<8>, 32>>(&hash)
+    );
+    let word = B256::new(hash);
+    assert_eq!(topic(&word), expected::<sol_data::FixedBytes<32>>(&word));
+    assert_ne!(topic(&hash), topic(&word));
+}
+
 #[test]
 fn array_members_that_are_dynamic_are_padded_in_place() {
     let values = vec!["a".to_string(), "bc".to_string()];

--- a/crates/sdk-derive/derive-core/src/abi/function.rs
+++ b/crates/sdk-derive/derive-core/src/abi/function.rs
@@ -250,6 +250,16 @@ mod tests {
     }
 
     #[test]
+    fn test_wide_fixed_bytes_aliases_have_no_signature() {
+        // Solidity's fixed-bytes types stop at `bytes32`, and the codec writes `B512` as one
+        // inline 64-byte blob that no Solidity type describes, so no selector can be derived.
+        let sig: Signature = parse_quote! {
+            fn verify(signature: B512) -> bool
+        };
+        assert!(FunctionABI::from_signature(&sig).is_err());
+    }
+
+    #[test]
     fn test_function_with_no_return() {
         let sig: Signature = parse_quote! {
             fn initialize(admin: Address)

--- a/crates/sdk-derive/derive-core/src/abi/function.rs
+++ b/crates/sdk-derive/derive-core/src/abi/function.rs
@@ -227,6 +227,29 @@ mod tests {
     }
 
     #[test]
+    fn test_byte_arrays_advertise_the_layout_the_codec_encodes() {
+        // `[u8; N]` is encoded one word per element, so the selector must say `uint8[N]`.
+        // Advertising `bytes32` would let canonical calldata select the route and then fail to
+        // decode.
+        let sig: Signature = parse_quote! {
+            fn store(root: [u8; 32], tag: [u8; 4]) -> [u8; 32]
+        };
+        let abi = FunctionABI::from_signature(&sig).unwrap();
+        assert_eq!(abi.inputs[0].ty, "uint8[32]");
+        assert_eq!(abi.inputs[1].ty, "uint8[4]");
+        assert_eq!(abi.outputs[0].ty, "uint8[32]");
+        assert_eq!(abi.signature().unwrap(), "store(uint8[32],uint8[4])");
+
+        // `bytesN` stays reachable through the types that carry the single-word codec.
+        let sig: Signature = parse_quote! {
+            fn store(root: FixedBytes<32>, tag: B32) -> B256
+        };
+        let abi = FunctionABI::from_signature(&sig).unwrap();
+        assert_eq!(abi.signature().unwrap(), "store(bytes32,bytes4)");
+        assert_eq!(abi.outputs[0].ty, "bytes32");
+    }
+
+    #[test]
     fn test_function_with_no_return() {
         let sig: Signature = parse_quote! {
             fn initialize(admin: Address)

--- a/crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs
+++ b/crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs
@@ -173,13 +173,10 @@ fn convert_array_type(array: &syn::TypeArray) -> Result<SolType, ConversionError
         ));
     }
 
+    // `[u8; N]` is `uint8[N]`, not `bytesN`. The codec encodes a Rust array element by element -
+    // one word per `u8` - so a selector that said `bytesN` would accept canonical calldata the
+    // router cannot decode. `bytesN` is what `FixedBytes<N>` and the `B8`..`B256` aliases carry.
     let elem_type = rust_to_sol(&array.elem)?;
-    if let SolType::Uint(8) = elem_type {
-        if len <= 32 {
-            return Ok(SolType::FixedBytes(len));
-        }
-    }
-
     Ok(SolType::FixedArray(Box::new(elem_type), len))
 }
 
@@ -387,9 +384,16 @@ mod tests {
 
     #[test]
     fn test_array_types() {
-        // Fixed size arrays of u8 up to 32 bytes are now converted to FixedBytes
-        assert_type("[u8; 5]", SolType::FixedBytes(5));
-        assert_type("[u8; 32]", SolType::FixedBytes(32));
+        // Fixed-size arrays of u8 are `uint8[N]`, never `bytesN`: the codec lays them out one
+        // word per element, and the selector has to describe that layout
+        assert_type(
+            "[u8; 5]",
+            SolType::FixedArray(Box::new(SolType::Uint(8)), 5),
+        );
+        assert_type(
+            "[u8; 32]",
+            SolType::FixedArray(Box::new(SolType::Uint(8)), 32),
+        );
 
         // Other fixed size arrays remain as FixedArray
         assert_type(
@@ -401,16 +405,19 @@ mod tests {
             SolType::FixedArray(Box::new(SolType::Address), 3),
         );
 
-        // Nested arrays - now with updated inner type
+        // Nested arrays
         assert_type(
             "[[u8; 5]; 3]",
-            SolType::FixedArray(Box::new(SolType::FixedBytes(5)), 3),
+            SolType::FixedArray(
+                Box::new(SolType::FixedArray(Box::new(SolType::Uint(8)), 5)),
+                3,
+            ),
         );
 
-        // Vec with fixed size arrays - now with updated inner type
+        // Vec with fixed size arrays
         assert_type(
             "Vec<[u8; 5]>",
-            SolType::Array(Box::new(SolType::FixedBytes(5))),
+            SolType::Array(Box::new(SolType::FixedArray(Box::new(SolType::Uint(8)), 5))),
         );
 
         // Dynamic arrays
@@ -422,19 +429,17 @@ mod tests {
     }
 
     #[test]
-    fn test_u8_arrays_to_fixed_bytes() {
-        // Test various sizes to ensure conversion is working
-        assert_type("[u8; 1]", SolType::FixedBytes(1));
-        assert_type("[u8; 16]", SolType::FixedBytes(16));
-        assert_type("[u8; 32]", SolType::FixedBytes(32));
+    fn test_u8_arrays_are_uint8_arrays_at_every_length() {
+        // The mapping does not change at 32: `bytesN` is a different layout (one right-padded
+        // word) and is only reachable through `FixedBytes<N>` and the `B*` aliases
+        for len in [1usize, 16, 32, 33] {
+            assert_type(
+                &format!("[u8; {len}]"),
+                SolType::FixedArray(Box::new(SolType::Uint(8)), len),
+            );
+        }
 
-        // Test that arrays larger than 32 remain as FixedArray
-        assert_type(
-            "[u8; 33]",
-            SolType::FixedArray(Box::new(SolType::Uint(8)), 33),
-        );
-
-        // Test that arrays of other types remain as FixedArray, even if length <= 32
+        // Arrays of other element types are fixed arrays as well
         assert_type(
             "[u16; 32]",
             SolType::FixedArray(Box::new(SolType::Uint(16)), 32),
@@ -490,8 +495,11 @@ mod tests {
         assert_type("&mut bool", SolType::Bool);
         assert_type("&Vec<u8>", SolType::Array(Box::new(SolType::Uint(8))));
 
-        // Fixed size array of u8 is now treated as FixedBytes
-        assert_type("&[u8; 5]", SolType::FixedBytes(5));
+        // A reference does not change the mapping of a byte array either
+        assert_type(
+            "&[u8; 5]",
+            SolType::FixedArray(Box::new(SolType::Uint(8)), 5),
+        );
     }
 
     #[test]

--- a/crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs
+++ b/crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs
@@ -71,6 +71,13 @@ fn convert_path_type(type_path: &syn::TypePath) -> Result<SolType, ConversionErr
     match type_name.as_str() {
         "Vec" => convert_vec_type(last_segment),
         "FixedBytes" => convert_fixed_bytes(&type_name, &last_segment.arguments),
+        // Solidity's fixed-bytes types stop at `bytes32`. The codec writes these aliases as one
+        // inline blob of N bytes, which no Solidity type describes (`fluentbase-codec` rejects
+        // them in Solidity mode for the same reason), so no selector can be derived for them.
+        "B512" | "B1024" | "B2048" => Err(ConversionError::InvalidBytesSize(format!(
+            "{type_name} is wider than bytes32, the widest fixed-bytes type in the Solidity ABI; \
+             use `Bytes` for a dynamic blob or `[u8; N]` for `uint8[N]`"
+        ))),
         _ => {
             // Special handling for array types is done in convert_array_type
             // Check for unsupported generic parameters in other types
@@ -126,9 +133,6 @@ fn convert_primitive_type(type_name: &str) -> Option<SolType> {
         "B192" => Some(SolType::FixedBytes(24)),
         "B224" => Some(SolType::FixedBytes(28)),
         "B256" => Some(SolType::FixedBytes(32)),
-        "B512" => Some(SolType::FixedArray(Box::new(SolType::Uint(8)), 64)),
-        "B1024" => Some(SolType::FixedArray(Box::new(SolType::Uint(8)), 128)),
-        "B2048" => Some(SolType::FixedArray(Box::new(SolType::Uint(8)), 256)),
         "bool" => Some(SolType::Bool),
         "Address" => Some(SolType::Address),
         "String" | "str" => Some(SolType::String),
@@ -562,18 +566,15 @@ mod tests {
         }
 
         #[test]
-        fn test_large_b_types() {
-            // Test large B-types that exceed Solidity's 32-byte limit for bytesN
-            // These should convert to fixed arrays of uint8
-            assert_type("B512", SolType::FixedArray(Box::new(SolType::Uint(8)), 64)); // 512 bits = 64 bytes
-            assert_type(
-                "B1024",
-                SolType::FixedArray(Box::new(SolType::Uint(8)), 128),
-            ); // 1024 bits = 128 bytes
-            assert_type(
-                "B2048",
-                SolType::FixedArray(Box::new(SolType::Uint(8)), 256),
-            ); // 2048 bits = 256 bytes
+        fn test_wide_b_types_have_no_solidity_type() {
+            // Solidity's fixed-bytes types stop at `bytes32`. These aliases used to be advertised
+            // as `uint8[N]`, which is not the single inline blob the codec writes for them, so no
+            // selector could ever match the calldata; they are rejected instead
+            for ty in ["B512", "B1024", "B2048"] {
+                assert_error(ty, |e| {
+                    assert!(matches!(e, ConversionError::InvalidBytesSize(_)));
+                });
+            }
         }
 
         #[test]
@@ -614,14 +615,10 @@ mod tests {
                 SolType::FixedArray(Box::new(SolType::FixedBytes(8)), 10),
             );
 
-            // Large B-types in collections
-            assert_type(
-                "Vec<B512>",
-                SolType::Array(Box::new(SolType::FixedArray(
-                    Box::new(SolType::Uint(8)),
-                    64,
-                ))),
-            );
+            // A wide alias is rejected inside a collection as well
+            assert_error("Vec<B512>", |e| {
+                assert!(matches!(e, ConversionError::InvalidBytesSize(_)));
+            });
 
             // Nested collections
             assert_type(
@@ -648,14 +645,10 @@ mod tests {
                 ]),
             );
 
-            // Large B-types in tuples
-            assert_type(
-                "(B512, u64)",
-                SolType::Tuple(vec![
-                    SolType::FixedArray(Box::new(SolType::Uint(8)), 64),
-                    SolType::Uint(64),
-                ]),
-            );
+            // A wide alias is rejected inside a tuple as well
+            assert_error("(B512, u64)", |e| {
+                assert!(matches!(e, ConversionError::InvalidBytesSize(_)));
+            });
         }
 
         #[test]
@@ -685,8 +678,10 @@ mod tests {
                 SolType::FixedArray(Box::new(SolType::FixedBytes(8)), 5),
             );
 
-            // References to large B-types
-            assert_type("&B512", SolType::FixedArray(Box::new(SolType::Uint(8)), 64));
+            // A reference to a wide alias is rejected as well
+            assert_error("&B512", |e| {
+                assert!(matches!(e, ConversionError::InvalidBytesSize(_)));
+            });
         }
 
         #[test]

--- a/crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs
+++ b/crates/sdk-derive/derive-core/src/abi/types/conversion/rust_to_sol.rs
@@ -62,6 +62,12 @@ fn convert_path_type(type_path: &syn::TypePath) -> Result<SolType, ConversionErr
 
     let type_name = last_segment.ident.to_string();
 
+    // A `B<bits>` alias is decided before the primitive table, so that a width the Solidity ABI
+    // has no type for is rejected rather than silently mapped to something else.
+    if let Some(width) = fixed_bytes_alias_width(&type_name) {
+        return fixed_bytes(width, &type_name);
+    }
+
     // Try primitive types first
     if let Some(result) = convert_primitive_type(&type_name) {
         return Ok(result);
@@ -71,13 +77,6 @@ fn convert_path_type(type_path: &syn::TypePath) -> Result<SolType, ConversionErr
     match type_name.as_str() {
         "Vec" => convert_vec_type(last_segment),
         "FixedBytes" => convert_fixed_bytes(&type_name, &last_segment.arguments),
-        // Solidity's fixed-bytes types stop at `bytes32`. The codec writes these aliases as one
-        // inline blob of N bytes, which no Solidity type describes (`fluentbase-codec` rejects
-        // them in Solidity mode for the same reason), so no selector can be derived for them.
-        "B512" | "B1024" | "B2048" => Err(ConversionError::InvalidBytesSize(format!(
-            "{type_name} is wider than bytes32, the widest fixed-bytes type in the Solidity ABI; \
-             use `Bytes` for a dynamic blob or `[u8; N]` for `uint8[N]`"
-        ))),
         _ => {
             // Special handling for array types is done in convert_array_type
             // Check for unsupported generic parameters in other types
@@ -123,16 +122,6 @@ fn convert_primitive_type(type_name: &str) -> Option<SolType> {
     }
 
     match type_name {
-        "B8" => Some(SolType::FixedBytes(1)),
-        "B16" => Some(SolType::FixedBytes(2)),
-        "B32" => Some(SolType::FixedBytes(4)),
-        "B64" => Some(SolType::FixedBytes(8)),
-        "B96" => Some(SolType::FixedBytes(12)),
-        "B128" => Some(SolType::FixedBytes(16)),
-        "B160" => Some(SolType::FixedBytes(20)),
-        "B192" => Some(SolType::FixedBytes(24)),
-        "B224" => Some(SolType::FixedBytes(28)),
-        "B256" => Some(SolType::FixedBytes(32)),
         "bool" => Some(SolType::Bool),
         "Address" => Some(SolType::Address),
         "String" | "str" => Some(SolType::String),
@@ -198,6 +187,60 @@ fn convert_slice_type(slice: &syn::TypeSlice) -> Result<SolType, ConversionError
     Ok(SolType::Array(Box::new(elem_type)))
 }
 
+/// The width in bytes a `B<bits>` alias stands for, if the name is one.
+///
+/// The list is exactly the aliases the primitive types crate defines; any other `B`-prefixed name
+/// is a user's own type - `B24` and `B4096` are structs, not fixed bytes. Whether a listed width
+/// has a Solidity type is [`fixed_bytes`]'s decision, not this one: every alias is routed there,
+/// so a wide one cannot reach the primitive table and bypass the width rule.
+fn fixed_bytes_alias_width(type_name: &str) -> Option<usize> {
+    const ALIASES: [(&str, usize); 13] = [
+        ("B8", 1),
+        ("B16", 2),
+        ("B32", 4),
+        ("B64", 8),
+        ("B96", 12),
+        ("B128", 16),
+        ("B160", 20),
+        ("B192", 24),
+        ("B224", 28),
+        ("B256", 32),
+        ("B512", 64),
+        ("B1024", 128),
+        ("B2048", 256),
+    ];
+
+    ALIASES
+        .iter()
+        .find(|(name, _)| *name == type_name)
+        .map(|(_, width)| *width)
+}
+
+/// The single home of "the Solidity ABI has no fixed-bytes type wider than `bytes32`".
+///
+/// Both spellings of a fixed-bytes parameter land here - the `B<bits>` aliases and an explicit
+/// `FixedBytes<N>` - so they are accepted and refused on the same rule, with the same message.
+/// `fluentbase-codec` asserts the same bound at the type level for the Solidity ABI.
+fn fixed_bytes(width: usize, described_as: &str) -> Result<SolType, ConversionError> {
+    // The two ways to be outside `bytes1`..`bytes32` fail for different reasons, so they say
+    // different things: there is no zero-width Solidity type at all, while a too-wide one has
+    // `Bytes` and `[u8; N]` to fall back on.
+    if width == 0 {
+        return Err(ConversionError::InvalidBytesSize(format!(
+            "{described_as} is zero bytes wide; the Solidity ABI's fixed-bytes types start at \
+             bytes1"
+        )));
+    }
+    if width > 32 {
+        return Err(ConversionError::InvalidBytesSize(format!(
+            "{described_as} is {width} bytes wide; the Solidity ABI has no fixed-bytes type wider \
+             than bytes32 - use `Bytes` for a dynamic blob or `[u8; {width}]` for \
+             `uint8[{width}]`"
+        )));
+    }
+    Ok(SolType::FixedBytes(width))
+}
+
 fn convert_fixed_bytes(type_name: &str, args: &PathArguments) -> Result<SolType, ConversionError> {
     if let PathArguments::AngleBracketed(angle_args) = args {
         if let Some(GenericArgument::Const(syn::Expr::Lit(syn::ExprLit {
@@ -206,9 +249,7 @@ fn convert_fixed_bytes(type_name: &str, args: &PathArguments) -> Result<SolType,
         }))) = angle_args.args.first()
         {
             if let Ok(size) = lit_int.base10_parse::<usize>() {
-                if size > 0 && size <= 32 {
-                    return Ok(SolType::FixedBytes(size));
-                }
+                return fixed_bytes(size, &format!("{type_name}<{size}>"));
             }
         }
     }
@@ -484,12 +525,22 @@ mod tests {
         assert_type("FixedBytes<1>", SolType::FixedBytes(1));
         assert_type("FixedBytes<32>", SolType::FixedBytes(32));
 
-        // Invalid sizes
+        // Invalid sizes. The two ends fail for different reasons, and each message has to name
+        // its own: a zero-width type has no Solidity counterpart at all, while a too-wide one is
+        // pointed at `Bytes` and `[u8; N]`.
         assert_error("FixedBytes<0>", |e| {
-            assert!(matches!(e, ConversionError::InvalidBytesSize(_)));
+            let ConversionError::InvalidBytesSize(msg) = e else {
+                panic!("expected InvalidBytesSize, got {e:?}");
+            };
+            assert!(msg.contains("zero bytes wide"), "{msg}");
+            assert!(msg.contains("start at bytes1"), "{msg}");
         });
         assert_error("FixedBytes<33>", |e| {
-            assert!(matches!(e, ConversionError::InvalidBytesSize(_)));
+            let ConversionError::InvalidBytesSize(msg) = e else {
+                panic!("expected InvalidBytesSize, got {e:?}");
+            };
+            assert!(msg.contains("33 bytes wide"), "{msg}");
+            assert!(msg.contains("wider than bytes32"), "{msg}");
         });
     }
 

--- a/crates/sdk-derive/derive-core/src/event.rs
+++ b/crates/sdk-derive/derive-core/src/event.rs
@@ -282,6 +282,20 @@ mod tests {
     }
 
     #[test]
+    fn test_byte_array_fields_sign_as_uint8_arrays() {
+        // `[u8; N]` is laid out one word per element by the codec and hashed as an array when
+        // indexed, so the signature has to say `uint8[N]`; `bytesN` belongs to `FixedBytes<N>`.
+        let input: DeriveInput = parse_quote! {
+            struct Tagged {
+                #[indexed]
+                tag: [u8; 4],
+                digest: B256,
+            }
+        };
+        assert!(generate(input).contains("\"Tagged(uint8[4],bytes32)\""));
+    }
+
+    #[test]
     fn test_no_indexed() {
         let input: DeriveInput = parse_quote! {
             struct DataStored {

--- a/crates/sdk-derive/docs/type_conversion.md
+++ b/crates/sdk-derive/docs/type_conversion.md
@@ -48,6 +48,8 @@ Fluentbase SDK provides bidirectional conversion between Solidity and Rust types
 - `[u8; N]` is `uint8[N]`, never `bytesN`. The codec encodes a Rust array one word per element,
   and the selector describes that layout; a `bytesN` parameter is declared as `FixedBytes<N>`
   (or `B32`, `B256`, ...), which is encoded as a single right-padded word
+- `B512`, `B1024`, `B2048` and `FixedBytes<N>` with N > 32 have no Solidity ABI type and are
+  rejected in Solidity-mode signatures; use `Bytes` for a dynamic blob or `[u8; N]` for `uint8[N]`
 - References (`&T` and `&mut T`) are dereferenced during conversion
 - Custom structs must implement `Codec` for serialization/deserialization
 

--- a/crates/sdk-derive/docs/type_conversion.md
+++ b/crates/sdk-derive/docs/type_conversion.md
@@ -14,7 +14,7 @@ Fluentbase SDK provides bidirectional conversion between Solidity and Rust types
 | `address` | `Address` | 20-byte type |
 | `string` | `String` | UTF-8 encoded |
 | `bytes` | `Bytes` | Dynamic byte array |
-| `bytes1` to `bytes32` | `FixedBytes<N>` or `[u8; N]` | Fixed-size byte arrays |
+| `bytes1` to `bytes32` | `FixedBytes<N>` | Fixed-size byte arrays, one right-padded word |
 | `uint8`/`uint16`/.../`uint128` | `u8`/`u16`/.../`u128` | Standard primitives |
 | `uint256` | `U256` | 256-bit unsigned integer |
 | `int8`/`int16`/.../`int128` | `i8`/`i16`/.../`i128` | Standard primitives |
@@ -32,20 +32,22 @@ Fluentbase SDK provides bidirectional conversion between Solidity and Rust types
 | `Address` | `address` | 20-byte type |
 | `String` or `&str` | `string` | UTF-8 encoded |
 | `Bytes` | `bytes` | Dynamic byte array |
-| `FixedBytes<N>` | `bytesN` | Fixed-size byte arrays |
-| `[u8; N]` where N ≤ 32 | `bytesN` | Special case for byte arrays |
+| `FixedBytes<N>` (N ≤ 32), `B8` to `B256` | `bytesN` | Fixed-size byte arrays, one right-padded word |
+| `[u8; N]` | `uint8[N]` | Byte arrays are ordinary fixed arrays: one word per element |
 | `u8`/`u16`/.../`u128` | `uint8`/`uint16`/.../`uint128` | Standard integers |
 | `U256` or `u256` | `uint256` | 256-bit unsigned integer |
 | `i8`/`i16`/.../`i128` | `int8`/`int16`/.../`int128` | Signed integers |
 | `I256` or `i256` | `int256` | 256-bit signed integer |
 | `Vec<T>` | `T[]` | Dynamic arrays |
-| `[T; N]` (except `[u8; N]` where N ≤ 32) | `T[N]` | Fixed-size arrays |
+| `[T; N]` | `T[N]` | Fixed-size arrays |
 | `(T1,T2,...)` | `(T1,T2,...)` | Tuples |
 | Custom structs | Tuples/structs | With `Codec` trait |
 
 ## Special Cases
 
-- `[u8; N]` where N ≤ 32 is automatically converted to `bytesN` in Solidity
+- `[u8; N]` is `uint8[N]`, never `bytesN`. The codec encodes a Rust array one word per element,
+  and the selector describes that layout; a `bytesN` parameter is declared as `FixedBytes<N>`
+  (or `B32`, `B256`, ...), which is encoded as a single right-padded word
 - References (`&T` and `&mut T`) are dereferenced during conversion
 - Custom structs must implement `Codec` for serialization/deserialization
 
@@ -61,6 +63,7 @@ use fluentbase_sdk::{
     derive::{router, Contract},
     Address,
     Bytes,
+    FixedBytes,
     SharedAPI,
     I256,
     U256,
@@ -75,7 +78,8 @@ pub trait SolidityTypesAPI {
     // Test various Solidity types mapping to Rust types
     fn address_test(&self, addr: Address) -> Address;
     fn bytes_test(&self, data: Bytes) -> Bytes;
-    fn fixed_bytes_test(&self, data: [u8; 32]) -> [u8; 32];
+    fn fixed_bytes_test(&self, data: FixedBytes<32>) -> FixedBytes<32>;
+    fn byte_array_test(&self, data: [u8; 32]) -> [u8; 32];
     fn uint256_test(&self, value: U256) -> U256;
     fn int256_test(&self, value: I256) -> I256;
     fn bool_test(&self, value: bool) -> bool;
@@ -97,7 +101,12 @@ impl<SDK: SharedAPI> SolidityTypesAPI for App<SDK> {
     }
 
     #[function_id("fixedBytesTest(bytes32)", validate(true))]
-    fn fixed_bytes_test(&self, data: [u8; 32]) -> [u8; 32] {
+    fn fixed_bytes_test(&self, data: FixedBytes<32>) -> FixedBytes<32> {
+        data
+    }
+
+    #[function_id("byteArrayTest(uint8[32])", validate(true))]
+    fn byte_array_test(&self, data: [u8; 32]) -> [u8; 32] {
         data
     }
 
@@ -143,7 +152,8 @@ basic_entrypoint!(App);
 
 - Use standard numeric types when possible (`u8`, `u16`, etc.) rather than always using `U256`
 - Implement `Codec` for all custom types used in contract interfaces
-- For fixed-size byte arrays, use `[u8; N]` where N ≤ 32 for proper `bytesN` conversion
+- For a Solidity `bytesN` parameter use `FixedBytes<N>` (or `B256` and friends); a `[u8; N]`
+  parameter is a `uint8[N]` and occupies N words
 - Test your contract interfaces thoroughly to ensure type compatibility
 - Only use `function_id` attribute inside `router` or `client` macros
 - When working with complex data structures, consider gas costs in Solidity

--- a/crates/sdk-derive/tests/ui/router/pass/direct_impl.rs
+++ b/crates/sdk-derive/tests/ui/router/pass/direct_impl.rs
@@ -7,6 +7,7 @@ use fluentbase_sdk::{
     derive::{router, Contract},
     Address,
     Bytes,
+    FixedBytes,
     SharedAPI,
     I256,
     U256,
@@ -30,7 +31,13 @@ impl<SDK: SharedAPI> App<SDK> {
     }
 
     #[function_id("fixedBytesTest(bytes32)", validate(true))]
-    pub fn fixed_bytes_test(&self, data: [u8; 32]) -> [u8; 32] {
+    pub fn fixed_bytes_test(&self, data: FixedBytes<32>) -> FixedBytes<32> {
+        data
+    }
+
+    // `[u8; N]` is encoded one word per element, so it advertises `uint8[N]`, not `bytesN`
+    #[function_id("byteArrayTest(uint8[32])", validate(true))]
+    pub fn byte_array_test(&self, data: [u8; 32]) -> [u8; 32] {
         data
     }
 

--- a/crates/sdk-derive/tests/ui/router/pass/trait_impl.rs
+++ b/crates/sdk-derive/tests/ui/router/pass/trait_impl.rs
@@ -7,6 +7,7 @@ use fluentbase_sdk::{
     derive::{router, Contract},
     Address,
     Bytes,
+    FixedBytes,
     SharedAPI,
     I256,
     U256,
@@ -21,7 +22,8 @@ pub trait SolidityTypesAPI {
     // Test various Solidity types mapping to Rust types
     fn address_test(&self, addr: Address) -> Address;
     fn bytes_test(&self, data: Bytes) -> Bytes;
-    fn fixed_bytes_test(&self, data: [u8; 32]) -> [u8; 32];
+    fn fixed_bytes_test(&self, data: FixedBytes<32>) -> FixedBytes<32>;
+    fn byte_array_test(&self, data: [u8; 32]) -> [u8; 32];
     fn uint256_test(&self, value: U256) -> U256;
     fn int256_test(&self, value: I256) -> I256;
     fn bool_test(&self, value: bool) -> bool;
@@ -43,7 +45,13 @@ impl<SDK: SharedAPI> SolidityTypesAPI for App<SDK> {
     }
 
     #[function_id("fixedBytesTest(bytes32)", validate(true))]
-    fn fixed_bytes_test(&self, data: [u8; 32]) -> [u8; 32] {
+    fn fixed_bytes_test(&self, data: FixedBytes<32>) -> FixedBytes<32> {
+        data
+    }
+
+    // `[u8; N]` is encoded one word per element, so it advertises `uint8[N]`, not `bytesN`
+    #[function_id("byteArrayTest(uint8[32])", validate(true))]
+    fn byte_array_test(&self, data: [u8; 32]) -> [u8; 32] {
         data
     }
 

--- a/examples/router-solidity/lib.rs
+++ b/examples/router-solidity/lib.rs
@@ -8,7 +8,7 @@ use alloc::string::String;
 use fluentbase_sdk::{
     basic_entrypoint,
     derive::{router, Contract},
-    SharedAPI,
+    FixedBytes, SharedAPI,
 };
 
 #[derive(Contract)]
@@ -19,6 +19,8 @@ struct App<SDK> {
 pub trait RouterAPI {
     fn greeting(&self, message: String) -> String;
     fn custom_greeting(&self, message: String) -> String;
+    fn byte_array(&self, data: [u8; 32]) -> [u8; 32];
+    fn fixed_bytes(&self, data: FixedBytes<32>) -> FixedBytes<32>;
 }
 
 #[router(mode = "solidity")]
@@ -31,6 +33,18 @@ impl<SDK: SharedAPI> RouterAPI for App<SDK> {
     #[function_id("customGreeting(string)")]
     fn custom_greeting(&self, message: String) -> String {
         message
+    }
+
+    // `[u8; 32]` is encoded one word per element, so it advertises `uint8[32]`, not `bytes32`
+    #[function_id("byteArray(uint8[32])", validate(true))]
+    fn byte_array(&self, data: [u8; 32]) -> [u8; 32] {
+        data
+    }
+
+    // `bytes32` is a single right-padded word, and `FixedBytes<32>` is the type that encodes it
+    #[function_id("fixedBytes(bytes32)", validate(true))]
+    fn fixed_bytes(&self, data: FixedBytes<32>) -> FixedBytes<32> {
+        data
     }
 }
 
@@ -91,5 +105,48 @@ mod tests {
         let output = CustomGreetingReturn::decode(&encoded_output.as_slice()).unwrap();
         println!("output: {:?}", &output.0);
         assert_eq!(output.0 .0, s);
+    }
+
+    /// A `[u8; 32]` parameter advertises `uint8[32]`, and the generated calldata has to be byte
+    /// for byte what Solidity produces for `uint8[32]` - selector and body. When the selector
+    /// said `bytes32` instead, canonical calldata reached this route and then failed to decode.
+    #[test]
+    fn test_byte_array_matches_solidity() {
+        let data: [u8; 32] = core::array::from_fn(|i| (i + 1) as u8);
+        let input = ByteArrayCall::new((data,)).encode();
+        sol!(
+            function byteArray(uint8[32] data);
+        );
+        let input_sol = byteArrayCall { data }.abi_encode();
+        assert_eq!(hex::encode(&input), hex::encode(&input_sol));
+
+        let sdk = TestingContextImpl::default().with_input(input);
+        let mut router = App::new(sdk.clone());
+        router.deploy();
+        router.main();
+        let encoded_output = &sdk.take_output();
+        let output = ByteArrayReturn::decode(&encoded_output.as_slice()).unwrap();
+        assert_eq!(output.0 .0, data);
+    }
+
+    /// The `bytes32` counterpart: `FixedBytes<32>` is the type that carries the single-word
+    /// codec, so it round-trips against a Solidity `bytes32` encoder.
+    #[test]
+    fn test_fixed_bytes_matches_solidity() {
+        let data = FixedBytes::<32>::from([7u8; 32]);
+        let input = FixedBytesCall::new((data,)).encode();
+        sol!(
+            function fixedBytes(bytes32 data);
+        );
+        let input_sol = fixedBytesCall { data }.abi_encode();
+        assert_eq!(hex::encode(&input), hex::encode(&input_sol));
+
+        let sdk = TestingContextImpl::default().with_input(input);
+        let mut router = App::new(sdk.clone());
+        router.deploy();
+        router.main();
+        let encoded_output = &sdk.take_output();
+        let output = FixedBytesReturn::decode(&encoded_output.as_slice()).unwrap();
+        assert_eq!(output.0 .0, data);
     }
 }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-1.93.1
+[toolchain]
+channel = "1.93.1"
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
Fixes [FLU-1313](https://linear.app/fluentlabs-xyz/issue/FLU-1313/low-flu-1073-not-fixed-u8-n-hashes-as-bytesn-in-the-selector-but), a re-find of FLU-1073.

## Problem

`rust_to_sol` mapped `[u8; N]` (N ≤ 32) to `bytesN` for the selector and the published ABI, while the codec encodes a Rust array one word per element, i.e. `uint8[N]`. Canonical calldata for the advertised selector reached the route and then failed to decode, generated clients produced bodies no Solidity decoder accepts, and indexed `[u8; N]` event fields were hashed as arrays under a `bytesN` signature.

`B512`/`B1024`/`B2048` had the same disagreement (`uint8[64]` advertised, a 64-byte inline blob written), and the Solidity-mode `FixedBytes<N>` encoder accepted N > 32 although no Solidity type has that layout.

## Changes (one commit each)

- **`[u8; N]` is `uint8[N]`** at every length. `bytesN` stays reachable through `FixedBytes<N>` and the `B8`..`B256` aliases, which carry the single-word codec. The codec is unchanged on purpose: the `[u8; 32]` layout is what the Universal Token legacy creation payload already depends on, so the wire format could not move; the selector was the side that lied.
- **`B512`/`B1024`/`B2048` are rejected** in Solidity-mode signatures with an error pointing at `Bytes` or `[u8; N]`.
- **`FixedBytes<N>` with N > 32 is a compile error** in `SolidityABI`/`SolidityPackedABI`: `HEADER_SIZE` asserts the width and every method reads it. `CompactABI` is unaffected. A `compile_fail` doctest pins it.
- **Codec regressions:** alloy parity for `[u8; N]` vs `uint8[N]` and `FixedBytes<N>` vs `bytesN` at every width 1..=32, in bodies, function arguments and indexed topics, plus an assertion that the two layouts never coincide.
- **Build regression:** a fixture routing `[u8; 4]`, `[u8; 32]`, `B256`, `FixedBytes<4>` pins the published ABI to `uint8[N]`/`bytesN` and goes through `generate_abi`'s selector cross-check.
- **Example regression:** `byteArray(uint8[32])` and `fixedBytes(bytes32)` routes in `examples/router-solidity`, `validate(true)`, round-tripped against `alloy-sol-types` (selector and body).
- Docs: `crates/sdk-derive/docs/type_conversion.md`.

## Breaking

Any routed method taking `[u8; N]` changes selector; the old one was undecodable. Authors who meant `bytesN` switch the parameter to `FixedBytes<N>`/`B256`, and with `validate(true)` they get a compile error naming the expected signature. Reverting the mapping makes the new example fail to compile with:

```
Function ID mismatch: Expected 0x629e98c5 for 'byteArray(bytes32)', but got 0xd943e54d
```

## Not done

The issue suggested extending the build-time selector check to verify layouts. `crates/build` works on the syn AST and cannot run the codec, and the selector and the body now derive from the single `rust_to_sol` mapping, so a layout divergence can only come from that mapping, which the codec parity tests pin. The build fixture exercises the existing selector cross-check for both layouts.

## Verification

- `cargo test -p fluentbase-sdk-derive-core`: 141 passed
- `cargo test -p fluentbase-codec`: all suites incl. doctests (`compile_fail` for `FixedBytes<33>`)
- `cargo test -p fluentbase-build --test abi_generation`: 14 passed
- `cargo test --manifest-path examples/Cargo.toml -p fluentbase-examples-router-solidity`: 4 passed
- `cargo clippy -p fluentbase-codec -p fluentbase-sdk-derive-core -p fluentbase-build --all-targets -- -D warnings`: clean
- `cargo check --manifest-path contracts/Cargo.toml --workspace --all-targets --no-default-features --features std`: clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Rust byte arrays now map to Solidity `uint8[N]`, while `FixedBytes<N>` and supported byte aliases map to `bytesN`.
  - ABI generation and router signatures now accurately reflect these distinct encodings.
  - Added Solidity router examples for byte-array and fixed-byte round trips.

- **Bug Fixes**
  - Fixed encoding, decoding, topic hashing, and selector consistency for byte arrays and fixed bytes.
  - Solidity fixed-byte types wider than 32 bytes are now rejected with clear validation errors.

- **Documentation**
  - Updated type-conversion guidance and examples to describe the new mappings and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->