### PR TITLE
docs: bring the examples and contracts READMEs in line with the tree

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,71 +1,149 @@
-# Fluentbase Contracts Workspace
+# Fluentbase Contracts
 
-This directory is a Cargo workspace that hosts a collection of smart contracts and precompiles built with the Fluentbase
-SDK. It includes cryptographic precompiles commonly used in EVM environments, example contracts, and integration
-utilities.
+This directory is the Cargo workspace for the system contracts that form the Fluent genesis file and ship in runtime
+upgrades: the EVM, WASM and token runtimes, the Ethereum precompiles, and the privileged contracts that manage a live
+chain. Every crate is written with the Fluentbase SDK, compiles to `wasm32-unknown-unknown`, and also builds as a
+normal Rust crate on the host so that its unit tests run without a node.
 
-## Structure
+The workspace is separate from the root workspace, but the root build drives it: the build script of `crates/contracts`
+compiles every member here to WASM and embeds the artifacts as `fluentbase_contracts::FLUENTBASE_CONTRACTS_<NAME>`,
+and `crates/genesis` maps those artifacts to their reserved addresses. A plain `cargo build` at the repository root
+therefore rebuilds everything in this directory.
 
-Each subfolder is an individual crate. Notable crates include:
+---
 
-- blake2f — BLAKE2f hashing precompile implementation.
-- bls12381 — BLS12-381 pairing-friendly curve precompile utilities.
-- bn256 — BN256 (alt_bn128) precompile utilities.
-- ecrecover — ECDSA public key recovery (secp256k1) precompile.
-- eip2935 — EIP-2935 related utilities (historical block hashes access helpers).
-- erc20 — Experimental ERC-20 token built on fluentbase-erc20.
-- evm — EVM runtime for running EVM-compatible applications.
-- identity — Simple identity contract.
-- kzg — KZG point evaluation precompile (EIP-4844).
-- modexp — Modular exponentiation precompile (EIP-198).
-- multicall — Batched/multicall helper contract.
-- nitro — A AWS Nitro attestation verifier.
-- ripemd160 — RIPEMD-160 precompile.
-- secp256r1 — secp256r1 (P-256) signature verification precompile (EIP-7212).
-- sha256 — SHA-256 hashing precompile.
-- svm — Solana VM (SVM) integration contracts.
-- wasm — A compiler form Wasm into rWasm (devnet & testnet only).
-- webauthn — WebAuthn verification helpers and tests.
+## Crates
+
+### Runtimes
+
+- `evm` — the EVM runtime. Executes EVM bytecode for every account that delegates to `PRECOMPILE_EVM_RUNTIME`. The
+  interpreter is pinned to a single hardfork (Osaka) and is replaced through `runtime-upgrade`, so EVM semantics are
+  upgraded forklessly.
+- `wasm` — the WASM runtime. Its deploy path compiles the submitted WASM module into rWasm, charges fuel per input
+  byte and rejects results larger than `RWASM_MAX_CODE_SIZE`.
+- `universal-token` — an ERC-20-style token runtime with a 4-byte selector ABI, ERC-2612 permits and optional
+  mintable/pausable plugins.
+- `svm` — the Solana VM runtime (loader v4). Excluded from the workspace and gated behind the `svm` feature of
+  `crates/contracts` and `crates/genesis` while SVM remains unstable (see the root README).
+
+### Ethereum precompiles
+
+Thin wrappers around `revm-precompile` or the SDK's crypto syscalls that mirror EVM gas rules:
+
+- `ecrecover` — secp256k1 public key recovery.
+- `sha256` — SHA-256.
+- `ripemd160` — RIPEMD-160.
+- `identity` — identity copy.
+- `modexp` — modular exponentiation (EIP-198, EIP-2565).
+- `bn256` — alt_bn128 addition, scalar multiplication and pairing.
+- `blake2f` — BLAKE2b F compression (EIP-152).
+- `kzg` — KZG point evaluation (EIP-4844).
+- `bls12381` — BLS12-381 G1/G2 addition, MSM, pairing and map-to-curve (EIP-2537). One crate serves all seven
+  addresses.
+- `eip7951` — secp256r1 (P-256) signature verification (EIP-7951, the successor of EIP-7212).
+
+### System and utility contracts
+
+- `eip2935` — the EIP-2935 ring buffer of recent block hashes.
+- `fee-manager` — collects protocol fees. The owner can withdraw the balance, transfer ownership or renounce it.
+- `runtime-upgrade` — privileged contract that replaces runtime and system contract bytecode on a live chain
+  (`upgradeTo`, `recompile`, `planUpgrade` and friends). Its README documents the authorization model.
+- `nitro` — AWS Nitro Enclaves attestation document verifier.
+- `webauthn` — WebAuthn assertion verification over P-256.
+- `create2-factory` — the deterministic deployment proxy. Not a Rust crate: it holds the Yul source and the EVM
+  bytecode that genesis places at the canonical factory address. Excluded from the workspace.
+
+Every Rust crate ships its own README and an `abi.json`.
+
+---
 
 ## Building
 
