### PR TITLE
build(deps): bump rwasm to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12094,7 +12094,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12112,7 +12112,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -12124,7 +12124,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12140,7 +12140,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12155,7 +12155,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -12168,7 +12168,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "either",
@@ -12181,7 +12181,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12199,7 +12199,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "either",
@@ -12236,7 +12236,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12248,7 +12248,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12274,7 +12274,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12285,7 +12285,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -12716,9 +12716,9 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba058d30cf12de60276718864a5c31b05b53aab709297556e5a324093d013267"
+checksum = "d682b0223f1284ea3e7322654e6b22d243f25b0e0607c2fe5ec2e54509ee9ecc"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12094,7 +12094,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -12112,7 +12112,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "bitvec",
  "phf 0.13.1",
@@ -12124,7 +12124,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -12140,7 +12140,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -12155,7 +12155,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -12168,7 +12168,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -12181,7 +12181,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -12199,7 +12199,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -12236,7 +12236,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -12248,7 +12248,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12274,7 +12274,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -12285,7 +12285,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ fluentbase-types = { path = "./crates/types", default-features = false, version 
 #solana_rbpf = { path = "../rbpf", default-features = false }
 
 # rwasm
-rwasm = { version = "0.4.7", default-features = false }
+rwasm = { version = "0.5.0", default-features = false }
 
 # alloy
 alloy-primitives = { version = "1.5.6", default-features = false, features = ["map-foldhash", "sha3-keccak", "rlp"] }

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -3865,7 +3865,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "bitvec",
  "phf",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "either",
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "either",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -4180,9 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba058d30cf12de60276718864a5c31b05b53aab709297556e5a324093d013267"
+checksum = "d682b0223f1284ea3e7322654e6b22d243f25b0e0607c2fe5ec2e54509ee9ecc"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -3865,7 +3865,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "bitvec",
  "phf",
@@ -3895,7 +3895,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -3987,7 +3987,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4022,7 +4022,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip7928",
  "bitflags",

--- a/crates/runtime/src/runtime/system_runtime.rs
+++ b/crates/runtime/src/runtime/system_runtime.rs
@@ -442,37 +442,22 @@ fn compile_wasmtime(config: CompilationConfig, wasm: &[u8]) -> Result<WasmtimeMo
 
 /// Instantiates a compiled Wasmtime module through fallible APIs.
 ///
-/// rWasm 0.4.7's `WasmtimeExecutor` constructor panics on module-dependent errors, so it only
-/// ever receives a fixed, empty module to create the store and linker with the same resource
-/// limits; the supplied module is then instantiated into that store.
+/// A module that links or instantiates badly is reported as an error, never a panic: admission
+/// runs this on untrusted upgrade payloads, and the store limits derive from
+/// `N_MAX_ALLOWED_MEMORY_PAGES` rather than from the module contents.
 fn instantiate_wasmtime(
     module: &WasmtimeModule,
     import_linker: Arc<ImportLinker>,
 ) -> Result<WasmtimeExecutor<RuntimeContext>, TrapCode> {
-    let empty = WasmtimeModule::new(module.engine(), b"\0asm\x01\0\0\0")
-        .map_err(|_| TrapCode::IllegalOpcode)?;
-    let mut executor = WasmtimeExecutor::new(
-        empty,
+    WasmtimeExecutor::try_new(
+        module.clone(),
         import_linker,
         RuntimeContext::default(),
         runtime_syscall_handler,
         None,
         Some(N_MAX_ALLOWED_MEMORY_PAGES),
-    );
-    let instance_pre = executor
-        .linker
-        .instantiate_pre(module)
-        .map_err(|_| TrapCode::IllegalOpcode)?;
-    let instance = instance_pre
-        .instantiate(&mut executor.store)
-        .map_err(|_| TrapCode::IllegalOpcode)?;
-    // Replacing these fields relies on the rWasm 0.4.7 layout: the constructor derives the
-    // store limits from `max_allowed_memory_pages` and the linker from the engine and import
-    // linker, never from the module contents, so nothing else in the executor refers to the
-    // empty module.
-    executor.instance_pre = instance_pre;
-    executor.instance = instance;
-    Ok(executor)
+    )
+    .map_err(|_| TrapCode::IllegalOpcode)
 }
 
 /// Requires an exported entrypoint to be a function taking `params` i32 arguments and returning

--- a/docs/07-rwasm-integration.md
+++ b/docs/07-rwasm-integration.md
@@ -34,6 +34,12 @@ Fluentbase compilation config defines:
 
 System runtimes and user contracts intentionally compile with different constraints.
 
+Syscall fuel procedures (`crates/types/src/block_fuel.rs`) address the metered length parameter by
+its position among the import's parameters. rWasm 0.4.x read that position as a raw 32-bit stack
+depth; the fuel-alignment change that follows 0.5.0 counts it from the last parameter (`1` is the
+last one) and rejects out-of-range positions at compile time. Every metered Fluentbase syscall takes
+only `i32` parameters, so both rules resolve to the same slot and the table is valid under either.
+
 ---
 
 ## Execution contract
@@ -45,6 +51,10 @@ Fluentbase runtime executor owns:
 - `execute/resume/memory_read` bridge used by REVM interruption handler.
 
 This is the concrete runtime-host handshake point used in every interruption cycle.
+
+System runtimes are instantiated on Wasmtime through `WasmtimeExecutor::try_new`, so a hint that
+fails to link or instantiate is reported as an `IllegalOpcode` admission error instead of panicking
+the node.
 
 Structured system-runtime outcomes are decoded completely before the host applies their effects.
 Collection counts must fit the remaining encoded body before reservation or iteration; byte payloads

--- a/e2e/codec/Cargo.lock
+++ b/e2e/codec/Cargo.lock
@@ -1883,6 +1883,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -2236,6 +2238,15 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "mach2"
@@ -3253,15 +3264,16 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba058d30cf12de60276718864a5c31b05b53aab709297556e5a324093d013267"
+checksum = "d682b0223f1284ea3e7322654e6b22d243f25b0e0607c2fe5ec2e54509ee9ecc"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",
  "downcast-rs",
  "hashbrown 0.17.1",
  "libm",
+ "lru",
  "num-derive",
  "num-traits",
  "paste",

--- a/e2e/evm/Cargo.lock
+++ b/e2e/evm/Cargo.lock
@@ -3840,7 +3840,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "bitvec",
  "phf",
@@ -3870,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3998,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "revm-statetest-types"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip7928",
  "k256",

--- a/e2e/evm/Cargo.lock
+++ b/e2e/evm/Cargo.lock
@@ -3840,7 +3840,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3858,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "bitvec",
  "phf",
@@ -3870,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eips 1.8.3",
  "revm-bytecode",
@@ -3914,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "either",
@@ -3927,7 +3927,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "either",
@@ -3962,7 +3962,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3974,7 +3974,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3998,7 +3998,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -4009,7 +4009,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -4021,7 +4021,7 @@ dependencies = [
 [[package]]
 name = "revm-statetest-types"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip7928",
  "k256",
@@ -4173,9 +4173,9 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba058d30cf12de60276718864a5c31b05b53aab709297556e5a324093d013267"
+checksum = "d682b0223f1284ea3e7322654e6b22d243f25b0e0607c2fe5ec2e54509ee9ecc"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3763,7 +3763,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3781,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "bitvec",
  "phf",
@@ -3793,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "either",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "auto_impl",
  "either",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#8674122294c0332319d7cef2edcd96c1586a1c15"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -4078,9 +4078,9 @@ dependencies = [
 
 [[package]]
 name = "rwasm"
-version = "0.4.7"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba058d30cf12de60276718864a5c31b05b53aab709297556e5a324093d013267"
+checksum = "d682b0223f1284ea3e7322654e6b22d243f25b0e0607c2fe5ec2e54509ee9ecc"
 dependencies = [
  "bincode 2.0.1",
  "bitvec",

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -3763,7 +3763,7 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 [[package]]
 name = "revm"
 version = "38.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3781,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "10.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "bitvec",
  "phf",
@@ -3793,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "16.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "17.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "13.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3837,7 +3837,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "18.1.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "19.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "auto_impl",
  "either",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "35.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "34.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3920,7 +3920,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "23.0.0"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -3931,7 +3931,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "11.0.1"
-source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#5e87cd70c9a9bb753e868610b762c609aa67ad4a"
+source = "git+https://github.com/fluentlabs-xyz/revm-rwasm.git?branch=v107-patched#57e1bbd7abc5c43a32e9ca65a866bce90f1c80fc"
 dependencies = [
  "alloy-eip7928",
  "bitflags",


### PR DESCRIPTION
Bumps `rwasm` from 0.4.7 to 0.5.0 across the workspace and re-resolves every lockfile (root, `contracts/`, `examples/`, `e2e/evm/`, `e2e/codec/`) so each tree carries a single rwasm copy.

## Changes

- `Cargo.toml`: `rwasm = "0.5.0"`.
- Lockfiles: rwasm 0.5.0, revm fork pinned to the merged fluentlabs-xyz/revm-rwasm#61 commit.
- `crates/runtime/src/runtime/system_runtime.rs`: `instantiate_wasmtime` uses the new `WasmtimeExecutor::try_new`, which returns link/instantiation errors instead of panicking. This drops the 0.4.7 workaround that instantiated an empty module first and then swapped the executor's `instance_pre`/`instance` fields.
- `docs/07-rwasm-integration.md`: notes on the fallible instantiation path and on syscall fuel-parameter addressing.

No other call site needed changes: nothing in fluentbase used the removed `RwasmModule::new_verified*` / `RwasmModuleError` API, and `CompilationConfig`'s new `max_allowed_function_types` field does not affect emitted bytecode, so the compilation-cache fingerprint is unchanged.

## Fork dependency

The revm fork required `rwasm ^0.4.3`; fluentlabs-xyz/revm-rwasm#61 lifted it to `0.5.0` and is merged (squash commit `57e1bbd7` on `v107-patched`). The lockfiles here pin that commit.

## crates.io 0.5.0 vs. the `v0.5.0` tag

The `rwasm 0.5.0` package on crates.io was published from commit `64150919`, while the `v0.5.0` tag is `bd935e0b`. The difference is exactly rwasm#202 (fuel alignment with wasmtime-rwasm `45.0.0-rwasm.2`), so the published crate still depends on wasmtime-rwasm `45.0.0-rwasm.1`, keeps the raw stack-depth meaning of `LinearFuelParams::param_index`, and lacks the unbounded-fuel fix on the Wasmtime store. This PR builds against what `0.5.0` resolves to. Every metered fluentbase syscall takes only `i32` parameters, so `crates/types/src/block_fuel.rs` is valid under both addressing rules; if a corrected release is published from the tag, only the version string and the lockfiles change.

## Verification (release, `--locked`, Apple Silicon)

| Suite | Result |
| --- | --- |
| root workspace, `std,wasmtime` (nextest) | 898 passed, 13 skipped |
| root workspace, `std` (nextest) | 898 passed, 13 skipped |
| codec doctests, `std` | passed |
| `contracts/`, `std` | 211 passed, 2 skipped |
| `examples/`, `std` | 44 passed |
| `e2e/evm` `good_coverage_tests`, `std,wasmtime` and `std` | 33 passed each |
| `e2e/evm` `fixture`, `std,wasmtime` and `std` | 7 passed each |
| `e2e/evm` full `tests::` GeneralStateTests (ethereum/tests `faf33b47`), `std,wasmtime` and `std` | 2848 passed each |
| clippy `--all-targets --all-features -D warnings` (root, contracts, examples) | clean in the gating form (`--workspace --all-targets`); the `--all-features` form used by the non-blocking Lint job hits a pre-existing deprecation at `crates/testing/src/evm.rs:277` |

`e2e/codec/` was not run: its build script needs the generated corpus (`make vectors`) and it does not exercise rwasm; its lockfile is updated for consistency.

`cargo fmt --all -- --check` on stable 1.93.1 flags one pre-existing hunk in `crates/runtime/src/module_factory.rs` (unchanged here); the same job is non-blocking on `devel`.

Rebased onto `devel` after #541 moved the standalone suites under `e2e/`; the relocated lockfiles carry the same changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Runtime module linking and instantiation failures are now reported as `IllegalOpcode` errors instead of causing panics.
  - Runtime instantiation now applies memory limits consistently across modules.

- **Documentation**
  - Clarified syscall fuel handling and compatibility across supported runtime versions.
  - Documented how module linking and instantiation failures are surfaced during admission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->