### PR TITLE
fix(revm): halt system runtime traps instead of panicking the node

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -812,8 +812,9 @@ pub(crate) fn process_runtime_execution_outcome<CTX: ContextTr>(
 /// Handle exit codes that are produced by the system runtime boundary.
 ///
 /// For system runtime v2, the return data is a structured envelope that must be decoded and
-/// committed into the journal. For non-system contracts we also ensure fatal exit codes are
-/// not user-controllable.
+/// committed into the journal. For non-system contracts we also ensure system exit codes are
+/// not user-controllable. For every frame, a fatal exit code becomes a deterministic halt
+/// before it reaches REVM.
 fn process_execution_result<CTX: ContextTr, INSP: Inspector<CTX>>(
     frame: &mut RwasmFrame,
     ctx: &mut CTX,
@@ -837,19 +838,24 @@ fn process_execution_result<CTX: ContextTr, INSP: Inspector<CTX>>(
             ownable_account,
             preloaded_slot_costs.as_deref(),
         )?;
-    } else {
-        match exit_code {
-            // Do not allow fatal exit codes to be surfaced by non-system runtime contracts.
-            //
-            // Note: we intentionally do not expose an API for user code to produce these; callers
-            // will be punished for attempting it.
-            ExitCode::UnexpectedFatalExecutionFailure | ExitCode::MissingStorageSlot => {
-                exit_code = ExitCode::UnknownError;
-            }
+    } else if exit_code == ExitCode::MissingStorageSlot {
+        // Do not allow system exit codes to be surfaced by non-system runtime contracts.
+        //
+        // Note: we intentionally do not expose an API for user code to produce these; callers
+        // will be punished for attempting it.
+        exit_code = ExitCode::UnknownError;
+    }
 
-            // Default behavior: nothing special to do.
-            _ => {}
-        }
+    // `UnexpectedFatalExecutionFailure` reports a guest trap (`unreachable`, a memory or stack
+    // violation, ...) or a host fault whose output has already been discarded. The runtime has
+    // evicted the trapped instance and `process_runtime_execution_outcome` skipped the envelope,
+    // so the only thing left is to halt this frame deterministically and let the journal
+    // checkpoint revert its effects. The code must never be forwarded as
+    // `InstructionResult::FatalExternalError`: REVM reserves that result for context and
+    // database errors and terminates the process on it, which would turn a sandboxed guest trap
+    // into a node crash. This holds for system runtimes as much as for user contracts.
+    if exit_code.is_fatal_exit_code() {
+        exit_code = ExitCode::UnknownError;
     }
 
     Ok(process_halt(frame, ctx, inspector, exit_code, return_data))

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -1320,6 +1320,34 @@ mod resume_boundary_tests {
     }
 
     #[test]
+    fn system_runtime_fatal_exit_halts_instead_of_surfacing_fatal_external_error() {
+        let mut ctx = new_context();
+        let mut frame = RwasmFrame::default();
+        frame.interpreter.gas = Gas::new(100_000);
+        // A system runtime that traps reports `UnexpectedFatalExecutionFailure` without an
+        // envelope. The frame must halt like any other failure: forwarding the code as
+        // `FatalExternalError` makes REVM terminate the process.
+        frame.interpreter.input.target_address = PRECOMPILE_EVM_RUNTIME;
+
+        let next_action = process_exec_result::<_, NoOpInspector>(
+            &mut frame,
+            &mut ctx,
+            None,
+            ExitCode::UnexpectedFatalExecutionFailure.into_i32(),
+            Bytes::new(),
+            None,
+        )
+        .unwrap();
+
+        match next_action {
+            NextAction::Return(result) => {
+                assert_eq!(result.result, InstructionResult::UnknownError);
+            }
+            _ => panic!("expected a returned halt"),
+        }
+    }
+
+    #[test]
     fn missing_resume_result_halts_instead_of_panicking() {
         let mut ctx = new_context();
         let mut frame = RwasmFrame::default();

--- a/crates/runtime/src/runtime/system_runtime.rs
+++ b/crates/runtime/src/runtime/system_runtime.rs
@@ -188,9 +188,10 @@ impl SystemRuntime {
     /// will automatically decrement fuel as instructions execute.
     ///
     /// ## Error handling model
-    /// - If Wasmtime traps unexpectedly, we **do not propagate** the trap outward as fatal.
-    ///   Instead, we mark `UnexpectedFatalExecutionFailure` in `execution_result` and return `Ok(())`
-    ///   so the outer executor can treat it as a partially controlled failure.
+    /// - If the engine traps unexpectedly, we **do not propagate** the trap outward as fatal.
+    ///   Instead, we evict this instance, mark `UnexpectedFatalExecutionFailure` in
+    ///   `execution_result` and return `Ok(())`; the REVM boundary
+    ///   (`process_execution_result`) turns that code into a deterministic frame halt.
     /// - Normal completion is signaled by output where the first 4 bytes are LE `exit_code`.
     /// - Interruption is requested by returning `ExitCode::InterruptionCalled` in that header.
     pub fn execute(&mut self) -> Result<(), TrapCode> {

--- a/crates/types/src/exit_code.rs
+++ b/crates/types/src/exit_code.rs
@@ -135,7 +135,9 @@ pub enum ExitCode {
     UnknownExternalFunction = -2011,
 
     /* System Error Codes */
-    /// An unexpected fatal execution failure (node should panic or terminate the execution)
+    /// An unexpected fatal execution failure: a guest trap or a host fault whose output must be
+    /// discarded. The REVM boundary halts the frame deterministically; the code never surfaces
+    /// to REVM as a fatal error.
     UnexpectedFatalExecutionFailure = -3001,
     /// Missing storage slot
     MissingStorageSlot = -3002,

--- a/docs/05-security-invariants.md
+++ b/docs/05-security-invariants.md
@@ -90,7 +90,15 @@ Why it matters: upgrade authority compromise is full-system compromise.
 
 Non-system user contracts must not be able to surface internal fatal runtime-only classes as normal outputs.
 
-Why it matters: prevents exposing internal failure classes as user-controlled behavior.
+`UnexpectedFatalExecutionFailure` never crosses the rWASM↔REVM boundary. Whether a user contract
+emits it or a system runtime traps into it, `process_execution_result` turns it into a
+deterministic `UnknownError` halt that burns the frame's gas; a nested caller observes a failed
+call and continues. `InstructionResult::FatalExternalError` is reserved for context and database
+errors, which propagate as typed errors. REVM terminates the process on it, so no guest exit code
+may map to it.
+
+Why it matters: prevents exposing internal failure classes as user-controlled behavior, and keeps a
+sandboxed guest trap from becoming a node crash.
 
 ---
 

--- a/docs/07-rwasm-integration.md
+++ b/docs/07-rwasm-integration.md
@@ -81,7 +81,8 @@ A dependency bump can silently change any of these.
 4. verify gas/fuel settlement remains deterministic,
 5. re-audit the invariant-violation halt paths on the rWASM↔REVM resume boundary
    (`crates/revm/src/executor.rs`: `execute_rwasm_resume`, `process_exec_result`,
-   `process_runtime_execution_outcome`; `crates/runtime/src/executor.rs`: `resume`,
+   `process_execution_result`, `process_runtime_execution_outcome`;
+   `crates/runtime/src/executor.rs`: `resume`,
    `memory_read`) — an upgrade that changes trap/interruption behavior may make these
    deterministic `UnknownError` halts reachable, and they must stay typed deterministic halts or
    block-execution errors, not panics. The default release profile unwinds while the reproducible

--- a/e2e/src/update_account.rs
+++ b/e2e/src/update_account.rs
@@ -5,12 +5,12 @@ use fluentbase_codec::SolidityABI;
 use fluentbase_genesis::GENESIS_CONTRACTS_BY_ADDRESS;
 use fluentbase_sdk::{
     address, bytes, compile_rwasm_maybe_system, crypto::crypto_keccak256, Address, Bytes, B256,
-    DEFAULT_UPDATE_GENESIS_AUTH, PRECOMPILE_EVM_RUNTIME, PRECOMPILE_RIPEMD160,
+    DEFAULT_UPDATE_GENESIS_AUTH, PRECOMPILE_EVM_RUNTIME, PRECOMPILE_IDENTITY, PRECOMPILE_RIPEMD160,
     PRECOMPILE_RUNTIME_UPGRADE, PRECOMPILE_WEBAUTHN_VERIFIER, U256, UPDATE_GENESIS_PREFIX,
 };
-use fluentbase_testing::EvmTestingContext;
+use fluentbase_testing::{EvmTestingContext, TxResultExt};
 use hex_literal::hex;
-use revm::context::result::ExecutionResult;
+use revm::context::result::{ExecutionResult, HaltReason};
 
 sol! {
     event RuntimeUpgraded(
@@ -123,9 +123,6 @@ fn test_upgrade_solidity_contract_preserves_storage() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Encountered unexpected internal return flag: FatalExternalError with instruction result: InterpreterResult { result: FatalExternalError, output: 0x, gas: Gas { tracker: GasTracker { gas_limit: 3000000, remaining: 0, reservoir: 0, state_gas_spent: 0, refunded: 0 }, memory: MemoryGas { words_num: 0, expansion_cost: 0 } } }"
-)]
 fn test_update_account_code_by_auth() {
     let mut ctx = EvmTestingContext::default().with_full_genesis();
 
@@ -208,6 +205,8 @@ fn test_update_account_code_by_auth() {
         &rwasm_bytecode_should_be
     );
 
+    // The upgraded runtime traps on entry. The trap stays inside the frame: the transaction halts
+    // deterministically and burns its gas instead of crashing the node.
     let result = ctx.call_evm_tx(
         DEPLOYER_ADDRESS,
         contract_address,
@@ -215,7 +214,39 @@ fn test_update_account_code_by_auth() {
         None,
         None,
     );
-    assert!(result.is_halt());
+    result
+        .expect_halt()
+        .expect_reason(HaltReason::UnknownError)
+        .expect_gas_used(3_000_000);
+}
+
+/// A system runtime that traps inside a nested call must halt only that frame. The caller runs in
+/// the EVM system runtime and is resumed after the interruption; it observes a failed call and
+/// finishes normally.
+#[test]
+fn test_system_runtime_trap_in_nested_call_halts_only_that_frame() {
+    const DEPLOYER_ADDRESS: Address = address!("0x7777777777777777777777777777777777777777");
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+
+    // PUSH0 x4; PUSH20 <identity>; GAS; STATICCALL; PUSH0; MSTORE; PUSH1 0x20; PUSH0; RETURN
+    // Returns the STATICCALL success flag as a 32-byte word.
+    let mut runtime = vec![0x5f, 0x5f, 0x5f, 0x5f, 0x73];
+    runtime.extend_from_slice(PRECOMPILE_IDENTITY.as_slice());
+    runtime.extend_from_slice(&[0x5a, 0xfa, 0x5f, 0x52, 0x60, 0x20, 0x5f, 0xf3]);
+    let probe_address = deploy_evm_runtime(&mut ctx, DEPLOYER_ADDRESS, &runtime);
+
+    // The genesis identity precompile answers an empty call successfully.
+    ctx.call_evm_tx(DEPLOYER_ADDRESS, probe_address, Bytes::new(), None, None)
+        .expect_ok()
+        .expect_output(B256::with_last_byte(1));
+
+    upgrade_wasm_runtime(&mut ctx, PRECOMPILE_IDENTITY);
+
+    // Now the identity precompile traps on entry. The nested frame fails and the caller carries
+    // on; without containment the node would panic on the child's fatal result.
+    ctx.call_evm_tx(DEPLOYER_ADDRESS, probe_address, Bytes::new(), None, None)
+        .expect_ok()
+        .expect_output(B256::ZERO);
 }
 
 #[test]
@@ -387,14 +418,8 @@ fn decode_runtime_upgraded(logs: &[revm::primitives::Log]) -> RuntimeUpgraded {
         .expect("failed to decode RuntimeUpgraded")
 }
 
-/// Reads `EXTCODEHASH` the way an ordinary EVM caller would — through deployed EVM bytecode — so
-/// the precompile masking rules apply.
-fn evm_ext_code_hash(ctx: &mut EvmTestingContext, address: Address) -> B256 {
-    const DEPLOYER_ADDRESS: Address = address!("0x9999999999999999999999999999999999999999");
-    // PUSH20 <address>; EXTCODEHASH; PUSH0; MSTORE; PUSH1 0x20; PUSH0; RETURN
-    let mut runtime = vec![0x73u8];
-    runtime.extend_from_slice(address.as_slice());
-    runtime.extend_from_slice(&[0x3f, 0x5f, 0x52, 0x60, 0x20, 0x5f, 0xf3]);
+/// Deploys hand-assembled EVM runtime bytecode by wrapping it in init code that returns it.
+fn deploy_evm_runtime(ctx: &mut EvmTestingContext, deployer: Address, runtime: &[u8]) -> Address {
     let runtime_len = runtime.len() as u8;
     // Copy the runtime tail (12 bytes in) out of the init code and return it.
     let mut init_bytecode = vec![
@@ -411,9 +436,20 @@ fn evm_ext_code_hash(ctx: &mut EvmTestingContext, address: Address) -> B256 {
         0x00,
         0xf3,
     ];
-    init_bytecode.extend_from_slice(&runtime);
+    init_bytecode.extend_from_slice(runtime);
+    let (address, _) = ctx.deploy_evm_tx_with_gas(deployer, init_bytecode.into());
+    address
+}
 
-    let (probe_address, _) = ctx.deploy_evm_tx_with_gas(DEPLOYER_ADDRESS, init_bytecode.into());
+/// Reads `EXTCODEHASH` the way an ordinary EVM caller would — through deployed EVM bytecode — so
+/// the precompile masking rules apply.
+fn evm_ext_code_hash(ctx: &mut EvmTestingContext, address: Address) -> B256 {
+    const DEPLOYER_ADDRESS: Address = address!("0x9999999999999999999999999999999999999999");
+    // PUSH20 <address>; EXTCODEHASH; PUSH0; MSTORE; PUSH1 0x20; PUSH0; RETURN
+    let mut runtime = vec![0x73u8];
+    runtime.extend_from_slice(address.as_slice());
+    runtime.extend_from_slice(&[0x3f, 0x5f, 0x52, 0x60, 0x20, 0x5f, 0xf3]);
+    let probe_address = deploy_evm_runtime(ctx, DEPLOYER_ADDRESS, &runtime);
     let result = ctx.call_evm_tx(DEPLOYER_ADDRESS, probe_address, Bytes::new(), None, None);
     assert!(result.is_success(), "{result:?}");
     B256::from_slice(result.output().unwrap())


### PR DESCRIPTION
## Summary

A non-`OutOfFuel` trap inside a system runtime (`unreachable`, a memory or stack violation) is reported as `ExitCode::UnexpectedFatalExecutionFailure`. The non-system branch of `process_execution_result` already remaps that code to `UnknownError`, but the system branch left it unchanged, so `instruction_result_from_exit_code` produced `InstructionResult::FatalExternalError` and REVM panicked: at the top level in the post-execution handler of the revm fork, and for a nested frame in `insert_interrupted_result`. Any trap in any system runtime crashed the node instead of failing the transaction.

Fixes [FLU-1302](https://linear.app/fluentlabs-xyz/issue/FLU-1302).

## Changes

- `crates/revm/src/executor.rs`: apply the fatal-code remap after both branches of `process_execution_result`. The runtime has already evicted the trapped instance and the structured envelope is skipped for fatal codes, so the frame halts with `UnknownError`, burns its gas, and the journal checkpoint reverts its effects. A nested caller observes a failed call and continues. `FatalExternalError` is now produced only for context and database errors, which propagate as typed errors. The syscall `return_halt!` path needs no change: it only emits fixed non-fatal codes.
- `crates/types/src/exit_code.rs`, `crates/runtime/src/runtime/system_runtime.rs`: doc comments no longer describe the code as a reason for the node to panic and point at where the halt happens.
- `docs/05-security-invariants.md` §7, `docs/07-rwasm-integration.md`: document the containment rule and add `process_execution_result` to the resume-boundary halt paths that an rWasm upgrade must re-audit.

## Tests

- `crates/revm/src/tests.rs`: `system_runtime_fatal_exit_halts_instead_of_surfacing_fatal_external_error` feeds the fatal code through `process_exec_result` for a frame executed by a system runtime and expects `InstructionResult::UnknownError`.
- `e2e/src/update_account.rs`: `test_update_account_code_by_auth` used to be `#[should_panic]` on the `FatalExternalError` message; it now expects an `UnknownError` halt that burns the transaction gas. New `test_system_runtime_trap_in_nested_call_halts_only_that_frame` has an EVM probe `STATICCALL` the identity precompile, upgrades the precompile to a trapping module, and checks the probe succeeds with a zero call flag afterwards. That exercises the resume of the calling system runtime after the child frame halted, which is the second panic site.

## Consensus impact

No historical block can contain a transaction that reached this path: producing or validating such a block terminated the node on both backends. The remap therefore changes no replayed receipt and needs no fork gate.

## Validation

Debug profile with the pinned toolchain (1.93.1). Three separate signed commits: the fix with its unit test, the e2e tests, and the docs.

- `cargo test -p fluentbase-revm --lib resume_boundary_tests`: 7 passed, including the new test.
- `cargo nextest run -p fluentbase-e2e update_account` with default features (`std,wasmtime`) and with `--no-default-features --features std`: 10 passed on each backend.
- `cargo nextest run -p fluentbase-e2e -E 'test(test_wasm_cant_use_fatal_exit_code)'`: passed, so the non-system remap is unchanged.
- `cargo nextest run -p fluentbase-revm -p fluentbase-runtime`: 146 passed.
- Negative control with `crates/revm/src/executor.rs` restored from `devel`: both e2e tests fail. The nested one panics at `crates/revm/src/evm.rs:443` with `revm: fatal external error`; the top-level one hits the host panic it previously encoded as `#[should_panic]`.
- `cargo clippy -p fluentbase-revm -p fluentbase-e2e -p fluentbase-runtime -p fluentbase-types --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `git diff --check devel...HEAD`: clean.
- `git verify-commit` on all three commits: good signatures.

The release workspace suites are left to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Guest runtime traps and host faults now halt execution deterministically instead of surfacing as fatal external errors that could terminate the node.
  * Failed nested runtime calls now halt only their own execution frame, allowing the calling transaction to resume and handle the failed call.
  * Fatal execution halts consistently consume the frame’s remaining gas and discard return data.

* **Documentation**
  * Clarified fatal-error containment and runtime integration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->