### PR TITLE
fix(contracts): drop static fees from engine-metered system runtimes

### DIFF
--- a/contracts/nitro/README.md
+++ b/contracts/nitro/README.md
@@ -45,4 +45,4 @@ A future strict selector should accept expected nonce, PCR policy, public key, u
 
 ## Gas/Fuel
 
-The entrypoint charges a fixed manual fuel amount before parsing. This prevents oversized or malformed attestations from being free to execute.
+The verifier is an engine-metered system runtime: the execution engine charges every instruction it executes, so the cost scales with the attestation being verified. The entrypoint charges no additional static fuel, and input above `NITRO_MAX_INPUT_SIZE` is rejected before the payload is copied.

--- a/contracts/nitro/src/lib.rs
+++ b/contracts/nitro/src/lib.rs
@@ -14,9 +14,6 @@ use fluentbase_sdk::{
     evm::write_evm_panic_message, system_entrypoint, ContextReader, ExitCode, SystemAPI,
 };
 
-/// Estimated Nitro attestation verification cost, in EVM gas units.
-const NITRO_VERIFY_GAS: u64 = 1_250_000;
-
 // Nitro attestation documents are bounded by their schema: this verifier caps
 // public_key at 1024 bytes, user_data and nonce at 512 bytes each, PCR count at
 // 32, and cabundle certs at 1024 bytes each. The bundled real fixtures are
@@ -24,9 +21,11 @@ const NITRO_VERIFY_GAS: u64 = 1_250_000;
 // large enough to force expensive allocation before parsing.
 const NITRO_MAX_INPUT_SIZE: u32 = 16 * 1024;
 
+/// Verifies an AWS Nitro attestation document.
+///
+/// This runtime is engine-metered (`ENGINE_METERED_PRECOMPILES`): the execution engine charges
+/// every instruction of the verification, so no static fee is charged on top of that.
 pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    sdk.sync_evm_gas(NITRO_VERIFY_GAS)?;
-
     if sdk.input_size() > NITRO_MAX_INPUT_SIZE {
         return Err(ExitCode::MalformedBuiltinParams);
     }

--- a/contracts/nitro/src/tests.rs
+++ b/contracts/nitro/src/tests.rs
@@ -6,6 +6,10 @@ use fluentbase_sdk::{Bytes, SharedContextInputV1};
 use fluentbase_testing::TestingContextImpl;
 use x509_cert::certificate::Certificate;
 
+/// Gas budget handed to the native test context. The runtime is engine-metered, so the native
+/// harness (which has no engine) must observe no fuel charged by the contract itself.
+const TEST_GAS_LIMIT: u64 = 1_250_000;
+
 /// Test for full attestation document verification.
 ///
 /// This test verifies a complete attestation document validation flow.
@@ -36,12 +40,13 @@ fn test_nitro_attestation_verification() {
     let mut sdk = TestingContextImpl::default()
         .with_shared_context_input(shared_ctx)
         .with_input(data.clone())
-        .with_gas_limit(NITRO_VERIFY_GAS);
+        .with_gas_limit(TEST_GAS_LIMIT);
 
     main_entry(&mut sdk).unwrap();
     assert_eq!(
         sdk.consumed_fuel(),
-        NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE
+        0,
+        "engine-metered runtime must not charge static fuel"
     );
     _ = sdk.take_output();
 }
@@ -72,12 +77,13 @@ fn test_nitro_attestation_stf_keygen() {
     let mut sdk = TestingContextImpl::default()
         .with_shared_context_input(shared_ctx)
         .with_input(data.clone())
-        .with_gas_limit(NITRO_VERIFY_GAS);
+        .with_gas_limit(TEST_GAS_LIMIT);
 
     main_entry(&mut sdk).unwrap();
     assert_eq!(
         sdk.consumed_fuel(),
-        NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE
+        0,
+        "engine-metered runtime must not charge static fuel"
     );
     _ = sdk.take_output();
 }