-You can build all contracts in this workspace from the contracts directory or the repository root:
+The recommended path is the root build, which compiles all contracts to WASM, converts them to rWasm and embeds them:
 
-- Build all crates in this workspace:
-  cargo build -p name-of-crate
-  or build all:
-  cargo build --workspace
+```bash
+make build # or: cargo build
+```
 
-- Release build tuned for WASM size/perf (see profiles in Cargo.toml):
-  cargo build --workspace --release
+To build a single contract by hand from this directory:
+
+```bash
+cargo build -p fluentbase-contracts-sha256 --release --target wasm32-unknown-unknown --no-default-features
+```
+
+The artifact lands in `target/contracts/wasm32-unknown-unknown/release/fluentbase_contracts_sha256.wasm` at the
+repository root. `.cargo/config.toml` sets that target directory and the rustflags every contract is built with
+(1 MiB stack, bulk memory, tail calls), and `--no-default-features` switches off the `std` feature that only exists
+for host-side tests.
+
+Reproducible builds run the WASM compilation inside the pinned `fluentbase-build` Docker image, which is what the
+release workflow does:
+
+```bash
+FLUENTBASE_CONTRACTS_DOCKER=true cargo build
+```
+
+`FLUENTBASE_BUILD_DOCKER_IMAGE`, `FLUENTBASE_BUILD_DOCKER_TAG` and `FLUENTBASE_BUILD_DOCKER_DIGEST` override the
+image, and `FLUENTBASE_CONTRACTS_IGNORE_DEFAULT_RUST_FLAGS` controls whether `fluentbase-build` injects its own
+rustflags on top of `.cargo/config.toml`. `make wasm_contracts_sizes` prints the size of every compiled contract.
+
+### Prerequisites
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+The toolchain version is pinned in the root `rust-toolchain.toml`.
+
+---
 
 ## Testing
 
-Many crates provide unit tests. Run tests for a specific crate:
-cargo test -p name-of-crate
-Or run all tests in the workspace:
-cargo test --workspace
+Unit tests run on the host with the `std` feature enabled (the default):
 
-## Workspace Configuration
+```bash
+cargo test -p fluentbase-contracts-sha256 # one crate
+cargo test --workspace                    # all crates
+```
 
-Shared configuration and dependencies are defined in contracts/Cargo.toml:
+`make test` at the repository root runs the same suites with `cargo nextest` in release mode, and `make clippy`
+lints this workspace with `-D warnings`; CI does both.
 
-- readme: README.md (this file)
-- Common dependencies:
-    - fluentbase-sdk, fluentbase-erc20, fluentbase-evm, fluentbase-svm
-    - revm-precompile (patched v82 branch)
-    - solana-program-error and solana-bincode (SVM integration)
-    - alloy-sol-types, serde, tiny-keccak, hex-literal, hex
-- Profiles:
-    - release: lto=fat, opt-level=3, panic=abort
-    - dev: optimized for small WASM binaries (opt-level="z", strip symbols)
+---
+
+## Workspace configuration
+
+`Cargo.toml` in this directory owns the shared configuration:
+
+- **Members** — every subdirectory except `.cargo`, `target`, `out` (output of the `fluentbase-build` CLI), `svm`
+  and `create2-factory`.
+- **Fluentbase crates** — `fluentbase-build`, `fluentbase-sdk`, `fluentbase-evm` and `fluentbase-testing`, all as
+  path dependencies into `../crates`, with `[patch.crates-io]` entries so that transitive dependencies resolve to
+  the same local copies.
+- **revm** — `revm-precompile` from the `fluentlabs-xyz/revm-rwasm` fork (`v107-patched` branch).
+- **Misc** — `alloy-sol-types`, `hex`, `k256`, `hashbrown`, `spin`, and `ecdsa` from the `rwasm-patches/signatures`
+  fork. `tiny-keccak` is patched to its `rwasm` branch.
+- **Features** — each crate exposes `default = ["std"]` for host tests and `debug-print` for runtime tracing. `evm`
+  additionally has `permissive-contract-size`, which the root build uses for a second, size-unlimited artifact.
+- **Profiles** — `release` is `lto = "fat"`, `opt-level = 3`, `panic = "abort"`, `codegen-units = 1`, stripped;
+  `dev` uses `opt-level = "z"` without debug info so that debug WASM binaries stay small.
+
+---
 
 ## Notes
 
