### PR TITLE
fix(evm): allow CALLCODE with value inside static calls

### DIFF
--- a/crates/evm/src/opcodes.rs
+++ b/crates/evm/src/opcodes.rs
@@ -616,13 +616,6 @@ fn call_code<
     let to = to.into_address();
     // Max gas limit is not possible in a real ethereum situation.
     let local_gas_limit = u64::try_from(local_gas_limit).unwrap_or(u64::MAX);
-    let has_transfer = !value.is_zero();
-    if context.interpreter.runtime_flag.is_static() && has_transfer {
-        context
-            .interpreter
-            .halt(InstructionResult::CallNotAllowedInsideStatic);
-        return;
-    }
     let Some(in_range) = get_memory_input_range(&mut context) else {
         return;
     };

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -476,9 +476,6 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             let value = U256::from_le_slice(&input[20..52]);
             let has_transfer = !value.is_zero();
             debug_syscall!("CALL_CODE", "to={:?} value={:?}", target_address, value);
-            if is_static && has_transfer {
-                return_halt!(StateChangeDuringStaticCall);
-            }
             charge_regular_gas!(gas::WARM_STORAGE_READ_COST);
             if has_transfer {
                 charge_regular_gas!(ctx.gas_params().transfer_value_cost());
@@ -498,7 +495,7 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             );
             charge_regular_gas!(gas_limit);
             // Add a call stipend if there is a value to be transferred.