@@ -113,18 +119,14 @@ fn bench_nitro_fuel_estimate() {
             let mut sdk = TestingContextImpl::default()
                 .with_shared_context_input(shared_ctx.clone())
                 .with_input(data.to_vec())
-                .with_gas_limit(NITRO_VERIFY_GAS);
+                .with_gas_limit(TEST_GAS_LIMIT);
 
             main_entry(&mut sdk).unwrap();
-            assert_eq!(
-                sdk.consumed_fuel(),
-                NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE
-            );
+            assert_eq!(sdk.consumed_fuel(), 0);
         }
 
         println!(
-            "nitro {name}: gas={NITRO_VERIFY_GAS}, fuel={}, iterations={iterations}, elapsed={:?}",
-            NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE,
+            "nitro {name}: iterations={iterations}, elapsed={:?}",
             started.elapsed()
         );
     }
@@ -134,13 +136,14 @@ fn bench_nitro_fuel_estimate() {
 fn oversized_input_is_rejected_before_copying_full_payload() {
     let mut sdk = TestingContextImpl::default()
         .with_input(Bytes::from(vec![0u8; NITRO_MAX_INPUT_SIZE as usize + 1]))
-        .with_gas_limit(NITRO_VERIFY_GAS);
+        .with_gas_limit(TEST_GAS_LIMIT);
 
     let err = main_entry(&mut sdk).unwrap_err();
     assert_eq!(err, ExitCode::MalformedBuiltinParams);
     assert_eq!(
         sdk.consumed_fuel(),
-        NITRO_VERIFY_GAS * fluentbase_sdk::FUEL_DENOM_RATE
+        0,
+        "engine-metered runtime must not charge static fuel"
     );
     assert!(sdk.take_output().is_empty());
 }

--- a/contracts/wasm/src/lib.rs
+++ b/contracts/wasm/src/lib.rs
@@ -4,20 +4,16 @@ extern crate fluentbase_sdk;
 
 use fluentbase_sdk::{
     default_compilation_config, rwasm_core::RwasmModule, system_entrypoint, ExitCode, SystemAPI,
-    FUEL_DENOM_RATE, RWASM_MAX_CODE_SIZE,
+    RWASM_MAX_CODE_SIZE,
 };
 
-/// An average overhead per each Wasm byte in fuel cost (~50 gas per byte).
-const WASM_COMPILATION_OVERHEAD_FUEL_PER_BYTE: u32 = (50 * FUEL_DENOM_RATE) as u32;
-
+/// Compiles user-supplied Wasm into rWasm during deployment.
+///
+/// This runtime is engine-metered (`ENGINE_METERED_PRECOMPILES`): the execution engine charges
+/// every instruction the compiler executes, so the deployment cost already scales with the work
+/// done on the input. No static per-byte fee is charged on top of that, otherwise the same
+/// compilation would be paid for twice.
 pub fn deploy_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    // Wasm compilation fuel cost is ~50k fuel per one byte (~2500gas/b)
-    let fuel_cost = sdk
-        .input_size()
-        .saturating_mul(WASM_COMPILATION_OVERHEAD_FUEL_PER_BYTE);
-    sdk.charge_fuel(fuel_cost as u64);
-
-    // Read wasm binary once we charged enough gas for input
     let wasm_binary = sdk.bytes_input();
 
     // Compile wasm into rwasm bytecode

--- a/contracts/webauthn/src/lib.rs
+++ b/contracts/webauthn/src/lib.rs
@@ -20,18 +20,16 @@ const VERIFY_SELECTOR: [u8; 4] = [0x94, 0x51, 0x6d, 0xde];
 /// keccak256("verifyStrict(bytes,bool,bytes32,bytes,(bytes,bytes,uint256,uint256,bytes32,bytes32),uint256,uint256)")
 const VERIFY_STRICT_SELECTOR: [u8; 4] = [0x42, 0x52, 0x0f, 0xdd];
 
-/// Estimated verification cost, in EVM gas units.
-const WEBAUTHN_VERIFY_GAS: u64 = 22_000;
-
 /// WebAuthn verification contract for blockchain authentication.
 ///
 /// Based on reference implementations:
 /// - Solady: https://github.com/vectorized/solady/blob/main/src/utils/WebAuthn.sol
 /// - Daimo: https://github.com/daimo-eth/p256-verifier/blob/master/src/WebAuthn.sol
 /// - Coinbase: https://github.com/base-org/webauthn-sol/blob/main/src/WebAuthn.sol
+///
+/// This runtime is engine-metered (`ENGINE_METERED_PRECOMPILES`): the execution engine charges
+/// every instruction of the verification, so no static fee is charged on top of that.
 pub fn main_entry<SDK: SystemAPI>(sdk: &mut SDK) -> Result<(), ExitCode> {
-    sdk.sync_evm_gas(WEBAUTHN_VERIFY_GAS)?;
-
     if sdk.input_size() < 4 {
         return Err(ExitCode::MalformedBuiltinParams);
     }
@@ -92,9 +90,7 @@ system_entrypoint!(main_entry);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use fluentbase_sdk::{
-        codec::bytes::BytesMut, crypto::crypto_sha256, Bytes, ContractContextV1, FUEL_DENOM_RATE,
-    };
+    use fluentbase_sdk::{codec::bytes::BytesMut, crypto::crypto_sha256, Bytes, ContractContextV1};
     use fluentbase_testing::TestingContextImpl;
     use p256::{
         ecdsa::{signature::SignerMut, SigningKey, VerifyingKey},
@@ -226,13 +222,17 @@ mod tests {
             Bytes::copy_from_slice(client_data_json.as_bytes()),
         ));
 
-        let (output, _) = exec(&encode_strict_call(&params), WEBAUTHN_VERIFY_GAS).unwrap();
+        let (output, _) = exec(&encode_strict_call(&params), TEST_GAS_LIMIT).unwrap();
         output
     }
 
     fn valid_call_input(require_user_verification: bool) -> Vec<u8> {
         encode_call(&valid_call_params(require_user_verification))
     }
+
+    /// Gas budget handed to the native test context. The runtime is engine-metered, so the
+    /// native harness (which has no engine) must observe no fuel charged by the contract itself.
+    const TEST_GAS_LIMIT: u64 = 22_000;
 
     fn exec(input: &[u8], gas_limit: u64) -> Result<(Vec<u8>, u64), ExitCode> {
         let mut sdk = TestingContextImpl::default()
@@ -247,18 +247,24 @@ mod tests {
     }
 
     #[test]
-    fn valid_signature_returns_true_and_charges_fuel() {
-        let (output, fuel) = exec(&valid_call_input(true), WEBAUTHN_VERIFY_GAS).unwrap();
+    fn valid_signature_returns_true_without_static_charge() {
+        let (output, fuel) = exec(&valid_call_input(true), TEST_GAS_LIMIT).unwrap();
         assert_eq!(output, B256::with_last_byte(1)[..]);
-        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+        assert_eq!(
+            fuel, 0,
+            "engine-metered runtime must not charge static fuel"
+        );
     }
 
     #[test]
-    fn strict_valid_signature_returns_true_and_charges_fuel() {
+    fn strict_valid_signature_returns_true_without_static_charge() {
         let (input, _) = valid_strict_call_input(true);
-        let (output, fuel) = exec(&input, WEBAUTHN_VERIFY_GAS).unwrap();
+        let (output, fuel) = exec(&input, TEST_GAS_LIMIT).unwrap();
         assert_eq!(output, B256::with_last_byte(1)[..]);
-        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+        assert_eq!(
+            fuel, 0,
+            "engine-metered runtime must not charge static fuel"
+        );
     }
 
     #[test]
@@ -266,9 +272,12 @@ mod tests {
         let (_, mut params) = valid_strict_call_input(true);
         params.2 = B256::with_last_byte(1);
 
-        let (output, fuel) = exec(&encode_strict_call(&params), WEBAUTHN_VERIFY_GAS).unwrap();
+        let (output, fuel) = exec(&encode_strict_call(&params), TEST_GAS_LIMIT).unwrap();
         assert_eq!(output, B256::default()[..]);
-        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+        assert_eq!(
+            fuel, 0,
+            "engine-metered runtime must not charge static fuel"
+        );
     }
 
     #[test]
@@ -276,9 +285,12 @@ mod tests {
         let (_, mut params) = valid_strict_call_input(true);
         params.3 = Bytes::copy_from_slice(b"https://example.com");
 
-        let (output, fuel) = exec(&encode_strict_call(&params), WEBAUTHN_VERIFY_GAS).unwrap();
+        let (output, fuel) = exec(&encode_strict_call(&params), TEST_GAS_LIMIT).unwrap();
         assert_eq!(output, B256::default()[..]);
-        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+        assert_eq!(
+            fuel, 0,
+            "engine-metered runtime must not charge static fuel"
+        );
     }
 
     #[test]
@@ -374,24 +386,21 @@ mod tests {
         authenticator_data[webauthn::AUTH_DATA_FLAGS_INDEX] = webauthn::AUTH_DATA_FLAGS_UP;
         params.2.authenticator_data = Bytes::copy_from_slice(&authenticator_data);
 
-        let (output, fuel) = exec(&encode_call(&params), WEBAUTHN_VERIFY_GAS).unwrap();
+        let (output, fuel) = exec(&encode_call(&params), TEST_GAS_LIMIT).unwrap();
         assert_eq!(output, B256::default()[..]);
-        assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+        assert_eq!(
+            fuel, 0,
+            "engine-metered runtime must not charge static fuel"
+        );
     }
 
     #[test]
-    fn malformed_selector_is_rejected_after_fuel_charge() {
+    fn malformed_selector_is_rejected() {
         let mut input = valid_call_input(true);
         input[0] ^= 0xff;
 
-        let err = exec(&input, WEBAUTHN_VERIFY_GAS).unwrap_err();
+        let err = exec(&input, TEST_GAS_LIMIT).unwrap_err();
         assert_eq!(err, ExitCode::MalformedBuiltinParams);
-    }
-
-    #[test]
-    fn insufficient_fuel_fails_before_verification() {
-        let err = exec(&valid_call_input(true), WEBAUTHN_VERIFY_GAS - 1).unwrap_err();
-        assert_eq!(err, ExitCode::OutOfFuel);
     }
 
     #[test]
@@ -407,12 +416,11 @@ mod tests {
             let started = std::time::Instant::now();
             let iterations = 100u32;
             for _ in 0..iterations {
-                let (_, fuel) = exec(&input, WEBAUTHN_VERIFY_GAS).unwrap();
-                assert_eq!(fuel, WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE);
+                let (_, fuel) = exec(&input, TEST_GAS_LIMIT).unwrap();
+                assert_eq!(fuel, 0);
             }
             println!(
-                "webauthn {name}: gas={WEBAUTHN_VERIFY_GAS}, fuel={}, iterations={iterations}, elapsed={:?}",
-                WEBAUTHN_VERIFY_GAS * FUEL_DENOM_RATE,
+                "webauthn {name}: iterations={iterations}, elapsed={:?}",
                 started.elapsed()
             );
         }

--- a/crates/types/src/genesis.rs
+++ b/crates/types/src/genesis.rs
@@ -159,13 +159,12 @@ pub fn is_execute_using_system_runtime(address: &Address) -> bool {
     EXECUTE_USING_SYSTEM_RUNTIME_ADDRESSES.contains(address)
 }
 
-/// Addresses whose execution should be charged by the runtime.
+/// Addresses whose execution is metered by the engine.
 ///
-/// These contracts should be compiled with `consume_fuel=true` and
-/// `builtins_consume_fuel=true`.
-///
-/// P.S: Engine metered precompiles are temporarily disabled, will
-///  be re-enabled in the next releases
+/// These runtimes execute with `consume_fuel=true`, so every instruction is charged by the
+/// engine. They must not add static execution charges of their own, otherwise the same work is
+/// paid for twice (see `docs/04-gas-and-fuel.md`). Membership is consensus-critical: changing it
+/// changes gas for every historical call to the address.
 pub const ENGINE_METERED_PRECOMPILES: &[Address] = &[
     PRECOMPILE_NITRO_VERIFIER,
     PRECOMPILE_WASM_RUNTIME,

--- a/docs/04-gas-and-fuel.md
+++ b/docs/04-gas-and-fuel.md
@@ -64,10 +64,21 @@ These formulas are part of runtime ABI behavior, not optional heuristics.
 
 Not all system runtimes meter fuel the same way.
 
-- **self-metered**: runtime code charges fuel explicitly,
-- **engine-metered**: execution engine automatically meters configured precompiles.
+- **self-metered**: runtime code charges fuel explicitly (`_charge_fuel`, `sync_evm_gas`); the
+  engine does not meter its instructions,
+- **engine-metered**: the execution engine meters every instruction of the runtime. The set is
+  `ENGINE_METERED_PRECOMPILES`: Nitro verifier, OAuth2 verifier, WASM runtime, WebAuthn verifier
+  and Universal Token runtime.
 
-Universal Token runtime is currently in engine-metered set.
+Engine-metered runtimes must not add static execution charges on top of engine fuel. The engine
+already prices the work they do, so a flat or per-byte fee for the same execution charges it
+twice. The WASM runtime's per-byte deploy fee and the Nitro and WebAuthn flat verification fees
+were removed for that reason. Deposits are not execution pricing and stay: the Universal Token
+constructor charges the EVM code-deposit rate for the metadata it installs.
+
+Membership in the engine-metered set is a node-side rule keyed on the address, so changing it
+changes gas for every historical call to that address and is a fork-level change. Static charges
+live in the runtime bytecode and are changed by runtime upgrade.
 
 ---
 


### PR DESCRIPTION
## Summary

The five addresses in `ENGINE_METERED_PRECOMPILES` execute with `consume_fuel=true`, so the engine charges every instruction they run. Three of them additionally charged a static fee for the same execution, so callers paid twice:

| Runtime | Static fee removed | Engine fuel (kept) |
|---|---|---|
| WASM runtime (`deploy`) | 50 gas per input byte | per-instruction cost of the compiler |
| Nitro verifier | flat 1,250,000 gas | per-instruction cost of verification |
| WebAuthn verifier | flat 22,000 gas | per-instruction cost of verification |

Measured on the release WASM runtime binary through the runtime executor (identical on the rwasm and wasmtime backends):

| Deploy input | Bytes | Static fee | Engine fuel | Total before |
|---|---|---|---|---|
| greeting | 190 | 9,500 gas | 10,076 gas | 19,576 gas |
| simple_storage | 27,047 | 1,352,350 gas | 400,753 gas | 1,753,103 gas |
| erc20 | 137,637 | 6,881,850 gas | 1,998,889 gas | 8,880,739 gas |

After this change the "Engine fuel" column is the whole price.

## Changes

- `contracts/wasm`: remove the per-byte compilation fee; the engine meters the compiler.
- `contracts/nitro`: remove the flat verification fee; keep the `NITRO_MAX_INPUT_SIZE` guard. Unit tests now pin that the contract charges no fuel of its own.
- `contracts/webauthn`: remove the flat verification fee. Unit tests pin the same; the out-of-fuel test that only exercised the removed charge is dropped.
- `docs/04-gas-and-fuel.md`, `crates/types/src/genesis.rs`: document the rule (engine-metered runtimes carry no static execution charges), list the set, and replace the stale note claiming the set is temporarily disabled.

Not changed on purpose:

- The Universal Token metadata deposit stays. It pays the EVM code-deposit rate for the metadata it installs, which is a storage deposit, not execution pricing.
- The engine-metered set itself. Membership is a node-side rule keyed on the address; changing it changes gas for every historical call and is a fork-level change. The static fees live in runtime bytecode, so they are removed by runtime upgrade instead.

## Rollout

No node change. New networks pick the new binaries up through genesis at build time. Live networks need a runtime upgrade of the three precompiles through the runtime-upgrade path; until then their on-chain code keeps the old fees, and historical execution is untouched either way.

## Verification

- `cargo test -p fluentbase-contracts-nitro -p fluentbase-contracts-webauthn` in `contracts/`: 23 and 25 passed.
- `cargo build --release --target wasm32-unknown-unknown --no-default-features` for the three contracts with the workspace rustflags: builds cleanly.
- `cargo +stable fmt --all -- --check`: clean.
- e2e gas assertions were reviewed; none pin the removed fees.

Fixes FLU-1385.