-- These crates are designed to compile to no_std/WASM-friendly targets where applicable.
-- Some crates provide precompile logic compatible with EVM semantics via fluentbase-evm and revm-precompile.
+- Every crate starts with `#![cfg_attr(target_arch = "wasm32", no_std, no_main)]`: `no_std` on WASM, `std` on the
+  host.
+- Precompiles and runtimes use `system_entrypoint!` with a
+  `main_entry(sdk: &mut impl SystemAPI) -> Result<(), ExitCode>` (and an optional `deploy_entry`). Router-style
+  contracts such as `fee-manager` and `runtime-upgrade` use
+  `#[derive(Contract)]`, `#[router(mode = "solidity")]` and `basic_entrypoint!`, the same API as the
+  [examples](../examples/README.md).
+- Addresses live in `crates/types` as `PRECOMPILE_*` constants. The Ethereum precompiles keep their canonical
+  addresses (`0x01` to `0x11`, and `0x100` for EIP-7951), `eip2935` sits at the address the EIP specifies, and the
+  Fluent runtimes and system contracts occupy the reserved `0x…5200xx` range. The same module lists which addresses
+  the system runtime executes and which are metered by the engine.
 
 ## Repository
 
-For more information, visit the repository:
 https://github.com/fluentlabs-xyz/fluentbase

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,202 +1,237 @@
 # Examples
 
-========
+Example contracts written with the Fluentbase SDK. Each example is its own crate in a small Cargo workspace that is
+separate from the root workspace. Every crate compiles to a WASM contract for the Fluent network and also builds as a
+normal Rust crate on the host, so its unit tests run without a node.
 
-In this repository, we provide examples of running apps on the Fluent network.
-All these apps are developed using the Fluentbase SDK and can be proven with our circuits (coming soon).
+The root build embeds the examples as well: the build script of `crates/contracts` compiles every member of this
+workspace to `wasm32-unknown-unknown` and exposes the bytes as `fluentbase_contracts::FLUENTBASE_EXAMPLES_<NAME>`,
+which the runtime tests and benchmarks in `e2e/runtime` execute.
 
