### PR TITLE
refactor(runtime): cut host-side overhead on the wasmtime hot path

### DIFF
--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -489,11 +489,16 @@ pub(crate) fn execute_rwasm_resume<CTX: ContextTr, INSP: Inspector<CTX>>(
         halted_frame,
         ..
     } = interruption_outcome;
+    let SystemInterruptionInputs {
+        call_id,
+        fuel16_ptr,
+        preloaded_slot_costs,
+        ..
+    } = inputs;
 
     // `result` is expected to exist if we got here; interruption plumbing guarantees it.
     // If the handler failed to fill it, halt the transaction deterministically instead of
     // panicking: with `panic = "abort"` a panic here would kill the node.
-    let call_id = inputs.call_id;
     let Some(result) = result else {
         warn!(
             call_id,
@@ -505,8 +510,6 @@ pub(crate) fn execute_rwasm_resume<CTX: ContextTr, INSP: Inspector<CTX>>(
             frame.interpreter.gas,
         ));
     };
-    let preloaded_slot_costs = inputs.preloaded_slot_costs.clone();
-
     // Convert REVM gas accounts into runtime fuel units.
     let fuel_consumed = result.gas.total_gas_spent().saturating_mul(FUEL_DENOM_RATE);
     let fuel_refunded = result
@@ -528,7 +531,7 @@ pub(crate) fn execute_rwasm_resume<CTX: ContextTr, INSP: Inspector<CTX>>(
 
     let effective_bytecode_address = frame.interpreter.input.effective_bytecode_address();
 
-    let outcome: Bytes = if is_execute_using_system_runtime(&effective_bytecode_address) {
+    let outcome: Vec<u8> = if is_execute_using_system_runtime(&effective_bytecode_address) {
         let outcome = RuntimeInterruptionOutcomeV1 {
             halted_frame,
             output: result.output,
@@ -536,23 +539,22 @@ pub(crate) fn execute_rwasm_resume<CTX: ContextTr, INSP: Inspector<CTX>>(
             fuel_refunded,
             exit_code,
         };
-        bincode::encode_to_vec(&outcome, bincode::config::legacy())
-            .unwrap()
-            .into()
+        bincode::encode_to_vec(&outcome, bincode::config::legacy()).unwrap()
     } else {
-        result.output
+        // `Bytes` hands its buffer back without copying when nothing else references it.
+        result.output.into()
     };
 
     // Resume inside the runtime.
     let mut runtime_context = RuntimeContext::default();
     let Ok((fuel_consumed, fuel_refunded, exit_code)) = syscall_resume_impl(
         &mut runtime_context,
-        inputs.call_id,
-        outcome.as_ref(),
+        call_id,
+        outcome,
         exit_code.into_i32(),
         fuel_consumed,
         fuel_refunded,
-        inputs.fuel16_ptr,
+        fuel16_ptr,
     ) else {
         // Note: this should never happen, because we always call resume here at 0 depth level, but
         //  it's the only error that can be triggered inside. Halt deterministically instead of

--- a/crates/runtime/src/context_wrapper.rs
+++ b/crates/runtime/src/context_wrapper.rs
@@ -83,7 +83,7 @@ impl NativeAPI for RuntimeContextWrapper {
         let (fuel_consumed, fuel_refunded, exit_code) = syscall_resume_impl(
             &mut self.ctx.borrow_mut(),
             call_id,
-            return_data,
+            return_data.to_vec(),
             exit_code,
             fuel_consumed,
             fuel_refunded,

--- a/crates/runtime/src/executor.rs
+++ b/crates/runtime/src/executor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    metrics::{self, RuntimeModeLabel, RuntimeTimer},
+    metrics::{self, RuntimeModeLabel, RuntimeStateLabel, RuntimeTimer},
     module_factory::ModuleFactory,
     runtime::{ContractRuntime, ExecutionMode, SystemRuntime},
     RuntimeContext,
@@ -352,7 +352,7 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         ctx: RuntimeContext,
     ) -> ExecutionResult {
         let timer = RuntimeTimer::start();
-        let state = metrics::state_label(ctx.state);
+        let state = RuntimeStateLabel::from_state(ctx.state);
         let system_runtime_params = match &bytecode_or_hash {
             BytecodeOrHash::Bytecode { address, hash, .. } => {
                 fluentbase_types::is_execute_using_system_runtime(address)
@@ -598,10 +598,10 @@ fn runtime_mode_label(runtime: &ExecutionMode) -> RuntimeModeLabel {
     }
 }
 
-fn runtime_labels(runtime: &ExecutionMode) -> (RuntimeModeLabel, &'static str) {
+fn runtime_labels(runtime: &ExecutionMode) -> (RuntimeModeLabel, RuntimeStateLabel) {
     (
         runtime_mode_label(runtime),
-        metrics::state_label(runtime.context().state),
+        RuntimeStateLabel::from_state(runtime.context().state),
     )
 }
 

--- a/crates/runtime/src/executor.rs
+++ b/crates/runtime/src/executor.rs
@@ -84,7 +84,7 @@ pub trait RuntimeExecutor {
     fn resume(
         &mut self,
         call_id: u32,
-        return_data: &[u8],
+        return_data: Vec<u8>,
         fuel16_ptr: u32,
         fuel_consumed: u64,
         fuel_refunded: i64,
@@ -129,7 +129,7 @@ impl RuntimeExecutor for ThreadLocalExecutor {
     fn resume(
         &mut self,
         call_id: u32,
-        return_data: &[u8],
+        return_data: Vec<u8>,
         fuel16_ptr: u32,
         fuel_consumed: u64,
         fuel_refunded: i64,
@@ -183,7 +183,10 @@ pub struct RuntimeFactoryExecutor {
     /// A module factory
     pub module_factory: ModuleFactory,
     /// Suspended runtimes keyed by per-transaction call identifier.
-    pub recoverable_runtimes: HashMap<u32, ExecutionMode>,
+    ///
+    /// Boxed because every interruption cycle takes the runtime out of the map and puts it back
+    /// under a fresh identifier; moving a pointer keeps that from copying the whole store twice.
+    pub recoverable_runtimes: HashMap<u32, Box<ExecutionMode>>,
     /// An import linker
     pub import_linker: Arc<ImportLinker>,
     /// Monotonically increasing counter for assigning call identifiers.
@@ -224,7 +227,7 @@ impl RuntimeFactoryExecutor {
     pub fn try_remember_runtime(
         &mut self,
         runtime_result: RuntimeResult,
-        runtime: ExecutionMode,
+        runtime: Box<ExecutionMode>,
     ) -> ExecutionResult {
         let interruption = match runtime_result {
             RuntimeResult::Result(result) => {
@@ -379,7 +382,7 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         };
 
         // If there is no cached store, then construct a new one (slow)
-        let mut exec_mode = if let Some((address, code_hash)) = system_runtime_params {
+        let mut exec_mode = Box::new(if let Some((address, code_hash)) = system_runtime_params {
             let consume_fuel = fluentbase_types::is_engine_metered_precompile(&address);
             let runtime = SystemRuntime::new(
                 module,
@@ -434,7 +437,7 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
                 return result;
             }
             ExecutionMode::Contract(runtime.unwrap())
-        };
+        });
         let mode = runtime_mode_label(&exec_mode);
 
         // Bound the linear memory held simultaneously by every live frame of this transaction.
@@ -480,7 +483,7 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
     fn resume(
         &mut self,
         call_id: u32,
-        return_data: &[u8],
+        return_data: Vec<u8>,
         fuel16_ptr: u32,
         fuel_consumed: u64,
         fuel_refunded: i64,
@@ -502,9 +505,9 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
         metrics::set_recoverable_runtimes(self.recoverable_runtimes.len());
         let (mode, state) = runtime_labels(&runtime);
         let mut fuel_remaining = runtime.remaining_fuel();
-        let mut resume_inner = |runtime: &mut ExecutionMode| {
-            // Copy return data into return data
-            runtime.context_mut().execution_result.return_data = return_data.to_vec();
+        let mut resume_inner = |runtime: &mut ExecutionMode, return_data: Vec<u8>| {
+            // Hand the caller's buffer to the runtime as its return data
+            runtime.context_mut().execution_result.return_data = return_data;
             if fuel16_ptr > 0 {
                 let mut buffer = [0u8; 16];
                 LittleEndian::write_u64(&mut buffer[..8], fuel_consumed);
@@ -526,7 +529,7 @@ impl RuntimeExecutor for RuntimeFactoryExecutor {
             }
             result
         };
-        let mut result = resume_inner(&mut runtime);
+        let mut result = resume_inner(&mut runtime, return_data);
         let fuel_consumed = fuel_remaining
             .zip(runtime.remaining_fuel())
             .map(|(before, after)| {
@@ -671,7 +674,7 @@ mod tests {
         .unwrap();
         let runtime = ExecutionMode::Contract(strategy_runtime);
 
-        let result = executor.try_remember_runtime(interruption, runtime);
+        let result = executor.try_remember_runtime(interruption, Box::new(runtime));
 
         assert_eq!(result.exit_code, ExitCode::UnknownError.into_i32());
         assert_eq!(result.fuel_consumed, 100);
@@ -684,7 +687,7 @@ mod tests {
         let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
 
         // No runtime was ever saved under this call_id; resume must fail cleanly, not panic.
-        let result = executor.resume(42, &[], 0, 100, 0, ExitCode::Ok.into_i32());
+        let result = executor.resume(42, vec![], 0, 100, 0, ExitCode::Ok.into_i32());
 
         assert_eq!(result.exit_code, ExitCode::UnknownError.into_i32());
         assert_eq!(result.fuel_consumed, 100);
@@ -757,7 +760,7 @@ mod tests {
         for child_fuel in [100, u64::MAX] {
             let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
             let call_id = interrupted_contract(&mut executor);
-            let result = executor.resume(call_id, &[], u32::MAX, child_fuel, 0, 0);
+            let result = executor.resume(call_id, vec![], u32::MAX, child_fuel, 0, 0);
 
             assert_eq!(result.exit_code, ExitCode::MemoryOutOfBounds.into_i32());
             assert_eq!(result.fuel_consumed, 0);
@@ -771,7 +774,7 @@ mod tests {
         for child_fuel in [0, 100] {
             let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
             let call_id = interrupted_contract(&mut executor);
-            let result = executor.resume(call_id, &[], 64, child_fuel, 0, 0);
+            let result = executor.resume(call_id, vec![], 64, child_fuel, 0, 0);
 
             assert_eq!(result.exit_code, ExitCode::Ok.into_i32());
             assert!(executor.recoverable_runtimes.is_empty());
@@ -784,7 +787,7 @@ mod tests {
     fn resume_contract_rejects_excessive_child_fuel() {
         let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
         let call_id = interrupted_contract(&mut executor);
-        let result = executor.resume(call_id, &[], 0, u64::MAX, 0, 0);
+        let result = executor.resume(call_id, vec![], 0, u64::MAX, 0, 0);
 
         assert_eq!(result.exit_code, ExitCode::OutOfFuel.into_i32());
         assert!(result.fuel_consumed <= 100_000);
@@ -820,9 +823,9 @@ mod tests {
             runtime.execute().unwrap();
             executor
                 .recoverable_runtimes
-                .insert(1, ExecutionMode::System(runtime));
+                .insert(1, Box::new(ExecutionMode::System(runtime)));
 
-            let result = executor.resume(1, &[], 0, child_fuel, 0, 0);
+            let result = executor.resume(1, vec![], 0, child_fuel, 0, 0);
 
             assert_eq!(result.exit_code, ExitCode::OutOfFuel.into_i32());
             assert!(result.fuel_consumed <= 100_000);
@@ -871,7 +874,9 @@ mod tests {
         // frames, not the size of the largest one.
         for (call_id, pages) in [(1u32, 3u32), (2, 5)] {
             let frame = suspended_frame_with_memory(&executor, pages);
-            executor.recoverable_runtimes.insert(call_id, frame);
+            executor
+                .recoverable_runtimes
+                .insert(call_id, Box::new(frame));
         }
 
         assert_eq!(
@@ -884,7 +889,7 @@ mod tests {
     fn in_flight_memory_ignores_frames_that_were_forgotten() {
         let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
         let frame = suspended_frame_with_memory(&executor, 4);
-        executor.recoverable_runtimes.insert(7, frame);
+        executor.recoverable_runtimes.insert(7, Box::new(frame));
         assert_eq!(
             executor.in_flight_memory_bytes(),
             4 * N_BYTES_PER_MEMORY_PAGE as u64
@@ -900,7 +905,7 @@ mod tests {
         // Room for the four pages already suspended, but not for the frame about to be built.
         executor.max_in_flight_memory_bytes = 5 * N_BYTES_PER_MEMORY_PAGE as u64;
         let frame = suspended_frame_with_memory(&executor, 4);
-        executor.recoverable_runtimes.insert(1, frame);
+        executor.recoverable_runtimes.insert(1, Box::new(frame));
 
         let result = executor.execute(
             contract_bytecode_with_memory(3),
@@ -920,7 +925,7 @@ mod tests {
         let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
         executor.max_in_flight_memory_bytes = 8 * N_BYTES_PER_MEMORY_PAGE as u64;
         let frame = suspended_frame_with_memory(&executor, 4);
-        executor.recoverable_runtimes.insert(1, frame);
+        executor.recoverable_runtimes.insert(1, Box::new(frame));
 
         let result = executor.execute(
             contract_bytecode_with_memory(3),
@@ -961,7 +966,9 @@ mod tests {
                 "frame {call_id} failed for another reason"
             );
             let frame = suspended_frame(executor, module.clone());
-            executor.recoverable_runtimes.insert(call_id, frame);
+            executor
+                .recoverable_runtimes
+                .insert(call_id, Box::new(frame));
             admitted += 1;
         }
         admitted

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -2,17 +2,26 @@
 //!
 //! The node installs the Prometheus recorder via `reth-node-metrics`; this crate only records
 //! low-cardinality runtime observations into that global recorder.
+//!
+//! Everything on the execute/resume path records through handles that are registered once per
+//! label set and reused afterwards. Building a `metrics::Key` with owned labels and resolving it
+//! against the recorder on every runtime call cost about a fifth of an interruption round trip.
+//! A handle binds to the recorder installed when it is first used, so the recorder has to be in
+//! place before the first execution; the node installs it during launch, ahead of genesis
+//! initialization and of any block or RPC execution.
 #![cfg_attr(not(feature = "std"), allow(unused_variables))]
 
 use crate::executor::ExecutionResult;
 use fluentbase_types::{
-    CompilationConfigFingerprint, ExitCode, COMPILATION_CONFIG_FINGERPRINT_VERSION, STATE_DEPLOY,
-    STATE_MAIN,
+    CompilationBackend, CompilationConfigFingerprint, ExitCode,
+    COMPILATION_CONFIG_FINGERPRINT_VERSION, STATE_DEPLOY, STATE_MAIN,
 };
 use rwasm::TrapCode;
 
 #[cfg(feature = "std")]
-use std::time::Instant;
+use metrics::{Counter, Gauge, Histogram};
+#[cfg(feature = "std")]
+use std::{sync::OnceLock, time::Instant};
 
 /// Low-cardinality runtime mode label.
 #[derive(Clone, Copy, Debug)]
@@ -22,20 +31,136 @@ pub enum RuntimeModeLabel {
 }
 
 impl RuntimeModeLabel {
+    const COUNT: usize = 2;
+
     fn as_str(self) -> &'static str {
         match self {
             Self::Contract => "contract",
             Self::System => "system",
         }
     }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Contract => 0,
+            Self::System => 1,
+        }
+    }
 }
 
 /// Runtime entrypoint/state label.
-pub fn state_label(state: u32) -> &'static str {
-    match state {
-        STATE_MAIN => "main",
-        STATE_DEPLOY => "deploy",
-        _ => "unknown",
+#[derive(Clone, Copy, Debug)]
+pub enum RuntimeStateLabel {
+    Main,
+    Deploy,
+    Unknown,
+}
+
+impl RuntimeStateLabel {
+    const COUNT: usize = 3;
+
+    pub fn from_state(state: u32) -> Self {
+        match state {
+            STATE_MAIN => Self::Main,
+            STATE_DEPLOY => Self::Deploy,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Main => "main",
+            Self::Deploy => "deploy",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Main => 0,
+            Self::Deploy => 1,
+            Self::Unknown => 2,
+        }
+    }
+}
+
+/// Which executor entry point produced an observation.
+#[derive(Clone, Copy, Debug)]
+enum Operation {
+    Execution,
+    Resume,
+}
+
+impl Operation {
+    const COUNT: usize = 2;
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Execution => "execution",
+            Self::Resume => "resume",
+        }
+    }
+
+    fn total_metric(self) -> &'static str {
+        match self {
+            Self::Execution => "fluentbase_runtime_executions_total",
+            Self::Resume => "fluentbase_runtime_resumes_total",
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Execution => 0,
+            Self::Resume => 1,
+        }
+    }
+}
+
+/// Coarse classification of an execution result.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Outcome {
+    Interrupted,
+    Success,
+    OutOfFuel,
+    Fatal,
+    Reverted,
+}
+
+impl Outcome {
+    const COUNT: usize = 5;
+
+    fn from_result(result: &ExecutionResult) -> Self {
+        if result.exit_code > 0 {
+            Self::Interrupted
+        } else if result.exit_code == ExitCode::Ok.into_i32() {
+            Self::Success
+        } else if result.exit_code == ExitCode::OutOfFuel.into_i32() {
+            Self::OutOfFuel
+        } else if result.exit_code == ExitCode::UnexpectedFatalExecutionFailure.into_i32() {
+            Self::Fatal
+        } else {
+            Self::Reverted
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Interrupted => "interrupted",
+            Self::Success => "success",
+            Self::OutOfFuel => "out_of_fuel",
+            Self::Fatal => "fatal",
+            Self::Reverted => "reverted",
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Interrupted => 0,
+            Self::Success => 1,
+            Self::OutOfFuel => 2,
+            Self::Fatal => 3,
+            Self::Reverted => 4,
+        }
     }
 }
 
@@ -60,14 +185,123 @@ impl RuntimeTimer {
     }
 }
 
+/// Handles for every observation recorded about one execute or resume call.
+#[cfg(feature = "std")]
+struct OperationMetrics {
+    execution_seconds: Histogram,
+    fuel_consumed: Histogram,
+    fuel_refunded: Histogram,
+    output_bytes: Histogram,
+    return_data_bytes: Histogram,
+    /// `fluentbase_runtime_executions_total` or `fluentbase_runtime_resumes_total`.
+    total: Counter,
+    /// `fluentbase_runtime_interruptions_total`, present only for interrupted outcomes.
+    interruptions: Option<Counter>,
+}
+
+#[cfg(feature = "std")]
+const OPERATION_CELLS: usize =
+    Operation::COUNT * RuntimeModeLabel::COUNT * RuntimeStateLabel::COUNT * Outcome::COUNT;
+
+#[cfg(feature = "std")]
+static OPERATION_METRICS: [OnceLock<OperationMetrics>; OPERATION_CELLS] =
+    [const { OnceLock::new() }; OPERATION_CELLS];
+
+#[cfg(feature = "std")]
+fn operation_cell(
+    operation: Operation,
+    mode: RuntimeModeLabel,
+    state: RuntimeStateLabel,
+    outcome: Outcome,
+) -> usize {
+    ((operation.index() * RuntimeModeLabel::COUNT + mode.index()) * RuntimeStateLabel::COUNT
+        + state.index())
+        * Outcome::COUNT
+        + outcome.index()
+}
+
+#[cfg(feature = "std")]
+fn register_operation_metrics(
+    operation: Operation,
+    mode: RuntimeModeLabel,
+    state: RuntimeStateLabel,
+    outcome: Outcome,
+) -> OperationMetrics {
+    let labels = [
+        ("operation", operation.as_str()),
+        ("mode", mode.as_str()),
+        ("state", state.as_str()),
+        ("outcome", outcome.as_str()),
+    ];
+    OperationMetrics {
+        execution_seconds: metrics::histogram!("fluentbase_runtime_execution_seconds", &labels),
+        fuel_consumed: metrics::histogram!("fluentbase_runtime_fuel_consumed", &labels),
+        fuel_refunded: metrics::histogram!("fluentbase_runtime_fuel_refunded", &labels),
+        output_bytes: metrics::histogram!("fluentbase_runtime_output_bytes", &labels),
+        return_data_bytes: metrics::histogram!("fluentbase_runtime_return_data_bytes", &labels),
+        total: metrics::counter!(
+            operation.total_metric(),
+            "mode" => mode.as_str(),
+            "state" => state.as_str(),
+            "outcome" => outcome.as_str(),
+        ),
+        interruptions: (outcome == Outcome::Interrupted).then(|| {
+            metrics::counter!(
+                "fluentbase_runtime_interruptions_total",
+                "mode" => mode.as_str(),
+                "state" => state.as_str(),
+            )
+        }),
+    }
+}
+
+#[cfg(feature = "std")]
+fn operation_metrics(
+    operation: Operation,
+    mode: RuntimeModeLabel,
+    state: RuntimeStateLabel,
+    outcome: Outcome,
+) -> &'static OperationMetrics {
+    OPERATION_METRICS[operation_cell(operation, mode, state, outcome)]
+        .get_or_init(|| register_operation_metrics(operation, mode, state, outcome))
+}
+
+#[cfg(feature = "std")]
+fn record_operation(
+    operation: Operation,
+    mode: RuntimeModeLabel,
+    state: RuntimeStateLabel,
+    timer: &RuntimeTimer,
+    result: &ExecutionResult,
+) {
+    let metrics = operation_metrics(operation, mode, state, Outcome::from_result(result));
+    metrics.execution_seconds.record(timer.elapsed_seconds());
+    metrics.fuel_consumed.record(result.fuel_consumed as f64);
+    metrics
+        .fuel_refunded
+        .record(result.fuel_refunded.max(0) as f64);
+    metrics.output_bytes.record(result.output.len() as f64);
+    metrics
+        .return_data_bytes
+        .record(result.return_data.len() as f64);
+    metrics.total.increment(1);
+    if let Some(interruptions) = &metrics.interruptions {
+        interruptions.increment(1);
+    }
+}
+
 /// Records an execution that failed before the runtime could be constructed.
-pub fn record_initialization_error(mode: RuntimeModeLabel, state: &'static str, trap: TrapCode) {
+pub fn record_initialization_error(
+    mode: RuntimeModeLabel,
+    state: RuntimeStateLabel,
+    trap: TrapCode,
+) {
     #[cfg(feature = "std")]
     {
         metrics::counter!(
             "fluentbase_runtime_initialization_errors_total",
             "mode" => mode.as_str(),
-            "state" => state,
+            "state" => state.as_str(),
             "trap" => trap_label(trap),
         )
         .increment(1);
@@ -77,77 +311,79 @@ pub fn record_initialization_error(mode: RuntimeModeLabel, state: &'static str, 
 /// Records one fresh runtime execution.
 pub fn record_execution(
     mode: RuntimeModeLabel,
-    state: &'static str,
+    state: RuntimeStateLabel,
     timer: &RuntimeTimer,
     result: &ExecutionResult,
 ) {
-    let outcome = result_outcome(result);
     #[cfg(feature = "std")]
     {
         set_compilation_cache_fingerprint_version();
-        record_common("execution", mode, state, outcome, timer, result);
-        metrics::counter!(
-            "fluentbase_runtime_executions_total",
-            "mode" => mode.as_str(),
-            "state" => state,
-            "outcome" => outcome,
-        )
-        .increment(1);
-        if outcome == "interrupted" {
-            metrics::counter!(
-                "fluentbase_runtime_interruptions_total",
-                "mode" => mode.as_str(),
-                "state" => state,
-            )
-            .increment(1);
-        }
+        record_operation(Operation::Execution, mode, state, timer, result);
     }
 }
 
 /// Records one resume attempt.
 pub fn record_resume(
     mode: RuntimeModeLabel,
-    state: &'static str,
+    state: RuntimeStateLabel,
     timer: &RuntimeTimer,
     result: &ExecutionResult,
 ) {
-    let outcome = result_outcome(result);
     #[cfg(feature = "std")]
-    {
-        record_common("resume", mode, state, outcome, timer, result);
-        metrics::counter!(
-            "fluentbase_runtime_resumes_total",
-            "mode" => mode.as_str(),
-            "state" => state,
-            "outcome" => outcome,
-        )
-        .increment(1);
-        if outcome == "interrupted" {
-            metrics::counter!(
-                "fluentbase_runtime_interruptions_total",
-                "mode" => mode.as_str(),
-                "state" => state,
-            )
-            .increment(1);
-        }
-    }
+    record_operation(Operation::Resume, mode, state, timer, result);
 }
 
+#[cfg(feature = "std")]
+static FORGOTTEN_RUNTIMES: [OnceLock<Counter>; RuntimeModeLabel::COUNT * RuntimeStateLabel::COUNT] =
+    [const { OnceLock::new() }; RuntimeModeLabel::COUNT * RuntimeStateLabel::COUNT];
+
 /// Records that a suspended runtime was explicitly dropped.
-pub fn record_forget_runtime(mode: RuntimeModeLabel, state: &'static str) {
+pub fn record_forget_runtime(mode: RuntimeModeLabel, state: RuntimeStateLabel) {
     #[cfg(feature = "std")]
-    metrics::counter!(
-        "fluentbase_runtime_forgotten_total",
-        "mode" => mode.as_str(),
-        "state" => state,
-    )
-    .increment(1);
+    FORGOTTEN_RUNTIMES[mode.index() * RuntimeStateLabel::COUNT + state.index()]
+        .get_or_init(|| {
+            metrics::counter!(
+                "fluentbase_runtime_forgotten_total",
+                "mode" => mode.as_str(),
+                "state" => state.as_str(),
+            )
+        })
+        .increment(1);
 }
+
+#[cfg(feature = "std")]
+static RECOVERABLE_RUNTIMES: OnceLock<Gauge> = OnceLock::new();
 
 /// Publishes the current number of suspended runtimes held by the executor.
 pub fn set_recoverable_runtimes(count: usize) {
     #[cfg(feature = "std")]
-    metrics::gauge!("fluentbase_runtime_recoverable_runtimes").set(count as f64);
+    RECOVERABLE_RUNTIMES
+        .get_or_init(|| metrics::gauge!("fluentbase_runtime_recoverable_runtimes"))
+        .set(count as f64);
+}
+
+#[cfg(feature = "std")]
+fn backend_index(backend: CompilationBackend) -> usize {
+    match backend {
+        CompilationBackend::Rwasm => 0,
+        CompilationBackend::Wasmtime => 1,
+    }
+}
+
+#[cfg(feature = "std")]
+static SYSTEM_RUNTIME_CACHE_LOOKUPS: [OnceLock<Counter>; 4] = [const { OnceLock::new() }; 4];
+
+#[cfg(feature = "std")]
+fn system_runtime_cache_lookup_counter(
+    fingerprint: CompilationConfigFingerprint,
+    result: &'static str,
+) -> Counter {
+    metrics::counter!(
+        "fluentbase_system_runtime_cache_lookups_total",
+        "fingerprint_version" => fingerprint.version.to_string(),
+        "backend" => fingerprint.backend.as_str(),
+        "result" => result,
+    )
 }
 
 /// Records whether a system runtime instance cache lookup reused an exact compatible key.
@@ -156,13 +392,19 @@ pub fn record_system_runtime_cache_lookup(
     cache_hit: bool,
 ) {
     #[cfg(feature = "std")]
-    metrics::counter!(
-        "fluentbase_system_runtime_cache_lookups_total",
-        "fingerprint_version" => fingerprint.version.to_string(),
-        "backend" => fingerprint.backend.as_str(),
-        "result" => if cache_hit { "hit" } else { "miss" },
-    )
-    .increment(1);
+    {
+        let result = if cache_hit { "hit" } else { "miss" };
+        // Every fingerprint built by `from_config` carries the current version, which makes the
+        // handle cacheable by backend and result. Anything else keeps its exact labels.
+        if fingerprint.version == COMPILATION_CONFIG_FINGERPRINT_VERSION {
+            SYSTEM_RUNTIME_CACHE_LOOKUPS
+                [backend_index(fingerprint.backend) * 2 + cache_hit as usize]
+                .get_or_init(|| system_runtime_cache_lookup_counter(fingerprint, result))
+                .increment(1);
+        } else {
+            system_runtime_cache_lookup_counter(fingerprint, result).increment(1);
+        }
+    }
 }
 
 /// Records deterministic invalidation of a cached system runtime instance.
@@ -196,52 +438,15 @@ pub fn record_module_cache_hash_miss(reason: &'static str) {
     .increment(1);
 }
 
+#[cfg(feature = "std")]
+static COMPILATION_CACHE_FINGERPRINT_VERSION: OnceLock<Gauge> = OnceLock::new();
+
 /// Exposes the active cache-key version for operational dashboards.
 pub fn set_compilation_cache_fingerprint_version() {
     #[cfg(feature = "std")]
-    metrics::gauge!("fluentbase_compilation_cache_fingerprint_version")
+    COMPILATION_CACHE_FINGERPRINT_VERSION
+        .get_or_init(|| metrics::gauge!("fluentbase_compilation_cache_fingerprint_version"))
         .set(COMPILATION_CONFIG_FINGERPRINT_VERSION as f64);
-}
-
-#[cfg(feature = "std")]
-fn record_common(
-    operation: &'static str,
-    mode: RuntimeModeLabel,
-    state: &'static str,
-    outcome: &'static str,
-    timer: &RuntimeTimer,
-    result: &ExecutionResult,
-) {
-    let labels = [
-        ("operation", operation),
-        ("mode", mode.as_str()),
-        ("state", state),
-        ("outcome", outcome),
-    ];
-    metrics::histogram!("fluentbase_runtime_execution_seconds", &labels)
-        .record(timer.elapsed_seconds());
-    metrics::histogram!("fluentbase_runtime_fuel_consumed", &labels)
-        .record(result.fuel_consumed as f64);
-    metrics::histogram!("fluentbase_runtime_fuel_refunded", &labels)
-        .record(result.fuel_refunded.max(0) as f64);
-    metrics::histogram!("fluentbase_runtime_output_bytes", &labels)
-        .record(result.output.len() as f64);
-    metrics::histogram!("fluentbase_runtime_return_data_bytes", &labels)
-        .record(result.return_data.len() as f64);
-}
-
-fn result_outcome(result: &ExecutionResult) -> &'static str {
-    if result.exit_code > 0 {
-        "interrupted"
-    } else if result.exit_code == ExitCode::Ok.into_i32() {
-        "success"
-    } else if result.exit_code == ExitCode::OutOfFuel.into_i32() {
-        "out_of_fuel"
-    } else if result.exit_code == ExitCode::UnexpectedFatalExecutionFailure.into_i32() {
-        "fatal"
-    } else {
-        "reverted"
-    }
 }
 
 fn trap_label(trap: TrapCode) -> &'static str {
@@ -252,5 +457,155 @@ fn trap_label(trap: TrapCode) -> &'static str {
         TrapCode::StackOverflow => "stack_overflow",
         TrapCode::UnreachableCodeReached => "unreachable_code_reached",
         _ => "other",
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use metrics::{Key, KeyName, Metadata, Recorder, SharedString, Unit};
+    use std::{collections::BTreeSet, sync::Mutex};
+
+    const OPERATIONS: [Operation; Operation::COUNT] = [Operation::Execution, Operation::Resume];
+    const MODES: [RuntimeModeLabel; RuntimeModeLabel::COUNT] =
+        [RuntimeModeLabel::Contract, RuntimeModeLabel::System];
+    const STATES: [RuntimeStateLabel; RuntimeStateLabel::COUNT] = [
+        RuntimeStateLabel::Main,
+        RuntimeStateLabel::Deploy,
+        RuntimeStateLabel::Unknown,
+    ];
+    const OUTCOMES: [Outcome; Outcome::COUNT] = [
+        Outcome::Interrupted,
+        Outcome::Success,
+        Outcome::OutOfFuel,
+        Outcome::Fatal,
+        Outcome::Reverted,
+    ];
+
+    /// Captures every key registered through it as `kind name{label=value,...}`.
+    #[derive(Default)]
+    struct CaptureRecorder {
+        keys: Mutex<Vec<String>>,
+    }
+
+    impl CaptureRecorder {
+        fn capture(&self, kind: &str, key: &Key) {
+            let labels = key
+                .labels()
+                .map(|label| format!("{}={}", label.key(), label.value()))
+                .collect::<Vec<_>>()
+                .join(",");
+            self.keys
+                .lock()
+                .unwrap()
+                .push(format!("{kind} {}{{{labels}}}", key.name()));
+        }
+    }
+
+    impl Recorder for CaptureRecorder {
+        fn describe_counter(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+        fn describe_gauge(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+        fn describe_histogram(&self, _: KeyName, _: Option<Unit>, _: SharedString) {}
+        fn register_counter(&self, key: &Key, _: &Metadata<'_>) -> Counter {
+            self.capture("counter", key);
+            Counter::noop()
+        }
+        fn register_gauge(&self, key: &Key, _: &Metadata<'_>) -> Gauge {
+            self.capture("gauge", key);
+            Gauge::noop()
+        }
+        fn register_histogram(&self, key: &Key, _: &Metadata<'_>) -> Histogram {
+            self.capture("histogram", key);
+            Histogram::noop()
+        }
+    }
+
+    #[test]
+    fn every_label_combination_maps_to_a_distinct_cell() {
+        let mut cells = BTreeSet::new();
+        for operation in OPERATIONS {
+            for mode in MODES {
+                for state in STATES {
+                    for outcome in OUTCOMES {
+                        let cell = operation_cell(operation, mode, state, outcome);
+                        assert!(
+                            cell < OPERATION_CELLS,
+                            "{operation:?} {mode:?} {state:?} {outcome:?}"
+                        );
+                        assert!(cells.insert(cell), "cell {cell} reused");
+                    }
+                }
+            }
+        }
+        assert_eq!(cells.len(), OPERATION_CELLS);
+    }
+
+    #[test]
+    fn outcome_follows_the_exit_code() {
+        let result = |exit_code: i32| ExecutionResult {
+            exit_code,
+            ..Default::default()
+        };
+        assert_eq!(Outcome::from_result(&result(7)), Outcome::Interrupted);
+        assert_eq!(Outcome::from_result(&result(0)), Outcome::Success);
+        assert_eq!(
+            Outcome::from_result(&result(ExitCode::OutOfFuel.into_i32())),
+            Outcome::OutOfFuel
+        );
+        assert_eq!(
+            Outcome::from_result(&result(
+                ExitCode::UnexpectedFatalExecutionFailure.into_i32()
+            )),
+            Outcome::Fatal
+        );
+        assert_eq!(
+            Outcome::from_result(&result(ExitCode::Panic.into_i32())),
+            Outcome::Reverted
+        );
+    }
+
+    #[test]
+    fn registered_keys_keep_the_published_names_and_labels() {
+        let recorder = CaptureRecorder::default();
+        metrics::with_local_recorder(&recorder, || {
+            register_operation_metrics(
+                Operation::Resume,
+                RuntimeModeLabel::System,
+                RuntimeStateLabel::Main,
+                Outcome::Interrupted,
+            );
+        });
+        let labels = "operation=resume,mode=system,state=main,outcome=interrupted";
+        let expected = [
+            format!("histogram fluentbase_runtime_execution_seconds{{{labels}}}"),
+            format!("histogram fluentbase_runtime_fuel_consumed{{{labels}}}"),
+            format!("histogram fluentbase_runtime_fuel_refunded{{{labels}}}"),
+            format!("histogram fluentbase_runtime_output_bytes{{{labels}}}"),
+            format!("histogram fluentbase_runtime_return_data_bytes{{{labels}}}"),
+            "counter fluentbase_runtime_resumes_total{mode=system,state=main,outcome=interrupted}"
+                .to_string(),
+            "counter fluentbase_runtime_interruptions_total{mode=system,state=main}".to_string(),
+        ];
+        assert_eq!(*recorder.keys.lock().unwrap(), expected);
+    }
+
+    #[test]
+    fn successful_executions_register_no_interruption_counter() {
+        let recorder = CaptureRecorder::default();
+        let registered = metrics::with_local_recorder(&recorder, || {
+            register_operation_metrics(
+                Operation::Execution,
+                RuntimeModeLabel::Contract,
+                RuntimeStateLabel::Deploy,
+                Outcome::Success,
+            )
+        });
+        assert!(registered.interruptions.is_none());
+        let keys = recorder.keys.lock().unwrap();
+        assert_eq!(keys.len(), 6);
+        assert_eq!(
+            keys[5],
+            "counter fluentbase_runtime_executions_total{mode=contract,state=deploy,outcome=success}"
+        );
     }
 }

--- a/crates/runtime/src/module_factory.rs
+++ b/crates/runtime/src/module_factory.rs
@@ -43,14 +43,9 @@ impl ModuleFactory {
         let mut ctx = self.lock_cache();
         let code_hash = bytecode_or_hash.code_hash();
         let module_key = match &bytecode_or_hash {
-            BytecodeOrHash::Bytecode { address, .. } => CompiledModuleCacheKey::new(
-                code_hash,
-                CompilationConfigFingerprint::from_config(
-                    &fluentbase_sdk_config_for_runtime_cache(*address),
-                    CompilationBackend::Rwasm,
-                    *address,
-                ),
-            ),
+            BytecodeOrHash::Bytecode { address, .. } => {
+                CompiledModuleCacheKey::new(code_hash, runtime_cache_fingerprint(*address))
+            }
             BytecodeOrHash::Hash(_hash) => {
                 // Hash-only lookups are only valid after an earlier bytecode warmup. Keep this
                 // deterministic by resolving through the explicit code-hash index.
@@ -128,13 +123,29 @@ impl Default for ModuleFactoryInner {
     }
 }
 
-fn fluentbase_sdk_config_for_runtime_cache(
-    address: fluentbase_types::Address,
-) -> rwasm::CompilationConfig {
+/// Cache-key fingerprint of the compilation policy applied to a contract executed at `address`.
+///
+/// This runs on every frame, so it must stay allocation-free. The fingerprint covers only the
+/// policy flags and the address ([`CompilationConfigFingerprint::from_config`]); the import
+/// linker and the state router the real compilation config carries do not take part in it, so
+/// they are deliberately left out here. Building them would allocate a full import table per
+/// lookup, which was a fifth of the host-side cost of an EVM call.
+fn runtime_cache_fingerprint(address: fluentbase_types::Address) -> CompilationConfigFingerprint {
+    CompilationConfigFingerprint::from_config(
+        &runtime_cache_policy(address),
+        CompilationBackend::Rwasm,
+        address,
+    )
+}
+
+/// Compilation policy flags for a contract executed at `address`, mirroring the SDK defaults
+/// without the import linker and the state router (see [`runtime_cache_fingerprint`]).
+fn runtime_cache_policy(address: fluentbase_types::Address) -> rwasm::CompilationConfig {
     let is_system_runtime = fluentbase_types::is_execute_using_system_runtime(&address);
     let should_charge_fuel = false;
 
-    fluentbase_sdk_like_default_config()
+    rwasm::CompilationConfig::default()
+        .with_allow_malformed_entrypoint_func_type(is_system_runtime)
         .with_consume_fuel(should_charge_fuel)
         .with_consume_fuel_for_bulk_ops(!is_system_runtime)
         .with_consume_fuel_for_params_and_locals(!is_system_runtime)
@@ -144,24 +155,6 @@ fn fluentbase_sdk_config_for_runtime_cache(
         } else {
             rwasm::N_DEFAULT_MAX_MEMORY_PAGES
         })
-        .with_allow_malformed_entrypoint_func_type(is_system_runtime)
-}
-
-fn fluentbase_sdk_like_default_config() -> rwasm::CompilationConfig {
-    rwasm::CompilationConfig::default()
-        .with_state_router(rwasm::StateRouterConfig {
-            states: Box::new([
-                ("deploy".into(), fluentbase_types::STATE_DEPLOY),
-                ("main".into(), fluentbase_types::STATE_MAIN),
-            ]),
-            opcode: Some(rwasm::Opcode::Call(
-                fluentbase_types::SysFuncIdx::STATE as u32,
-            )),
-        })
-        .with_import_linker(fluentbase_types::import_linker_v1_preview())
-        .with_allow_malformed_entrypoint_func_type(false)
-        .with_consume_fuel_for_bulk_ops(true)
-        .with_builtins_consume_fuel(true)
 }
 
 /// Trait for estimating heap-allocated memory size of cached values.
@@ -356,12 +349,51 @@ mod tests {
     fn cache_key_with_address_byte(code_hash: B256, address_byte: u8) -> CompiledModuleCacheKey {
         CompiledModuleCacheKey::new(
             code_hash,
-            CompilationConfigFingerprint::from_config(
-                &fluentbase_sdk_like_default_config(),
-                CompilationBackend::Rwasm,
-                fluentbase_types::Address::repeat_byte(address_byte),
-            ),
+            runtime_cache_fingerprint(fluentbase_types::Address::repeat_byte(address_byte)),
         )
+    }
+
+    /// The full compilation config the SDK applies to a contract at `address`, including the
+    /// parts the fingerprint must ignore: the import linker and the state router.
+    fn full_runtime_config(address: fluentbase_types::Address) -> rwasm::CompilationConfig {
+        runtime_cache_policy(address)
+            .with_state_router(rwasm::StateRouterConfig {
+                states: Box::new([
+                    ("deploy".into(), fluentbase_types::STATE_DEPLOY),
+                    ("main".into(), fluentbase_types::STATE_MAIN),
+                ]),
+                opcode: Some(rwasm::Opcode::Call(
+                    fluentbase_types::SysFuncIdx::STATE as u32,
+                )),
+            })
+            .with_import_linker(fluentbase_types::import_linker_v1_preview())
+    }
+
+    #[test]
+    fn fingerprint_matches_the_full_compilation_config() {
+        for address in [
+            fluentbase_types::Address::repeat_byte(0x11),
+            fluentbase_types::PRECOMPILE_EVM_RUNTIME,
+            fluentbase_types::PRECOMPILE_WASM_RUNTIME,
+        ] {
+            let expected = CompilationConfigFingerprint::from_config(
+                &full_runtime_config(address),
+                CompilationBackend::Rwasm,
+                address,
+            );
+            assert_eq!(runtime_cache_fingerprint(address), expected, "{address}");
+        }
+    }
+
+    #[test]
+    fn system_and_user_policies_produce_distinct_fingerprints() {
+        let user = runtime_cache_fingerprint(fluentbase_types::Address::repeat_byte(0x11));
+        let system = runtime_cache_fingerprint(fluentbase_types::PRECOMPILE_EVM_RUNTIME);
+        assert!(!user.allow_malformed_entrypoint_func_type);
+        assert!(system.allow_malformed_entrypoint_func_type);
+        assert_eq!(user.max_allowed_memory_pages, rwasm::N_DEFAULT_MAX_MEMORY_PAGES);
+        assert_eq!(system.max_allowed_memory_pages, rwasm::N_MAX_ALLOWED_MEMORY_PAGES);
+        assert_ne!(user.stable_bytes(), system.stable_bytes());
     }
 
     fn new_cache(

--- a/crates/runtime/src/runtime/system_runtime.rs
+++ b/crates/runtime/src/runtime/system_runtime.rs
@@ -138,18 +138,9 @@ impl SystemRuntime {
         ctx: RuntimeContext,
         consume_fuel: bool,
     ) -> Result<Self, TrapCode> {
-        let config = system_runtime_compilation_config(import_linker.clone(), consume_fuel);
         let cache_key = CompiledModuleCacheKey::new(
             code_hash,
-            CompilationConfigFingerprint::from_config(
-                &config,
-                if cfg!(feature = "wasmtime") {
-                    CompilationBackend::Wasmtime
-                } else {
-                    CompilationBackend::Rwasm
-                },
-                address,
-            ),
+            system_runtime_fingerprint(address, consume_fuel),
         );
         let compiled_runtime = COMPILED_RUNTIMES.with_borrow_mut(|compiled_runtimes| {
             if let Some(compiled_runtime) = compiled_runtimes.get(&cache_key).cloned() {
@@ -161,6 +152,9 @@ impl SystemRuntime {
             }
             crate::metrics::record_system_runtime_cache_lookup(cache_key.config_fingerprint, false);
 
+            // The full config (with the import linker and the state router) is only needed to
+            // load the module, so it is built on the miss path alone.
+            let config = system_runtime_compilation_config(import_linker.clone(), consume_fuel);
             let executor = load_system_runtime(&rwasm_module.hint_section, config, import_linker)?;
 
             #[allow(clippy::arc_with_non_send_sync)]
@@ -509,16 +503,13 @@ fn require_entrypoint_abi(
         .ok_or(TrapCode::IllegalOpcode)
 }
 
-fn system_runtime_compilation_config(
-    import_linker: Arc<ImportLinker>,
-    consume_fuel: bool,
-) -> CompilationConfig {
+/// Compilation policy flags shared by every system runtime.
+///
+/// This is the part of the config the cache fingerprint is derived from; it carries no import
+/// linker and no state router, so computing a cache key stays allocation-free on the per-frame
+/// path. [`system_runtime_compilation_config`] adds the remaining pieces for actual loading.
+fn system_runtime_policy(consume_fuel: bool) -> CompilationConfig {
     CompilationConfig::default()
-        .with_state_router(StateRouterConfig {
-            states: Box::new([("deploy".into(), STATE_DEPLOY), ("main".into(), STATE_MAIN)]),
-            opcode: Some(Opcode::Call(SysFuncIdx::STATE as u32)),
-        })
-        .with_import_linker(import_linker)
         .with_allow_malformed_entrypoint_func_type(true)
         .with_consume_fuel(consume_fuel)
         // Wasmtime meters bulk operations itself; rWasm instrumentation would diverge.
@@ -526,6 +517,34 @@ fn system_runtime_compilation_config(
         .with_consume_fuel_for_params_and_locals(false)
         .with_builtins_consume_fuel(false)
         .with_max_allowed_memory_pages(N_MAX_ALLOWED_MEMORY_PAGES)
+}
+
+/// Cache-key fingerprint for the system runtime at `address` under the active backend.
+fn system_runtime_fingerprint(
+    address: Address,
+    consume_fuel: bool,
+) -> CompilationConfigFingerprint {
+    CompilationConfigFingerprint::from_config(
+        &system_runtime_policy(consume_fuel),
+        if cfg!(feature = "wasmtime") {
+            CompilationBackend::Wasmtime
+        } else {
+            CompilationBackend::Rwasm
+        },
+        address,
+    )
+}
+
+fn system_runtime_compilation_config(
+    import_linker: Arc<ImportLinker>,
+    consume_fuel: bool,
+) -> CompilationConfig {
+    system_runtime_policy(consume_fuel)
+        .with_state_router(StateRouterConfig {
+            states: Box::new([("deploy".into(), STATE_DEPLOY), ("main".into(), STATE_MAIN)]),
+            opcode: Some(Opcode::Call(SysFuncIdx::STATE as u32)),
+        })
+        .with_import_linker(import_linker)
 }
 
 #[cfg(test)]
@@ -560,6 +579,27 @@ mod tests {
 
         assert!(config.consume_fuel);
         assert!(!config.consume_fuel_for_bulk_ops);
+    }
+
+    #[test]
+    fn system_runtime_fingerprint_matches_the_full_compilation_config() {
+        for (address, consume_fuel) in [
+            (fluentbase_types::PRECOMPILE_EVM_RUNTIME, false),
+            (fluentbase_types::PRECOMPILE_WASM_RUNTIME, true),
+        ] {
+            let config =
+                system_runtime_compilation_config(import_linker_v1_preview(), consume_fuel);
+            let backend = if cfg!(feature = "wasmtime") {
+                CompilationBackend::Wasmtime
+            } else {
+                CompilationBackend::Rwasm
+            };
+            assert_eq!(
+                system_runtime_fingerprint(address, consume_fuel),
+                CompilationConfigFingerprint::from_config(&config, backend, address),
+                "{address} consume_fuel={consume_fuel}"
+            );
+        }
     }
 
     #[test]

--- a/crates/runtime/src/syscall_handler/host/read_input.rs
+++ b/crates/runtime/src/syscall_handler/host/read_input.rs
@@ -1,10 +1,8 @@
-//! Builtin to copy a slice of the input buffer into linear memory.
-use crate::syscall_handler::syscall_process_exit_code;
-use crate::RuntimeContext;
+use crate::{syscall_handler::syscall_process_exit_code, RuntimeContext};
+use core::{mem::take, ops::Range};
 use fluentbase_types::ExitCode;
 use rwasm::{StoreTr, TrapCode, Value};
 
-/// Reads [offset, offset+length) from `ctx.input` and writes it at target_ptr.
 pub fn syscall_read_input_handler(
     ctx: &mut impl StoreTr<RuntimeContext>,
     params: &[Value],
@@ -15,10 +13,30 @@ pub fn syscall_read_input_handler(
         params[1].i32().unwrap() as u32,
         params[2].i32().unwrap() as u32,
     );
-    let input = syscall_read_input_impl(ctx.data_mut(), offset, length)
+    let range = syscall_read_input_range(ctx.data(), offset, length)
         .map_err(|exit_code| syscall_process_exit_code(ctx, exit_code))?;
-    ctx.memory_write(target_ptr, &input)?;
-    Ok(())
+    // Write straight from the input buffer into guest memory. The buffer is taken out of the
+    // context for the duration of the write because the store borrows the context mutably.
+    let input = take(&mut ctx.data_mut().input);
+    let result = ctx.memory_write(target_ptr, &input[range]);
+    ctx.data_mut().input = input;
+    result
+}
+
+/// Validates `offset..offset + length` against the frame input and returns it as a range.
+pub fn syscall_read_input_range(
+    ctx: &RuntimeContext,
+    offset: u32,
+    length: u32,
+) -> Result<Range<usize>, ExitCode> {
+    let offset_length = offset
+        .checked_add(length)
+        .ok_or(ExitCode::InputOutputOutOfBounds)?;
+    if offset_length <= ctx.input.len() as u32 {
+        Ok(offset as usize..offset_length as usize)
+    } else {
+        Err(ExitCode::InputOutputOutOfBounds)
+    }
 }
 
 pub fn syscall_read_input_impl(
@@ -26,14 +44,8 @@ pub fn syscall_read_input_impl(
     offset: u32,
     length: u32,
 ) -> Result<Vec<u8>, ExitCode> {
-    let offset_length = offset
-        .checked_add(length)
-        .ok_or(ExitCode::InputOutputOutOfBounds)?;
-    if offset_length <= ctx.input.len() as u32 {
-        Ok(ctx.input[(offset as usize)..(offset as usize + length as usize)].to_vec())
-    } else {
-        Err(ExitCode::InputOutputOutOfBounds)
-    }
+    let range = syscall_read_input_range(ctx, offset, length)?;
+    Ok(ctx.input[range].to_vec())
 }
 
 #[cfg(test)]
@@ -45,5 +57,16 @@ mod tests {
         let mut ctx = RuntimeContext::default();
         let exit_code = syscall_read_input_impl(&mut ctx, u32::MAX, 100).unwrap_err();
         assert_eq!(exit_code, ExitCode::InputOutputOutOfBounds);
+    }
+
+    #[test]
+    fn range_is_bounded_by_the_input() {
+        let ctx = RuntimeContext::default().with_input(vec![1, 2, 3, 4]);
+        assert_eq!(syscall_read_input_range(&ctx, 1, 3), Ok(1..4));
+        assert_eq!(syscall_read_input_range(&ctx, 4, 0), Ok(4..4));
+        assert_eq!(
+            syscall_read_input_range(&ctx, 2, 3),
+            Err(ExitCode::InputOutputOutOfBounds)
+        );
     }
 }

--- a/crates/runtime/src/syscall_handler/host/read_output.rs
+++ b/crates/runtime/src/syscall_handler/host/read_output.rs
@@ -1,10 +1,8 @@
-//! Builtin to copy a slice of the current return_data into linear memory.
-use crate::syscall_handler::syscall_process_exit_code;
-use crate::RuntimeContext;
+use crate::{syscall_handler::syscall_process_exit_code, RuntimeContext};
+use core::{mem::take, ops::Range};
 use fluentbase_types::ExitCode;
 use rwasm::{StoreTr, TrapCode, Value};
 
-/// Reads [offset, offset+length) from ctx.execution_result.return_data and writes it at target_ptr.
 pub fn syscall_read_output_handler(
     ctx: &mut impl StoreTr<RuntimeContext>,
     params: &[Value],
@@ -15,10 +13,30 @@ pub fn syscall_read_output_handler(
         params[1].i32().unwrap() as u32,
         params[2].i32().unwrap() as u32,
     );
-    let input = syscall_read_output_impl(ctx.data_mut(), offset, length)
+    let range = syscall_read_output_range(ctx.data(), offset, length)
         .map_err(|exit_code| syscall_process_exit_code(ctx, exit_code))?;
-    ctx.memory_write(target_ptr, &input)?;
-    Ok(())
+    // Write straight from the return-data buffer into guest memory. The buffer is taken out of
+    // the context for the duration of the write because the store borrows the context mutably.
+    let return_data = take(&mut ctx.data_mut().execution_result.return_data);
+    let result = ctx.memory_write(target_ptr, &return_data[range]);
+    ctx.data_mut().execution_result.return_data = return_data;
+    result
+}
+
+/// Validates `offset..offset + length` against the return data and returns it as a range.
+pub fn syscall_read_output_range(
+    ctx: &RuntimeContext,
+    offset: u32,
+    length: u32,
+) -> Result<Range<usize>, ExitCode> {
+    let offset_length = offset
+        .checked_add(length)
+        .ok_or(ExitCode::InputOutputOutOfBounds)?;
+    if offset_length <= ctx.execution_result.return_data.len() as u32 {
+        Ok(offset as usize..offset_length as usize)
+    } else {
+        Err(ExitCode::InputOutputOutOfBounds)
+    }
 }
 
 pub fn syscall_read_output_impl(
@@ -26,18 +44,8 @@ pub fn syscall_read_output_impl(
     offset: u32,
     length: u32,
 ) -> Result<Vec<u8>, ExitCode> {
-    let offset_length = offset
-        .checked_add(length)
-        .ok_or(ExitCode::InputOutputOutOfBounds)?;
-    if offset_length <= ctx.execution_result.return_data.len() as u32 {
-        Ok(
-            ctx.execution_result.return_data
-                [(offset as usize)..(offset as usize + length as usize)]
-                .to_vec(),
-        )
-    } else {
-        Err(ExitCode::InputOutputOutOfBounds)
-    }
+    let range = syscall_read_output_range(ctx, offset, length)?;
+    Ok(ctx.execution_result.return_data[range].to_vec())
 }
 
 #[cfg(test)]
@@ -49,5 +57,17 @@ mod tests {
         let mut ctx = RuntimeContext::default();
         let exit_code = syscall_read_output_impl(&mut ctx, u32::MAX, 100).unwrap_err();
         assert_eq!(exit_code, ExitCode::InputOutputOutOfBounds);
+    }
+
+    #[test]
+    fn range_is_bounded_by_the_return_data() {
+        let mut ctx = RuntimeContext::default();
+        ctx.execution_result.return_data = vec![1, 2, 3, 4];
+        assert_eq!(syscall_read_output_range(&ctx, 1, 3), Ok(1..4));
+        assert_eq!(syscall_read_output_range(&ctx, 4, 0), Ok(4..4));
+        assert_eq!(
+            syscall_read_output_range(&ctx, 2, 3),
+            Err(ExitCode::InputOutputOutOfBounds)
+        );
     }
 }

--- a/crates/runtime/src/syscall_handler/host/resume.rs
+++ b/crates/runtime/src/syscall_handler/host/resume.rs
@@ -36,7 +36,7 @@ pub fn syscall_resume_handler(
     let (fuel_consumed, fuel_refunded, exit_code) = syscall_resume_impl(
         caller.data_mut(),
         call_id,
-        &return_data,
+        return_data,
         exit_code,
         fuel_consumed,
         fuel_refunded,
@@ -55,7 +55,7 @@ pub fn syscall_resume_handler(
 pub fn syscall_resume_impl(
     ctx: &mut RuntimeContext,
     call_id: u32,
-    return_data: &[u8],
+    return_data: Vec<u8>,
     exit_code: i32,
     fuel_consumed: u64,
     fuel_refunded: i64,

--- a/crates/runtime/src/syscall_handler/host/write_output.rs
+++ b/crates/runtime/src/syscall_handler/host/write_output.rs
@@ -1,23 +1,43 @@
-/// Builtin to append bytes to the runtime output buffer.
 use crate::RuntimeContext;
 use rwasm::{StoreTr, TrapCode, Value};
 
-/// Reads a slice from linear memory and appends it to ctx.execution_result.output.
 pub fn syscall_write_output_handler(
     caller: &mut impl StoreTr<RuntimeContext>,
     params: &[Value],
     _result: &mut [Value],
 ) -> Result<(), TrapCode> {
-    // Allocation safety invariant: the rWASM translator injects the `_write` linear fuel charge,
-    // including `length`, before this host handler can run. Each append is charged separately, so
-    // repeated writes are cumulatively bounded by the frame's remaining fuel. Keep the import's
-    // fuel procedure in sync with this allocation if the syscall is changed.
     let (offset, length) = (params[0].i32().unwrap(), params[1].i32().unwrap());
+    // The store validates the range against guest memory before it allocates the buffer.
     let data = caller.memory_read_into_vec(offset as usize, length as usize)?;
-    syscall_write_output_impl(caller.data_mut(), &data);
+    syscall_write_output_owned(caller.data_mut(), data);
     Ok(())
 }
 
 pub fn syscall_write_output_impl(ctx: &mut RuntimeContext, data: &[u8]) {
     ctx.execution_result.output.extend_from_slice(data);
+}
+
+/// Appends `data` to the frame output, adopting the buffer outright when the output is still
+/// empty. System runtimes write their whole envelope in a single call, so that write is copy-free.
+pub fn syscall_write_output_owned(ctx: &mut RuntimeContext, data: Vec<u8>) {
+    let output = &mut ctx.execution_result.output;
+    if output.is_empty() {
+        *output = data;
+    } else {
+        output.extend_from_slice(&data);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn owned_write_adopts_then_appends() {
+        let mut ctx = RuntimeContext::default();
+        syscall_write_output_owned(&mut ctx, vec![1, 2]);
+        syscall_write_output_owned(&mut ctx, vec![3]);
+        syscall_write_output_impl(&mut ctx, &[4]);
+        assert_eq!(ctx.execution_result.output, vec![1, 2, 3, 4]);
+    }
 }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -94,3 +94,7 @@ harness = false
 [[bench]]
 name = "greeting"
 harness = false
+
+[[bench]]
+name = "evmperf"
+harness = false

--- a/e2e/benches/evmperf.rs
+++ b/e2e/benches/evmperf.rs
@@ -1,0 +1,168 @@
+//! Throughput comparison of native revm against the rWasm-hosted EVM runtime on workloads that
+//! isolate the cost centers: pure interpretation, hashing syscalls, storage interruptions and a
+//! realistic ERC20 transfer.
+//!
+//! Run everything with `cargo bench -p fluentbase-e2e --bench evmperf --profile release`, or one
+//! case with `EVMPERF_CASE=<name> EVMPERF_MODE=<native|rwasm|reset> EVMPERF_ITERS=<n>` (the
+//! `reset` mode drops the cached system runtime before every call, as the node does per block).
+use fluentbase_e2e::EvmTestingContextWithGenesis;
+use fluentbase_runtime::runtime::SystemRuntime;
+use fluentbase_sdk::{Address, Bytes};
+use fluentbase_testing::{EvmTestingContext, TxBuilder};
+use hex_literal::hex;
+use std::time::Instant;
+
+const OWNER: Address = Address::ZERO;
+
+fn initcode_for(code: &[u8]) -> Bytes {
+    assert!(code.len() < 256);
+    let mut init = vec![
+        0x60,
+        code.len() as u8,
+        0x60,
+        0x0c,
+        0x60,
+        0x00,
+        0x39,
+        0x60,
+        code.len() as u8,
+        0x60,
+        0x00,
+        0xf3,
+    ];
+    init.extend_from_slice(code);
+    init.into()
+}
+
+/// Runtime code that repeats `body` `n` times:
+/// `PUSH2 n; JUMPDEST; <body>; PUSH1 1; SWAP1; SUB; DUP1; PUSH1 3; JUMPI; STOP`.
+fn loop_code(n: u16, body: &[u8]) -> Vec<u8> {
+    let mut code = vec![0x61, (n >> 8) as u8, n as u8, 0x5b];
+    code.extend_from_slice(body);
+    code.extend_from_slice(&[0x60, 0x01, 0x90, 0x03, 0x80, 0x60, 0x03, 0x57, 0x00]);
+    code
+}
+
+fn deploy(ctx: &mut EvmTestingContext, init: Bytes) -> Address {
+    let nonce = ctx.nonce(OWNER);
+    let result = TxBuilder::create(ctx, OWNER, init)
+        .gas_limit(10_000_000)
+        .exec();
+    assert!(result.is_success(), "deploy failed: {result:?}");
+    OWNER.create(nonce)
+}
+
+struct Case {
+    name: &'static str,
+    init: Bytes,
+    input: Bytes,
+    iters: usize,
+}
+
+fn run_case(native: bool, reset_per_call: bool, case: &Case) -> (f64, u64) {
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+    ctx.disabled_rwasm = native;
+    let addr = deploy(&mut ctx, case.init.clone());
+    // Warm up caches (compiled modules, instantiated runtimes, journal state).
+    for _ in 0..3 {
+        let r = ctx.call_evm_tx(OWNER, addr, case.input.clone(), Some(3_000_000), None);
+        assert!(r.is_success(), "{}: {:?}", case.name, r);
+    }
+    let mut gas = 0u64;
+    let start = Instant::now();
+    for _ in 0..case.iters {
+        if reset_per_call {
+            SystemRuntime::reset_cached_runtimes();
+        }
+        let r = ctx.call_evm_tx(OWNER, addr, case.input.clone(), Some(3_000_000), None);
+        gas += r.tx_gas_used();
+    }
+    let secs = start.elapsed().as_secs_f64();
+    (secs / case.iters as f64 * 1e6, gas / case.iters as u64)
+}
+
+fn main() {
+    let transfer: Bytes = hex!("a9059cbb00000000000000000000000011111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000000001").into();
+    let cases = vec![
+        Case {
+            name: "erc20_transfer",
+            init: hex::decode(include_bytes!("../assets/ERC20.bin"))
+                .unwrap()
+                .into(),
+            input: transfer,
+            iters: 2000,
+        },
+        Case {
+            name: "arith_loop_20k",
+            init: initcode_for(&loop_code(20_000, &[])),
+            input: Bytes::new(),
+            iters: 200,
+        },
+        Case {
+            name: "keccak_loop_10k",
+            // PUSH1 32 PUSH1 0 KECCAK256 POP
+            init: initcode_for(&loop_code(10_000, &[0x60, 0x20, 0x60, 0x00, 0x20, 0x50])),
+            input: Bytes::new(),
+            iters: 200,
+        },
+        Case {
+            name: "sload_loop_2k",
+            // PUSH1 0 SLOAD POP
+            init: initcode_for(&loop_code(2_000, &[0x60, 0x00, 0x54, 0x50])),
+            input: Bytes::new(),
+            iters: 100,
+        },
+        Case {
+            name: "sstore_loop_2k",
+            // DUP1 PUSH1 0 SSTORE
+            init: initcode_for(&loop_code(2_000, &[0x80, 0x60, 0x00, 0x55])),
+            input: Bytes::new(),
+            iters: 100,
+        },
+    ];
+    if let Ok(only) = std::env::var("EVMPERF_CASE") {
+        let mode = std::env::var("EVMPERF_MODE").unwrap_or_else(|_| "rwasm".into());
+        let iters: usize = std::env::var("EVMPERF_ITERS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1000);
+        let case = cases.iter().find(|c| c.name == only).expect("unknown case");
+        let case = Case {
+            name: case.name,
+            init: case.init.clone(),
+            input: case.input.clone(),
+            iters,
+        };
+        let (us, gas) = run_case(mode == "native", mode == "reset", &case);
+        println!(
+            "{} {} iters={} gas={} avg_us={:.1} Mgas/s={:.1}",
+            case.name,
+            mode,
+            iters,
+            gas,
+            us,
+            gas as f64 / us
+        );
+        return;
+    }
+    println!(
+        "{:<18} {:>10} {:>12} {:>12} {:>12} {:>10} {:>10}",
+        "case", "gas/tx", "native_us", "rwasm_us", "rwasm_reset", "slowdown", "rwasm_Mgas/s"
+    );
+    for case in &cases {
+        let (nat_us, gas) = run_case(true, false, case);
+        let (rw_us, gas2) = run_case(false, false, case);
+        let (rw_reset_us, _) = run_case(false, true, case);
+        assert_eq!(gas, gas2, "gas mismatch for {}", case.name);
+        println!(
+            "{:<18} {:>10} {:>12.1} {:>12.1} {:>12.1} {:>9.1}x {:>10.1}",
+            case.name,
+            gas,
+            nat_us,
+            rw_us,
+            rw_reset_us,
+            rw_us / nat_us,
+            gas as f64 / rw_us
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Profiling the rWasm-hosted EVM under wasmtime showed that most of the host-side cost of a call is bookkeeping rather than execution: a storage opcode round trip (yield out of the runtime, service it in revm, re-enter `main`) spent under 1% in the journal and about a fifth each in metrics key building and in allocation, and every new frame rebuilt a full import linker just to compute a cache fingerprint. This PR removes that overhead without touching the interruption protocol, gas accounting, or any consensus-visible behavior.

- **Cache fingerprints without an import linker.** `ModuleFactory::get_module_or_init` and `SystemRuntime::new` built a complete `CompilationConfig` (import linker with ~60 entries plus state router) per frame and discarded it. The fingerprint only reads policy flags and the address, so it is now derived from a linker-less policy config; the full config is built on the cache-miss path alone. Tests assert the fingerprints are identical to the ones derived from the full config.
- **Metric handles registered once per label set.** Execute/resume recorded five histograms and two counters through `histogram!`/`counter!` with owned labels on every call. Handles are now registered once per `(operation, mode, state, outcome)` and reused. Metric names and labels are unchanged (covered by a test with a capturing recorder). Handles bind to the recorder installed at first use; the node installs the Prometheus recorder during launch before genesis init and any execution.
- **Suspended runtimes behind a `Box`, resume data by value.** Every interruption cycle moved the whole `ExecutionMode` out of and back into `recoverable_runtimes` under a new call id, and copied the resume payload. Only a pointer moves now, and the caller's buffer is handed over instead of cloned (`Bytes` → `Vec` is copy-free when the buffer is uniquely owned).
- **Copy-free I/O syscalls.** `_read_input`/`_read_output` write directly from the context buffers into guest memory; `_write_output` adopts the guest's buffer when the output is still empty, which is the case for a system runtime's single envelope write.
- **Bench.** `e2e/benches/evmperf.rs` compares native revm with the rWasm-hosted EVM on workloads that isolate the cost centers and reports µs/call and Mgas/s.

## Numbers

`cargo bench -p fluentbase-e2e --bench evmperf --profile release`, Apple Silicon, `std,wasmtime`, before and after run back-to-back (µs per call):

| workload | gas/tx | native revm | rWasm before | rWasm after | change |
|---|---|---|---|---|---|
| ERC20 transfer | 35k | 3.3 | 17.9 / 17.4 | 11.4 / 11.8 | -35% (2.0 → 3.0 Ggas/s) |
| arithmetic loop, no host ops | 541k | 211 | 365 / 369 | 361 / 365 | unchanged |
| keccak loop | 721k | 1478 | 2865 / 2679 | 2698 / 2730 | unchanged |
| 2000 warm SLOADs | 285k | 43 | 2317 / 2317 | 1776 / 1765 | -24% (123 → 161 Mgas/s) |
| 2000 warm SSTOREs | 287k | 65 | 2272 / 2314 | 1731 / 1721 | -25% (125 → 166 Mgas/s) |

Per storage round trip that is 1.14 µs → 0.87 µs. The "reset" column of the bench (system runtime re-instantiated before every call, as the node does per block) is unchanged at ~2.7 ms for the ERC20 case; that cost is deliberately left alone here.

The remaining gap to native on storage-heavy code is the interruption protocol itself (one yield/re-enter per host-bound opcode), which stays as is. The next layer of overhead is inside the rwasm wasmtime backend and is out of scope here: `get_export("memory")`/`get_func("main")` string lookups on every call, a `Vec<Val>` per call, `get_fuel().is_ok()` building an error on every fuel touch, and untyped `func_new` imports.

## Testing

- `cargo clippy -p fluentbase-runtime -p fluentbase-revm -p fluentbase-e2e --all-targets --features std,wasmtime -- -D warnings`
- `cargo test -p fluentbase-runtime` with `std,wasmtime` and with `std` only
- `cargo test -p fluentbase-revm --features std,wasmtime`
- `cargo test -p fluentbase-e2e --release --features std,wasmtime` for the `evm`, `wasm`, `universal_token`, `exec_input`, `fuel` and `router` modules