-            if !value.is_zero() {
+            if has_transfer {
                 gas_limit = gas_limit.saturating_add(ctx.cfg().gas_params().call_stipend());
             }
             inspect!(

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -1775,3 +1775,91 @@ mod eip8037_state_gas_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod static_call_frame_tests {
+    use super::*;
+    use fluentbase_sdk::{
+        syscall::{SYSCALL_ID_CALL, SYSCALL_ID_CALL_CODE},
+        FUEL_DENOM_RATE,
+    };
+    use revm::{
+        handler::system_interruption::SystemInterruptionInputs,
+        interpreter::{CallScheme, CallValue, FrameInput},
+    };
+
+    const CONTRACT: Address = address!("2222222222222222222222222222222222222222");
+    const CALLEE: Address = address!("3333333333333333333333333333333333333333");
+    const GAS_LIMIT: u64 = 1_000_000;
+
+    /// Raises a CALL-family syscall from a frame executing `CONTRACT` and returns what the host
+    /// decided to do next.
+    fn execute_call_syscall(code_hash: B256, is_static: bool, value: U256) -> NextAction {
+        let mut ctx: RwasmContext<InMemoryDB> =
+            RwasmContext::new(InMemoryDB::default(), RwasmSpecId::PRAGUE);
+        ctx.cfg = CfgEnv::new_with_spec(RwasmSpecId::PRAGUE);
+        ctx.block = BlockEnv::default();
+        ctx.tx = TxEnv::default();
+
+        let mut frame = RwasmFrame::default();
+        frame.interpreter.input.target_address = CONTRACT;
+        frame.interpreter.runtime_flag.is_static = is_static;
+        frame.interpreter.gas = Gas::new(GAS_LIMIT);
+
+        let mut input = vec![0u8; 52];
+        input[0..20].copy_from_slice(CALLEE.as_slice());
+        input[20..52].copy_from_slice(&value.to_le_bytes::<32>());
+        let mr = ForwardInputMemoryReader(input.into());
+
+        let interruption_inputs = SystemInterruptionInputs {
+            call_id: 0,
+            code_hash,
+            input: 0..mr.0.len(),
+            fuel_limit: GAS_LIMIT * FUEL_DENOM_RATE,
+            state: STATE_MAIN,
+            fuel16_ptr: 0,
+            gas: Gas::new(GAS_LIMIT),
+            preloaded_slot_costs: None,
+        };
+        execute_rwasm_interruption::<_, NoOpInspector>(
+            &mut frame,
+            None,
+            &mut ctx,
+            interruption_inputs,
+            mr,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn call_code_with_value_inside_static_frame_opens_a_frame() {
+        // CALLCODE moves the value from the caller to itself, so EIP-214 does not forbid it inside
+        // a static context the way it forbids CALL with value.
+        let NextAction::NewFrame(FrameInput::Call(inputs)) =
+            execute_call_syscall(SYSCALL_ID_CALL_CODE, true, U256::ONE)
+        else {
+            panic!("CALLCODE with value must open a call frame inside a static context");
+        };
+        assert_eq!(inputs.scheme, CallScheme::CallCode);
+        assert!(
+            inputs.is_static,
+            "the static flag must propagate into the callee frame"
+        );
+        assert_eq!(inputs.value, CallValue::Transfer(U256::ONE));
+        assert_eq!(inputs.target_address, CONTRACT);
+        assert_eq!(inputs.caller, CONTRACT);
+        assert_eq!(inputs.bytecode_address, CALLEE);
+    }
+
+    #[test]
+    fn call_with_value_inside_static_frame_halts() {
+        let NextAction::Return(result) = execute_call_syscall(SYSCALL_ID_CALL, true, U256::ONE)
+        else {
+            panic!("CALL with value must halt inside a static context");
+        };
+        assert_eq!(
+            result.result,
+            InstructionResult::StateChangeDuringStaticCall
+        );
+    }
+}

--- a/e2e/runtime/src/evm.rs
+++ b/e2e/runtime/src/evm.rs
@@ -653,21 +653,27 @@ fn extcodecopy_bytecode(callee: Address, memory_offset: U256, len: U256) -> Vec<
     bytecode
 }
 
-/// A call opcode with the given output range. `CALL`/`CALLCODE` also take a (zero) value argument.
-fn call_bytecode(op: u8, callee: Address, out_offset: U256, out_len: U256) -> Vec<u8> {
+/// The argument pushes and the call opcode itself; `CALL`/`CALLCODE` also take `value`.
+fn call_args(op: u8, callee: Address, value: U256, out_offset: U256, out_len: U256) -> Vec<u8> {
     let mut bytecode = Vec::new();
     push_u256(&mut bytecode, out_len);
     push_u256(&mut bytecode, out_offset);
     bytecode.push(opcode::PUSH0); // args length
     bytecode.push(opcode::PUSH0); // args offset
     if op == opcode::CALL || op == opcode::CALLCODE {
-        bytecode.push(opcode::PUSH0); // value
+        push_u256(&mut bytecode, value);
     }
     bytecode.push(opcode::PUSH20);
     bytecode.extend_from_slice(callee.as_slice());
     bytecode.push(opcode::PUSH2); // forwarded gas
     bytecode.extend_from_slice(&[0xff, 0xff]);
     bytecode.push(op);
+    bytecode
+}
+
+/// A call opcode with the given output range and no value, followed by `STOP`.
+fn call_bytecode(op: u8, callee: Address, out_offset: U256, out_len: U256) -> Vec<u8> {
+    let mut bytecode = call_args(op, callee, U256::ZERO, out_offset, out_len);
     bytecode.push(opcode::STOP);
     bytecode
 }
@@ -785,4 +791,85 @@ fn test_nonzero_length_call_output_rejects_unrepresentable_offset() {
             "opcode {op:#04x} must reject an unrepresentable output length"
         );
     }
+}
+
+/// A `CALL`/`CALLCODE` forwarding `value` to `callee`; returns the call's success flag as a word.
+fn value_call_bytecode(op: u8, callee: Address, value: U256) -> Vec<u8> {
+    let mut bytecode = call_args(op, callee, value, U256::ZERO, U256::ZERO);
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::MSTORE);
+    bytecode.extend_from_slice(&[opcode::PUSH1, 32]);
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::RETURN);
+    bytecode
+}
+
+/// A `STATICCALL` into `callee`; returns the callee's 32-byte output followed by the static
+/// call's own success flag.
+fn staticcall_bytecode(callee: Address) -> Vec<u8> {
+    let mut bytecode = call_args(
+        opcode::STATICCALL,
+        callee,
+        U256::ZERO,
+        U256::ZERO,
+        U256::from(32),
+    );
+    bytecode.extend_from_slice(&[opcode::PUSH1, 32]);
+    bytecode.push(opcode::MSTORE);
+    bytecode.extend_from_slice(&[opcode::PUSH1, 64]);
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::RETURN);
+    bytecode
+}
+
+/// Runs `op` with a one-wei value from inside a `STATICCALL` frame and returns the inner call's
+/// success flag together with the static call's own success flag.
+fn run_value_call_inside_staticcall(op: u8) -> (U256, U256) {
+    const CALLER_ADDRESS: Address = Address::repeat_byte(0x11);
+    const OUTER_ADDRESS: Address = Address::repeat_byte(0x22);
+    const INNER_ADDRESS: Address = Address::repeat_byte(0x33);
+    const TARGET_ADDRESS: Address = Address::repeat_byte(0x44);
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+    ctx.add_evm_contract(TARGET_ADDRESS, [opcode::STOP]);
+    ctx.add_evm_contract(
+        INNER_ADDRESS,
+        value_call_bytecode(op, TARGET_ADDRESS, U256::ONE),
+    );
+    ctx.add_evm_contract(OUTER_ADDRESS, staticcall_bytecode(INNER_ADDRESS));
+    ctx.add_balance(INNER_ADDRESS, U256::ONE);
+    let result = ctx.call_evm_tx(
+        CALLER_ADDRESS,
+        OUTER_ADDRESS,
+        Bytes::new(),
+        Some(1_000_000),
+        None,
+    );
+    assert!(result.is_success(), "{result:?}");
+    let output = result.output().unwrap();
+    assert_eq!(output.len(), 64);
+    (
+        U256::from_be_slice(&output[..32]),
+        U256::from_be_slice(&output[32..]),
+    )
+}
+
+#[test]
+fn test_callcode_with_value_is_allowed_inside_staticcall() {
+    // CALLCODE only moves the value from the calling account to itself, so EIP-214 does not
+    // forbid it inside a static context the way it forbids CALL with value.
+    assert_eq!(
+        run_value_call_inside_staticcall(opcode::CALLCODE),
+        (U256::ONE, U256::ONE),
+        "CALLCODE with value must succeed inside a static call"
+    );
+}
+
+#[test]
+fn test_call_with_value_is_rejected_inside_staticcall() {
+    // The inner frame halts on the CALL, so the STATICCALL fails and its output stays zeroed.
+    assert_eq!(
+        run_value_call_inside_staticcall(opcode::CALL),
+        (U256::ZERO, U256::ZERO),
+        "CALL with value must still fail inside a static call"
+    );
 }