-To initialize, build, and deploy these examples, you can use the [gblend CLI](https://github.com/fluentlabs-xyz/gblend).
+---
 
-By the way, we also have a Makefile for building examples, so you can use it as well.
+## Layout
 
-## Creating a new app
+- `greeting` — the minimal contract: `entrypoint!` with a single `main_entry` that writes to the output.
+- `abi-solidity` — decoding and encoding Solidity ABI values by hand with `SolidityABI`.
+- `balance` — reading an account balance through `SharedAPI`.
+- `checkmate` — using an external `no_std` crate (the `shakmaty` chess engine) inside a contract.
+- `client-solidity` — `#[client(mode = "solidity")]`: typed clients for cross-contract calls.
+- `constructor-params` — a `deploy` entry that reads constructor input and persists it in storage.
+- `erc20` — a complete ERC-20 token: `#[router]`, `#[derive(Event)]`, `#[constructor]` and typed storage.
+- `json` — parsing JSON input with `serde_json_core`.
+- `keccak`, `sha256` — hashing through the SDK's crypto syscalls.
+- `memory-oom` — allocating the maximum allowed memory; exercises the runtime's out-of-memory path.
+- `panic` — what a `panic!` inside a contract looks like to the caller.
+- `router-solidity` — `#[router(mode = "solidity")]` with explicit `#[function_id]` selectors and ABI validation.
+- `rwasm` — compiling a WASM module into rWasm from inside a contract.
+- `secp256k1` — signature verification with the `libsecp256k1` crate.
+- `simple-storage` — storage reads and writes with `solidity_storage!`.
+- `storage` — an ERC-20 built on `solidity_storage!`; the source is currently commented out.
+- `storage-usage` — typed storage: `StorageMap`, `StorageVec`, `StorageString`, nested maps and custom slots.
+- `tiny-keccak` — running a third-party hashing crate. Prefer the SDK's `crypto_keccak256` in real contracts.
+- `unwiped-output` — output written before a later syscall is kept.
+- `svm` — Solana programs for the SVM runtime. Excluded from the workspace while SVM is unstable (see the root
+  README).
 
-### From scratch
+---
 
-To create your own repository with example, create an empty crate and add fluentbase SDK dependency.
-
-```bash
-cargo new hello_world --lib
-```
-
-Now put the following code into `src/lib.rs` file.
-
-```rust
-#![no_std]
-extern crate alloc;
-// this line is required to enable Fluentbase panic handlers and allocators
-extern crate fluentbase_sdk;
-
-use fluentbase_sdk::{SysPlatformSDK, SDK};
-
-#[no_mangle]
-extern "C" fn deploy() {}
-
-#[no_mangle]
-extern "C" fn main() {
-    let str = "Hello, World";
-    SDK::sys_write(str.as_bytes());
-}
-```
-
-As you can see, there are two functions that must be exported with exact names:
-
-- `deploy` - this function is called before creating app (similar to Solidity's constructor)
-- `main` - this one is getting called on each contract interaction
-
-To add Fluentbase SDK dependency add the following dep in your `Cargo.toml` file:
-
-```toml
-[dependencies]
-fluentbase-sdk = { git = "https://github.com/fluentlabs-xyz/fluentbase", default-features = false }
-```
-
-If you don't want to use EVM features then just disable `evm` feature flag.
-
-Additionally add these lines into your `Cargo.toml` file:
-
-```toml
-[profile.release]
-panic = "abort"
-lto = true
-opt-level = 'z'
-strip = true
-```
-
-### Using templates (with gblend)
-
-## Choose template
-
-The `gblend init` command helps you bootstrap new projects using templates:
-
-### List Templates
-
-```bash
-# List all available templates
-gblend init rust -l
-```
-
-### Creating New Project
-
-```bash
-# Initialize project from template
-gblend init rust -t greeting -p ./greeting
-```
-
-> [!NOTE]
-> Replace `greeting` with any template name and `./greeting` with your desired project path.
-
-### Post-Initialization Steps
-
-After project creation, you'll want to:
-
-1. Review the generated code in `lib.rs`
-2. [Build your project](#build)
-3. [Deploy your contract](#deploy)
-
-> [!TIP]
-> Templates provide a quick start with working examples and proper project structure. They're the recommended way to
-> begin new Fluent Network projects.
-
-## Build
-
-The `gblend build` command compiles your smart contracts for deployment:
-
-### Build Basic Usage
-
-```bash
-# Build project in release mode with .wat file generation
-gblend build rust -r --wat
-```
-
-### Build Options
-
-- Use `-r, --release` for optimized release builds
-- Add `--wat` to generate WebAssembly text format
-- Specify custom path with `-p, --path`
-
-### Using Makefiles
-
-The repository uses a two-level Makefile structure:
-
-1. Root Makefile for building all examples:
-
-```bash
-# Build all examples
-make all
-
-# Build specific example
-make greeting
-make keccak256
-```
-
-2. Each example has its own Makefile with WASM compilation settings
-
-### Project Structure
-
-For simplicity, all examples are stored inside one crate and managed through Cargo features.
-
-> [!NOTE]
-> When adding new examples, remember to update both `Cargo.toml` and `Makefile` with your new features.
+## Building
 
 ### Prerequisites
-
-Install the required WebAssembly target:
 
 ```bash
 rustup target add wasm32-unknown-unknown
 ```
 
-> [!NOTE]
-> Your compiled WASM binary will be located at `target/wasm32-unknown-unknown/release/<name>.wasm`
+The toolchain version is pinned in the root `rust-toolchain.toml`.
 
-> [!TIP]
-> Use `wasm2wat` tool to inspect the WebAssembly text format of your compiled binary:
->
-> ```bash
-> wasm2wat target/wasm32-unknown-unknown/release/hello_world.wasm
-> ```
+### Build an example
 
-The next step is to [deploy your contract](#deploy).
-
-## Deploy
-
-The `gblend deploy` command provides several options for deploying your application:
-
-### Network Selection
-
-- Use `--local` for deploying to a local network
-- Use `--dev` for deploying to the development network
-- Specify a custom RPC endpoint with `--rpc <URL>` and `--chain-id <CHAIN_ID>` for other networks
-
-### Authentication
-
-You can provide your private key in several ways:
-
-1. Command line: `--private-key <KEY>`
-2. Environment variable: `DEPLOY_PRIVATE_KEY`
-3. Environment file: Create `.env` file with `DEPLOY_PRIVATE_KEY=<your-key>`
-
-### Deploy Basic Usage
+From this directory:
 
 ```bash
-# Deploy to local network
-gblend deploy --local path/to/contract.wasm
-
-# Deploy to devnet
-gblend deploy --dev path/to/contract.wasm
-
-# Deploy with custom RPC
-gblend deploy --rpc https://your-node.network --chain-id 1234 path/to/contract.wasm
+cargo build -p fluentbase-examples-greeting --release --target wasm32-unknown-unknown --no-default-features
 ```
 
-> [!TIP]
-> Using environment files is recommended for managing private keys securely. Create a `.env` file in your project root:
+The artifact lands in `target/contracts/wasm32-unknown-unknown/release/fluentbase_examples_greeting.wasm` at the
+repository root (`.cargo/config.toml` points the target directory there). `--no-default-features` switches off the
+`std` feature, which exists only for host-side tests.
+
+`make build` at the repository root compiles every example the same way as part of the contracts build.
+
+> Tip: `wasm2wat` from [wabt](https://github.com/WebAssembly/wabt) prints the text form of a compiled contract, which
+> is a quick way to check its imports and exports:
 >
-> ```
-> DEPLOY_PRIVATE_KEY=0x...
+> ```bash
+> wasm2wat target/contracts/wasm32-unknown-unknown/release/fluentbase_examples_greeting.wasm
 > ```
 
-> [!NOTE]
-> Additional parameters like `gas-limit`, `gas-price`, and `confirmations` can also be configured through environment
-> variables or command line flags.
+---
+
+## Testing
+
+Unit tests run on the host against `fluentbase_testing::TestingContextImpl`, an in-memory implementation of the SDK:
+
+```bash
+cargo test -p fluentbase-examples-greeting # one example
+cargo test --workspace                     # all examples
+```
+
+`make test` at the repository root runs the same suites with `cargo nextest` in release mode, and `make clippy` lints
+this workspace with `-D warnings`; CI does both.
+
+---
+
+## Creating a new app
+
+### Cargo.toml
+
+Create a library crate and depend on the published SDK; that is all the contract itself needs. Unit tests additionally
+need `fluentbase-testing`, which is not on crates.io, so pull it from the repository. It brings the SDK and the runtime
+from the same checkout, so patch the registry SDK to that source as well and only one copy of the crate ends up in the
+build:
+
+```toml
+[package]
+name = "hello-world"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+fluentbase-sdk = { version = "1.4.2", default-features = false }
+
+[dev-dependencies]
+fluentbase-testing = { git = "https://github.com/fluentlabs-xyz/fluentbase", branch = "devel" }
+
+[features]
+default = ["std"]
+std = ["fluentbase-sdk/std", "fluentbase-testing/std"]
+
+[profile.release]
+panic = "abort"
+lto = "fat"
+opt-level = 3
+strip = true
+codegen-units = 1
+
+[patch.crates-io]
+fluentbase-sdk = { git = "https://github.com/fluentlabs-xyz/fluentbase", branch = "devel" }
+```
+
+> Note: use the default branch rather than a release tag for the git dependencies. The workspace references the
+> `revm-rwasm` fork by branch, so an older tag can fall out of step with it; `v1.4.2` already no longer builds on the
+> host against the current fork.
+
+### Function entrypoint
+
+The simplest contract is a function that receives the SDK and writes to the output. `entrypoint!` expands into the
+`main` and `deploy` exports the runtime calls, plus the panic handler and allocator a `no_std` WASM binary needs:
+
+```rust
+#![cfg_attr(target_arch = "wasm32", no_std, no_main)]
+extern crate alloc;
+extern crate fluentbase_sdk;
+
+use fluentbase_sdk::{entrypoint, SharedAPI};
+
+pub fn main_entry(mut sdk: impl SharedAPI) {
+    sdk.write("Hello, World".as_bytes());
+}
+
+entrypoint!(main_entry);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fluentbase_testing::TestingContextImpl;
+
+    #[test]
+    fn test_contract_works() {
+        let sdk = TestingContextImpl::default();
+        main_entry(sdk.clone());
+        assert_eq!(&sdk.take_output(), "Hello, World".as_bytes());
+    }
+}
+```
+
+- `main` runs on every call to the contract.
+- `deploy` runs once when the contract is created, like a Solidity constructor. Pass a second function to
+  `entrypoint!(main_entry, deploy_entry)` to handle it; see `constructor-params`.
+
+### Solidity-compatible router
+
+For a contract with several methods, describe them as a trait and let `#[router(mode = "solidity")]` generate the
+selector dispatch and ABI codec. `#[derive(Contract)]` provides the `new` constructor and `basic_entrypoint!` wires
+`deploy` and `main` to the struct:
+
+```rust
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
+extern crate alloc;
+extern crate fluentbase_sdk;
+
+use alloc::string::String;
+use fluentbase_sdk::{
+    basic_entrypoint,
+    derive::{router, Contract},
+    SharedAPI,
+};
+
+#[derive(Contract)]
+struct App<SDK> {
+    sdk: SDK,
+}
+
+pub trait RouterAPI {
+    fn greeting(&self, message: String) -> String;
+}
+
+#[router(mode = "solidity")]
+impl<SDK: SharedAPI> RouterAPI for App<SDK> {
+    #[function_id("greeting(string)")]
+    fn greeting(&self, message: String) -> String {
+        message
+    }
+}
+
+impl<SDK: SharedAPI> App<SDK> {
+    pub fn deploy(&self) {
+        // any custom deployment logic here
+    }
+}
+
+basic_entrypoint!(App);
+```
+
+`router-solidity` shows the full version with selector validation and tests that compare the generated calldata
+against `alloy-sol-types`, and `erc20` adds events, a constructor and typed storage on top.
+
+### Build and test
+
+```bash
+cargo test
+cargo build --release --target wasm32-unknown-unknown --no-default-features
+```
+
+The contract is at `target/wasm32-unknown-unknown/release/hello_world.wasm`.
+
+---
+
+## Deploying
+
+[gblend](https://github.com/fluentlabs-xyz/gblend) is the CLI for Fluent applications. It is a fork of Foundry's
+`forge` that understands WASM contracts, so it scaffolds, builds, deploys and verifies both Rust and Solidity code:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/fluentlabs-xyz/gblend/refs/tags/latest/gblendup/install | bash
+gblendup
+
+gblend init my-project          # scaffold a blended Rust + Solidity project
+gblend build                    # compile everything in it
+gblend create my_contract.wasm --wasm --rpc-url https://rpc.testnet.fluent.xyz --private-key $PRIVATE_KEY --broadcast
+```
+
+The full set of commands, templates and verification flags is documented at https://docs.fluent.xyz/gblend/usage.


### PR DESCRIPTION
## Summary

- `examples/README.md`: replaces the pre-1.0 SDK snippet (`SysPlatformSDK`, `#[no_mangle]` exports, git SDK dependency) with the current `entrypoint!`/`SharedAPI` and `Contract`/`router`/`basic_entrypoint!` APIs as used by `greeting` and `router-solidity`, lists every example crate, documents the cargo build/test commands and how the root build embeds the examples for `e2e/runtime`, and updates the gblend section to the current `init`/`build`/`create --wasm` flow (the old `init rust`, `build rust --wat` and `deploy --local` subcommands no longer exist).
- `contracts/README.md`: the crate list now matches the 20 directories (drops `erc20`, `multicall`, `secp256r1`; adds `create2-factory`, `eip7951`, `fee-manager`, `runtime-upgrade`, `universal-token`; marks `svm` and `create2-factory` as excluded from the workspace), and the dependency, feature, profile and address sections mirror `contracts/Cargo.toml` and `crates/types`.

No code changes.

## Verification

- From `examples/`: `cargo build -p fluentbase-examples-greeting --release --target wasm32-unknown-unknown --no-default-features` and `cargo test -p fluentbase-examples-greeting`.
- From `contracts/`: `cargo build -p fluentbase-contracts-sha256 --release --target wasm32-unknown-unknown --no-default-features` and `cargo test -p fluentbase-contracts-sha256`.
- The new-app `Cargo.toml` was exercised in a scratch crate outside the repo: `fluentbase-sdk = "1.4.2"` from crates.io builds the wasm, and `fluentbase-testing` from `branch = "devel"` plus a `[patch.crates-io]` entry for the SDK runs the unit test. Pinning the git dependencies to the `v1.4.2` tag fails on the host because the tag uses rwasm 0.4.7 while the `revm-rwasm` branch it references moved to 0.5.0; the README notes this.
- gblend commands checked against the gblend repository README and https://docs.fluent.xyz/gblend/usage.