### PR DESCRIPTION
## Summary

`CALLCODE` with a non-zero value was halted inside a static context (`CallNotAllowedInsideStatic` in the EVM guest, `StateChangeDuringStaticCall` in the host syscall handler). That guard, added in #412, diverges from canonical EVM semantics: EIP-214 forbids `CALL` with value inside `STATICCALL`, but `CALLCODE` moves the value from the executing account to itself, so neither geth nor upstream revm rejects it. This removes the guard from both layers so `STATICCALL` → `CALLCODE(value > 0)` executes as it does on Ethereum; `CALL` with value inside a static frame still halts.

## Changes

- `crates/evm/src/opcodes.rs`: `call_code` no longer halts on `is_static && value != 0`.
- `crates/revm/src/syscall.rs`: the `SYSCALL_ID_CALL_CODE` arm no longer halts on `is_static && has_transfer`; the stipend check reuses `has_transfer` like the `CALL` arm.
- `crates/revm/src/tests.rs`: syscall-level tests that `CALLCODE` with value inside a static frame opens a `CallCode` frame with the static flag propagated, and that `CALL` with value still halts.
- `e2e/runtime/src/evm.rs`: end-to-end `STATICCALL` → `CALLCODE(1 wei)` succeeds through the guest interpreter, `STATICCALL` → `CALL(1 wei)` still fails; the call-argument encoding is shared with the existing `call_bytecode` helper.

## Notes

This changes execution semantics: a historical transaction that hit the old halt would re-execute differently. The old behaviour dates from #412 (May 2026), so any affected history is limited to blocks after that release.

## Verification

```
cargo fmt --all -- --check
cargo clippy -p fluentbase-revm -p fluentbase-evm -p fluentbase-e2e --all-targets -- -D warnings
cargo test -p fluentbase-revm static_call_frame_tests
cargo test -p fluentbase-e2e --lib -- inside_staticcall call_output
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * `CALLCODE` can now transfer value when executed inside a static call, while preserving the static context for the new frame.
  * `CALL` with a non-zero value in a static context continues to halt as required by EIP-214.

* **Testing**
  * Added coverage for value-transferring `CALLCODE` and `CALL` behavior within `STATICCALL` frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->