### PR TITLE
fix: follow-ups from the 2026-09-11 e2e audit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: "Dry run only (verify without publishing)"
+        description: "Dry run only (verify without publishing). Switch off only to re-run the publish of a canonical stable tag ref."
         required: false
-        default: false
+        default: true
         type: boolean
 
 env:
@@ -19,7 +19,9 @@ env:
 jobs:
   publish:
     name: Publish to crates.io
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) || (github.ref_type == 'tag' && !contains(github.ref_name, '-')) }}
+    # Every manual run enters the job so that a misdirected real publish fails
+    # visibly in the tag check below instead of being skipped silently.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref_type == 'tag' && !contains(github.ref_name, '-')) }}
     runs-on: ubuntu-latest
 
     steps:
@@ -38,22 +40,29 @@ jobs:
 
       - name: Verify canonical release tag
         # crates.io publishing is irreversible, so only the exact canonical
-        # stable tag v<workspace-version> may publish. A workflow_dispatch dry
-        # run from a non-tag ref has no tag to validate and publishes nothing.
+        # stable tag v<workspace-version> may publish - whether the run comes
+        # from a tag push or from a manual run with `dry_run` switched off. A
+        # dry run publishes nothing and therefore has nothing to validate.
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}
         run: |
-          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
-            echo "Not a tag ref; skipping tag validation (dry run only)"
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "Dry run: nothing will be published, skipping tag validation"
             exit 0
+          fi
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            echo "crates.io publishing requires a canonical stable release tag ref (got ${GITHUB_REF_TYPE} ${GITHUB_REF_NAME})" >&2
+            exit 1
           fi
           channel="$(./.github/scripts/check-release-tag.sh "${GITHUB_REF_NAME}")"
           echo "$channel"
-          if [[ "${GITHUB_EVENT_NAME}" != "workflow_dispatch" && "$channel" != "channel=stable" ]]; then
+          if [[ "$channel" != "channel=stable" ]]; then
             echo "crates.io publishing requires the canonical stable release tag" >&2
             exit 1
           fi
 
       - name: Publish to crates.io
-        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.dry_run }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,6 +163,8 @@ Important notes:
 
 - Releases should only be created from the `main` branch
 - Pushing a version tag (e.g., `v1.2.3`) to the `main` branch will automatically trigger the publish workflow
+- The publish workflow can also be dispatched by hand. It is a dry run by default; switching `dry_run`
+  off publishes for real and is accepted only on the canonical stable tag ref
 - Ensure all changes are merged to `main` before creating a release
 
 1. **Switch to main and update**

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2120,6 +2120,7 @@ dependencies = [
 name = "fluentbase-contracts-webauthn"
 version = "0.1.0"
 dependencies = [
+ "alloy-json-abi",
  "base64",
  "fluentbase-sdk",
  "fluentbase-testing",

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2084,6 +2084,7 @@ dependencies = [
 name = "fluentbase-contracts-runtime-upgrade"
 version = "0.1.0"
 dependencies = [
+ "alloy-json-abi",
  "alloy-sol-types",
  "fluentbase-build",
  "fluentbase-sdk",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -29,6 +29,7 @@ revm-precompile = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", br
 #solana-program-option = { git = "https://github.com/fluentlabs-xyz/agave", branch = "feat/svm", default-features = false }
 #solana-bincode = { git = "https://github.com/fluentlabs-xyz/agave", branch = "feat/svm", default-features = false }
 # misc
+alloy-json-abi = { version = "1.5.0", features = ["serde_json"] }
 alloy-sol-types = { version = "1.5.0" }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 ecdsa = { git = "https://github.com/rwasm-patches/signatures.git", default-features = false, features = ["hazmat", "verifying"] }

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -47,7 +47,7 @@ Thin wrappers around `revm-precompile` or the SDK's crypto syscalls that mirror 
 - `eip2935` — the EIP-2935 ring buffer of recent block hashes.
 - `fee-manager` — collects protocol fees. The owner can withdraw the balance, transfer ownership or renounce it.
 - `runtime-upgrade` — privileged contract that replaces runtime and system contract bytecode on a live chain
-  (`upgradeTo`, `recompile`, `planUpgrade` and friends). Its README documents the authorization model.
+  (`upgradeTo`, `planUpgrade` and friends). Its README documents the authorization model.
 - `nitro` — AWS Nitro Enclaves attestation document verifier.
 - `webauthn` — WebAuthn assertion verification over P-256.
 - `create2-factory` — the deterministic deployment proxy. Not a Rust crate: it holds the Yul source and the EVM

--- a/contracts/runtime-upgrade/Cargo.toml
+++ b/contracts/runtime-upgrade/Cargo.toml
@@ -10,6 +10,8 @@ fluentbase-sdk = { workspace = true }
 fluentbase-testing = { workspace = true }
 # Independent Solidity ABI decoder used to validate emitted event log data.
 alloy-sol-types = { workspace = true }
+# Independent reader of the published `abi.json`, to pin it to the router's selectors.
+alloy-json-abi = { workspace = true }
 
 [build-dependencies]
 fluentbase-build = { workspace = true }

--- a/contracts/runtime-upgrade/README.md
+++ b/contracts/runtime-upgrade/README.md
@@ -14,6 +14,15 @@ The contract validates the submitted WASM bytes, compiles them to rWasm for `tar
 native runtime-upgrade syscall, then emits `RuntimeUpgraded(target, genesisHash, genesisVersion,
 codeHash)`.
 
+### `upgradeEvmTo(address target, uint256 genesisHash, string genesisVersion, bytes evmBytecode)`
+
+Owner-only direct upgrade path for system contracts written in Solidity.
+
+The contract rejects empty bytecode and bytecode above `EVM_MAX_CODE_SIZE`, installs the bytes for
+`target` through the native EVM runtime-upgrade syscall (which stores them as analyzed EVM
+metadata), then emits `RuntimeUpgraded(target, genesisHash, genesisVersion, codeHash)` with
+`codeHash = keccak256(evmBytecode)`.
+
 ### `planUpgrade(uint256 genesisHash, string genesisVersion, address[] targets, bytes32[] wasmHashes, address upgrador)`
 
 Owner-only planning path for release upgrades that should be executable by a delegated account.
@@ -48,6 +57,15 @@ release metadata, and every remaining target/hash pair are cleared, and `Upgrade
 genesisHash, upgrador, targets, wasmHashes)` is emitted describing exactly what was revoked. The
 event is skipped when no plan exists. If a transition reverts (zero address, non-owner caller), the
 plan is left untouched along with the rest of the state.
+
+## Published ABI
+
+`abi.json` is generated from the router by `scripts/generate-contract-abis.bash` (which runs
+`fluentbase-build --generate abi` for every contract). The `#[function_id("...")]` attributes on
+the router are the source of the selectors: `genesisHash` is pinned as `uint256`, so the
+published entries say `uint256` even though the Rust parameter is `B256`, and the generator
+refuses an entry whose selector differs from the router's. `test_published_abi_matches_router_selectors`
+pins the checked-in artifact to the compiled selectors.
 
 ## Trust Model
 

--- a/contracts/runtime-upgrade/README.md
+++ b/contracts/runtime-upgrade/README.md
@@ -14,14 +14,6 @@ The contract validates the submitted WASM bytes, compiles them to rWasm for `tar
 native runtime-upgrade syscall, then emits `RuntimeUpgraded(target, genesisHash, genesisVersion,
 codeHash)`.
 
-### `recompile(address target)`
-
-Owner-only maintenance path for already deployed WASM bytecode.
-
-The contract reads bytecode from `target` with `code_size`/`code_copy`, requires the loaded length
-to match the reported size, recompiles the bytecode through the same install path as `upgradeTo`,
-and emits `ContractRecompiled(target, codeHash)`.
-
 ### `planUpgrade(uint256 genesisHash, string genesisVersion, address[] targets, bytes32[] wasmHashes, address upgrador)`
 
 Owner-only planning path for release upgrades that should be executable by a delegated account.
@@ -59,7 +51,7 @@ plan is left untouched along with the rest of the state.
 
 ## Trust Model
 
-- `owner` can perform direct upgrades, recompile existing targets, and replace the current plan.
+- `owner` can perform direct upgrades and replace the current plan.
 - `upgrador` can execute only owner-approved target/hash pairs from the current plan.
 - Delegated upgrade authority never outlives the owner that granted it. A plan is scoped to its
   creating owner, so ownership rotation is sufficient for compromise response and renunciation

--- a/contracts/runtime-upgrade/abi.json
+++ b/contracts/runtime-upgrade/abi.json
@@ -7,9 +7,9 @@
         "type": "address"
       },
       {
-        "internalType": "bytes32",
+        "internalType": "uint256",
         "name": "genesis_hash",
-        "type": "bytes32"
+        "type": "uint256"
       },
       {
         "internalType": "string",
@@ -24,7 +24,7 @@
     ],
     "name": "upgradeTo",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -33,19 +33,34 @@
         "internalType": "address",
         "name": "target_address",
         "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "genesis_hash",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "genesis_version",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "evm_bytecode",
+        "type": "bytes"
       }
     ],
-    "name": "recompile",
+    "name": "upgradeEvmTo",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
     "inputs": [
       {
-        "internalType": "bytes32",
+        "internalType": "uint256",
         "name": "genesis_hash",
-        "type": "bytes32"
+        "type": "uint256"
       },
       {
         "internalType": "string",
@@ -70,7 +85,7 @@
     ],
     "name": "planUpgrade",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -88,7 +103,7 @@
     ],
     "name": "upgradeToPlanned",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -101,7 +116,7 @@
     ],
     "name": "changeOwner",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -114,14 +129,14 @@
         "type": "address"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
     "inputs": [],
     "name": "renounceOwnership",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   }
 ]

--- a/contracts/runtime-upgrade/src/lib.rs
+++ b/contracts/runtime-upgrade/src/lib.rs
@@ -29,13 +29,6 @@ struct RuntimeUpgraded {
 }
 
 #[derive(Event)]
-struct ContractRecompiled {
-    #[indexed]
-    target_address: Address,
-    code_hash: B256,
-}
-
-#[derive(Event)]
 struct UpgradePlanned {
     #[indexed]
     genesis_hash: B256,
@@ -88,9 +81,6 @@ trait RuntimeUpgradeTr {
         genesis_version: String,
         evm_bytecode: Bytes,
     );
-
-    /// Recompile already deployed WASM runtime smart contract
-    fn recompile(&mut self, target_address: Address);
 
     /// Plan a bulk runtime upgrade as exact target/hash pairs.
     ///
@@ -165,37 +155,6 @@ impl<SDK: SharedAPI> RuntimeUpgradeTr for App<SDK> {
             target_address,
             genesis_hash,
             genesis_version,
-            code_hash,
-        }
-        .emit(&mut self.sdk)
-        .unwrap();
-    }
-
-    #[function_id("recompile(address)")]
-    fn recompile(&mut self, target_address: Address) {
-        _ = self.only_owner();
-
-        let Ok(code_size) = self.sdk.code_size(&target_address).ok() else {
-            panic!("runtime-upgrade: can't obtain code size");
-        };
-        if code_size == 0 {
-            panic!("runtime-upgrade: empty target bytecode");
-        }
-
-        let Ok(wasm_bytecode) = self
-            .sdk
-            .code_copy(&target_address, 0, code_size as u64)
-            .ok()
-        else {
-            panic!("runtime-upgrade: can't load target bytecode");
-        };
-        if wasm_bytecode.len() != code_size as usize {
-            panic!("runtime-upgrade: incomplete target bytecode");
-        }
-
-        let code_hash = self.compile_and_install(target_address, wasm_bytecode);
-        ContractRecompiled {
-            target_address,
             code_hash,
         }
         .emit(&mut self.sdk)

--- a/contracts/runtime-upgrade/src/tests.rs
+++ b/contracts/runtime-upgrade/src/tests.rs
@@ -185,20 +185,6 @@ fn test_upgrade_to_encoding() {
 }
 
 #[test]
-fn test_recompile_encoding() {
-    let target = address!("2222222222222222222222222222222222222222");
-
-    let call = RecompileCall::new((target,));
-    let encoded = call.encode();
-
-    assert!(encoded.len() >= 4);
-    println!("Encoded call data: {}", hex::encode(&encoded));
-
-    let decoded = RecompileCall::decode(&&encoded[4..]).expect("failed to decode");
-    assert_eq!(decoded.0 .0, target, "target_address mismatch");
-}
-
-#[test]
 fn test_upgrade_evm_to_encoding() {
     let target = address!("2222222222222222222222222222222222222222");
     let genesis_hash = B256::from([0xab; 32]);
@@ -293,16 +279,11 @@ fn test_upgrade_to_planned_encoding() {
 }
 
 #[test]
-fn test_upgrade_and_recompile_event_signatures_are_distinct() {
+fn test_runtime_upgraded_event_signature() {
     assert_eq!(
         RuntimeUpgraded::SIGNATURE,
         "RuntimeUpgraded(address,bytes32,string,bytes32)"
     );
-    assert_eq!(
-        ContractRecompiled::SIGNATURE,
-        "ContractRecompiled(address,bytes32)"
-    );
-    assert_ne!(RuntimeUpgraded::SELECTOR, ContractRecompiled::SELECTOR);
 }
 
 #[test]

--- a/contracts/runtime-upgrade/src/tests.rs
+++ b/contracts/runtime-upgrade/src/tests.rs
@@ -278,6 +278,38 @@ fn test_upgrade_to_planned_encoding() {
     assert_eq!(decoded.0 .1, wasm_bytecode, "wasm_bytecode mismatch");
 }
 
+/// The published ABI must select exactly the methods the router dispatches on: the router pins
+/// `uint256` for the genesis hash, so the artifact has to say `uint256` too, whatever the Rust
+/// parameter type is.
+#[test]
+fn test_published_abi_matches_router_selectors() {
+    let abi = alloy_json_abi::JsonAbi::from_json_str(include_str!("../abi.json"))
+        .expect("abi.json must parse");
+
+    let mut published: Vec<(String, [u8; 4])> = abi
+        .functions()
+        .map(|function| (function.name.clone(), function.selector().0))
+        .collect();
+    published.sort();
+
+    let mut expected: Vec<(String, [u8; 4])> = [
+        ("upgradeTo", UpgradeToCall::SELECTOR),
+        ("upgradeEvmTo", UpgradeEvmToCall::SELECTOR),
+        ("planUpgrade", PlanUpgradeCall::SELECTOR),
+        ("upgradeToPlanned", UpgradeToPlannedCall::SELECTOR),
+        ("changeOwner", ChangeOwnerCall::SELECTOR),
+        ("owner", OwnerCall::SELECTOR),
+        ("renounceOwnership", RenounceOwnershipCall::SELECTOR),
+    ]
+    .into_iter()
+    .map(|(name, selector)| (name.to_string(), selector))
+    .collect();
+    expected.sort();
+
+    assert_eq!(published, expected);
+    assert!(abi.constructor.is_none());
+}
+
 #[test]
 fn test_runtime_upgraded_event_signature() {
     assert_eq!(

--- a/contracts/webauthn/Cargo.toml
+++ b/contracts/webauthn/Cargo.toml
@@ -12,6 +12,7 @@ revm-precompile = { workspace = true }
 sha2 = { version = "0.10", default-features = false }
 
 [dev-dependencies]
+alloy-json-abi = { workspace = true }
 fluentbase-testing = { workspace = true }
 p256 = { version = "0.13.2", default-features = false, features = [
     "ecdsa",

--- a/contracts/webauthn/abi.json
+++ b/contracts/webauthn/abi.json
@@ -93,11 +93,6 @@
         "type": "bytes"
       },
       {
-        "internalType": "uint256",
-        "name": "origin_index",
-        "type": "uint256"
-      },
-      {
         "components": [
           {
             "internalType": "bytes",

--- a/contracts/webauthn/src/lib.rs
+++ b/contracts/webauthn/src/lib.rs
@@ -99,6 +99,23 @@ mod tests {
 
     type StrictCallParams = (Bytes, bool, B256, Bytes, WebAuthnAuth, U256, U256);
 
+    /// The published ABI must select exactly the entrypoints this contract dispatches on.
+    #[test]
+    fn test_published_abi_matches_dispatched_selectors() {
+        let abi = alloy_json_abi::JsonAbi::from_json_str(include_str!("../abi.json"))
+            .expect("abi.json must parse");
+        let selector = |name: &str| {
+            let functions = abi
+                .function(name)
+                .unwrap_or_else(|| panic!("{name} is not published"));
+            assert_eq!(functions.len(), 1, "{name} must be published once");
+            functions[0].selector().0
+        };
+        assert_eq!(selector("verify"), VERIFY_SELECTOR);
+        assert_eq!(selector("verifyStrict"), VERIFY_STRICT_SELECTOR);
+        assert_eq!(abi.functions().count(), 2);
+    }
+
     fn valid_call_params(
         require_user_verification: bool,
     ) -> (Bytes, bool, WebAuthnAuth, U256, U256) {

--- a/crates/build/tests/abi_generation.rs
+++ b/crates/build/tests/abi_generation.rs
@@ -480,9 +480,10 @@ fn module_qualified_struct_selectors_agree_with_the_router() {
     );
 }
 
-/// A custom selector that no longer matches the published ABI stops the build
+/// A pinned selector the ABI can reproduce is what gets published: the entry takes the pinned
+/// name and leaf types, so callers encoding from the artifact reach the router
 #[test]
-fn selector_that_diverges_from_the_abi_fails_the_build() {
+fn pinned_selector_the_abi_can_reproduce_is_published() {
     let (_temp, project) = duplicate_names_project(&["a", "b"]);
     fs::write(
         project.join("src").join("lib.rs"),
@@ -493,11 +494,38 @@ fn selector_that_diverges_from_the_abi_fails_the_build() {
     )
     .expect("rewrite lib.rs");
 
+    assert_selectors_agree(
+        &project,
+        &[("set_a", "renameMe((uint256,bool))", "0x410cd56e")],
+    );
+    let abi = generate_abi(&project).expect("generate ABI");
+    assert!(
+        abi.iter().all(|entry| entry["name"] != "setA"),
+        "the derived name must not be published next to the pinned one"
+    );
+}
+
+/// A custom selector the published ABI cannot reproduce stops the build
+#[test]
+fn selector_that_diverges_from_the_abi_fails_the_build() {
+    let (_temp, project) = duplicate_names_project(&["a", "b"]);
+    fs::write(
+        project.join("src").join("lib.rs"),
+        DUPLICATE_NAMES_ROOT.replace(
+            "    pub fn set_a(",
+            "    #[function_id(\"setA((uint256,uint256))\")]\n    pub fn set_a(",
+        ),
+    )
+    .expect("rewrite lib.rs");
+
     let error = format!(
         "{:#}",
         generate_abi(&project).expect_err("a router selector the ABI cannot reproduce should fail")
     );
-    assert!(error.contains("0x410cd56e"), "unexpected error: {error}");
+    assert!(
+        error.contains("setA((uint256,uint256))"),
+        "unexpected error: {error}"
+    );
     assert!(error.contains("ABI migration"), "unexpected error: {error}");
 }
 

--- a/crates/sdk-derive/derive-core/src/abi/function.rs
+++ b/crates/sdk-derive/derive-core/src/abi/function.rs
@@ -285,7 +285,7 @@ fn wire_layout(ty: &str) -> Option<WireLayout> {
             let is_valid = if is_fixed_bytes {
                 (1..=32).contains(&width)
             } else {
-                width % 8 == 0 && (8..=256).contains(&width)
+                width.is_multiple_of(8) && (8..=256).contains(&width)
             };
             is_valid.then_some(WireLayout::Word)
         }

--- a/crates/sdk-derive/derive-core/src/abi/function.rs
+++ b/crates/sdk-derive/derive-core/src/abi/function.rs
@@ -146,7 +146,8 @@ impl FunctionABI {
     /// otherwise callers encoding from the artifact never reach the method. The entry takes the
     /// pinned name, and every leaf parameter whose derived type differs takes the pinned type at
     /// its position. Tuples cannot be mapped onto a different pinned type, and a different number
-    /// of parameters cannot be mapped at all; both are errors.
+    /// of parameters cannot be mapped at all; both are errors, and on an error the entry is left
+    /// exactly as it was derived.
     pub fn retype_from_signature(&mut self, signature: &str) -> Result<(), ABIError> {
         let (name, params) = signature
             .strip_suffix(')')
@@ -167,7 +168,8 @@ impl FunctionABI {
             )));
         }
 
-        for (input, pinned_type) in self.inputs.iter_mut().zip(pinned_types) {
+        let mut inputs = self.inputs.clone();
+        for (input, pinned_type) in inputs.iter_mut().zip(pinned_types) {
             let derived_type = input.get_canonical_type()?;
             if derived_type == pinned_type {
                 continue;
@@ -183,6 +185,8 @@ impl FunctionABI {
             input.internal_type = pinned_type.clone();
             input.ty = pinned_type;
         }
+
+        self.inputs = inputs;
         self.name = name.to_string();
 
         Ok(())
@@ -315,19 +319,23 @@ mod tests {
         assert_eq!(abi.signature().unwrap(), "set((uint256,bool),bytes32)");
     }
 
-    /// A tuple that disagrees with the pinned signature, or a different arity, cannot be mapped
+    /// A tuple that disagrees with the pinned signature, or a different arity, cannot be mapped,
+    /// and a failed mapping leaves the derived entry untouched
     #[test]
     fn test_pinned_signature_rejects_tuple_retypes_and_arity_changes() {
         let sig: Signature = parse_quote! {
             fn set(config: (U256, bool), owner: Address)
         };
         let mut abi = FunctionABI::from_signature(&sig).unwrap();
+        let derived = abi.clone();
+
         assert!(abi
-            .retype_from_signature("set((uint256,uint256),address)")
+            .retype_from_signature("renamed((uint256,uint256),bytes32)")
             .is_err());
         assert!(abi.retype_from_signature("set(uint256,address)").is_err());
         assert!(abi.retype_from_signature("set((uint256,bool))").is_err());
         assert!(abi.retype_from_signature("set").is_err());
+        assert_eq!(abi, derived);
     }
 
     #[test]

--- a/crates/sdk-derive/derive-core/src/abi/function.rs
+++ b/crates/sdk-derive/derive-core/src/abi/function.rs
@@ -139,6 +139,55 @@ impl FunctionABI {
         }
     }
 
+    /// Makes the entry hash to a pinned signature
+    ///
+    /// A `#[function_id("name(type,...)")]` attribute is the interface the router dispatches on,
+    /// whatever the Rust parameter types derive to. The published entry has to say the same thing,
+    /// otherwise callers encoding from the artifact never reach the method. The entry takes the
+    /// pinned name, and every leaf parameter whose derived type differs takes the pinned type at
+    /// its position. Tuples cannot be mapped onto a different pinned type, and a different number
+    /// of parameters cannot be mapped at all; both are errors.
+    pub fn retype_from_signature(&mut self, signature: &str) -> Result<(), ABIError> {
+        let (name, params) = signature
+            .strip_suffix(')')
+            .and_then(|head| head.split_once('('))
+            .ok_or_else(|| {
+                ABIError::TypeConversion(format!(
+                    "pinned signature `{signature}` is not of the form name(type,...)"
+                ))
+            })?;
+        let pinned_types = split_top_level_types(params);
+
+        if pinned_types.len() != self.inputs.len() {
+            return Err(ABIError::TypeConversion(format!(
+                "pinned signature `{signature}` has {} parameters, but `{}` takes {}",
+                pinned_types.len(),
+                self.name,
+                self.inputs.len()
+            )));
+        }
+
+        for (input, pinned_type) in self.inputs.iter_mut().zip(pinned_types) {
+            let derived_type = input.get_canonical_type()?;
+            if derived_type == pinned_type {
+                continue;
+            }
+            if input.components.is_some() || pinned_type.starts_with('(') {
+                return Err(ABIError::TypeConversion(format!(
+                    "parameter `{}` derives to `{derived_type}`, but the pinned signature says \
+                     `{pinned_type}`; a tuple parameter cannot be retyped, so the pinned \
+                     signature has to spell out the same components",
+                    input.name
+                )));
+            }
+            input.internal_type = pinned_type.clone();
+            input.ty = pinned_type;
+        }
+        self.name = name.to_string();
+
+        Ok(())
+    }
+
     /// Returns canonical function signature for Solidity ABI
     /// Format: fnName(type1,type2,...)
     pub fn signature(&self) -> Result<String, ABIError> {
@@ -180,10 +229,106 @@ impl FunctionABI {
     }
 }
 
+/// Splits the parameter list of a canonical signature on the commas outside tuples
+fn split_top_level_types(params: &str) -> Vec<String> {
+    let mut types = Vec::new();
+    let mut depth = 0usize;
+    let mut current = String::new();
+    for ch in params.chars() {
+        match ch {
+            '(' => {
+                depth += 1;
+                current.push(ch);
+            }
+            ')' => {
+                depth = depth.saturating_sub(1);
+                current.push(ch);
+            }
+            ',' if depth == 0 => types.push(core::mem::take(&mut current)),
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        types.push(current);
+    }
+    types
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use syn::parse_quote;
+
+    /// A pinned signature retypes the leaf parameters whose derived type differs
+    #[test]
+    fn test_pinned_signature_retypes_leaf_parameters() {
+        let sig: Signature = parse_quote! {
+            fn upgrade_to(target_address: Address, genesis_hash: B256, genesis_version: String, wasm_bytecode: Bytes)
+        };
+        let mut abi = FunctionABI::from_signature(&sig).unwrap();
+        assert_eq!(
+            abi.signature().unwrap(),
+            "upgradeTo(address,bytes32,string,bytes)"
+        );
+
+        abi.retype_from_signature("upgradeTo(address,uint256,string,bytes)")
+            .unwrap();
+
+        assert_eq!(abi.inputs[1].name, "genesis_hash");
+        assert_eq!(abi.inputs[1].ty, "uint256");
+        assert_eq!(abi.inputs[1].internal_type, "uint256");
+        assert_eq!(abi.inputs[0].ty, "address");
+        assert_eq!(
+            abi.signature().unwrap(),
+            "upgradeTo(address,uint256,string,bytes)"
+        );
+        // keccak256("upgradeTo(address,uint256,string,bytes)")[..4]
+        assert_eq!(abi.function_id().unwrap(), [0x28, 0x8f, 0xb3, 0xb8]);
+    }
+
+    /// The entry takes the pinned name, so the artifact describes what callers actually send
+    #[test]
+    fn test_pinned_signature_renames_the_entry() {
+        let sig: Signature = parse_quote! {
+            fn first_method(to: Address, amount: U256) -> bool
+        };
+        let mut abi = FunctionABI::from_signature(&sig).unwrap();
+
+        abi.retype_from_signature("transfer(address,uint256)")
+            .unwrap();
+
+        assert_eq!(abi.name, "transfer");
+        assert_eq!(abi.function_id().unwrap(), [0xa9, 0x05, 0x9c, 0xbb]);
+    }
+
+    /// Tuples keep their components: a pinned signature spelling them the same way is accepted
+    #[test]
+    fn test_pinned_signature_keeps_matching_tuples() {
+        let sig: Signature = parse_quote! {
+            fn set(config: (U256, bool), owner: Address)
+        };
+        let mut abi = FunctionABI::from_signature(&sig).unwrap();
+
+        abi.retype_from_signature("set((uint256,bool),bytes32)")
+            .unwrap();
+
+        assert_eq!(abi.signature().unwrap(), "set((uint256,bool),bytes32)");
+    }
+
+    /// A tuple that disagrees with the pinned signature, or a different arity, cannot be mapped
+    #[test]
+    fn test_pinned_signature_rejects_tuple_retypes_and_arity_changes() {
+        let sig: Signature = parse_quote! {
+            fn set(config: (U256, bool), owner: Address)
+        };
+        let mut abi = FunctionABI::from_signature(&sig).unwrap();
+        assert!(abi
+            .retype_from_signature("set((uint256,uint256),address)")
+            .is_err());
+        assert!(abi.retype_from_signature("set(uint256,address)").is_err());
+        assert!(abi.retype_from_signature("set((uint256,bool))").is_err());
+        assert!(abi.retype_from_signature("set").is_err());
+    }
 
     #[test]
     fn test_basic_function_abi() {

--- a/crates/sdk-derive/derive-core/src/abi/function.rs
+++ b/crates/sdk-derive/derive-core/src/abi/function.rs
@@ -145,9 +145,10 @@ impl FunctionABI {
     /// whatever the Rust parameter types derive to. The published entry has to say the same thing,
     /// otherwise callers encoding from the artifact never reach the method. The entry takes the
     /// pinned name, and every leaf parameter whose derived type differs takes the pinned type at
-    /// its position. Tuples cannot be mapped onto a different pinned type, and a different number
-    /// of parameters cannot be mapped at all; both are errors, and on an error the entry is left
-    /// exactly as it was derived.
+    /// its position, provided both are encoded the same way (a single word, dynamic bytes, or
+    /// arrays of those). A substitution that changes the calldata layout, a tuple mapped onto a
+    /// different pinned type, and a different number of parameters cannot be mapped; all are
+    /// errors, and on an error the entry is left exactly as it was derived.
     pub fn retype_from_signature(&mut self, signature: &str) -> Result<(), ABIError> {
         let (name, params) = signature
             .strip_suffix(')')
@@ -179,6 +180,15 @@ impl FunctionABI {
                     "parameter `{}` derives to `{derived_type}`, but the pinned signature says \
                      `{pinned_type}`; a tuple parameter cannot be retyped, so the pinned \
                      signature has to spell out the same components",
+                    input.name
+                )));
+            }
+            let derived_layout = wire_layout(&derived_type);
+            if derived_layout.is_none() || derived_layout != wire_layout(&pinned_type) {
+                return Err(ABIError::TypeConversion(format!(
+                    "parameter `{}` derives to `{derived_type}`, but the pinned signature says \
+                     `{pinned_type}`, which is encoded differently; only a type with the same \
+                     calldata layout can stand in for another",
                     input.name
                 )));
             }
@@ -230,6 +240,55 @@ impl FunctionABI {
 
     pub fn from_json_value(value: serde_json::Value) -> Result<Self, serde_json::Error> {
         serde_json::from_value(value)
+    }
+}
+
+/// How a canonical leaf type is laid out in calldata
+///
+/// Two types with the same layout are encoded identically, so one can stand in for the other in a
+/// published signature without changing what the generated codec decodes.
+#[derive(Debug, PartialEq, Eq)]
+enum WireLayout {
+    /// One 32-byte word: integers, `address`, `bool`, `bytesN`
+    Word,
+    /// Offset, length and padded data: `bytes` and `string`
+    DynamicBytes,
+    /// Offset, length and the elements of the inner layout
+    Array(Box<WireLayout>),
+    /// A fixed number of elements of the inner layout, inline
+    FixedArray(usize, Box<WireLayout>),
+}
+
+fn wire_layout(ty: &str) -> Option<WireLayout> {
+    if let Some(inner) = ty.strip_suffix("[]") {
+        return wire_layout(inner).map(|inner| WireLayout::Array(Box::new(inner)));
+    }
+    if let Some(inner) = ty.strip_suffix(']') {
+        let (inner, length) = inner.rsplit_once('[')?;
+        let length = length.parse().ok()?;
+        return wire_layout(inner).map(|inner| WireLayout::FixedArray(length, Box::new(inner)));
+    }
+    match ty {
+        "bytes" | "string" => Some(WireLayout::DynamicBytes),
+        "address" | "bool" => Some(WireLayout::Word),
+        _ => {
+            let (is_fixed_bytes, width) = if let Some(width) = ty.strip_prefix("bytes") {
+                (true, width)
+            } else if let Some(width) = ty.strip_prefix("uint") {
+                (false, width)
+            } else if let Some(width) = ty.strip_prefix("int") {
+                (false, width)
+            } else {
+                return None;
+            };
+            let width: usize = width.parse().ok()?;
+            let is_valid = if is_fixed_bytes {
+                (1..=32).contains(&width)
+            } else {
+                width % 8 == 0 && (8..=256).contains(&width)
+            };
+            is_valid.then_some(WireLayout::Word)
+        }
     }
 }
 
@@ -317,6 +376,43 @@ mod tests {
             .unwrap();
 
         assert_eq!(abi.signature().unwrap(), "set((uint256,bool),bytes32)");
+    }
+
+    /// Only a type encoded the same way can stand in for the derived one: a pinned `bytes32`
+    /// for a `[u8; 32]` (`uint8[32]`, 32 words) would publish calldata the codec cannot decode
+    #[test]
+    fn test_pinned_signature_keeps_the_calldata_layout() {
+        let sig: Signature = parse_quote! {
+            fn store(root: [u8; 32], data: Bytes, ids: Vec<U256>, pair: [U256; 2], flag: bool)
+        };
+        let mut abi = FunctionABI::from_signature(&sig).unwrap();
+        let derived = abi.clone();
+        assert_eq!(
+            abi.signature().unwrap(),
+            "store(uint8[32],bytes,uint256[],uint256[2],bool)"
+        );
+
+        for rejected in [
+            "store(bytes32,bytes,uint256[],uint256[2],bool)",
+            "store(uint8[32],bytes32,uint256[],uint256[2],bool)",
+            "store(uint8[32],bytes,uint256,uint256[2],bool)",
+            "store(uint8[32],bytes,uint256[],uint256[3],bool)",
+            "store(uint8[32],bytes,uint256[],uint256[2],bytes)",
+            "store(uint8[32],bytes,uint256[],uint256[2],uint7)",
+        ] {
+            assert!(
+                abi.retype_from_signature(rejected).is_err(),
+                "{rejected} changes the calldata layout"
+            );
+            assert_eq!(abi, derived);
+        }
+
+        abi.retype_from_signature("store(bytes1[32],string,bytes32[],int256[2],uint8)")
+            .unwrap();
+        assert_eq!(
+            abi.signature().unwrap(),
+            "store(bytes1[32],string,bytes32[],int256[2],uint8)"
+        );
     }
 
     /// A tuple that disagrees with the pinned signature, or a different arity, cannot be mapped,

--- a/crates/sdk-derive/derive-core/src/method.rs
+++ b/crates/sdk-derive/derive-core/src/method.rs
@@ -494,14 +494,30 @@ impl<'a, T: MethodLike> MethodCollector<'a, T> {
         has_only_self && has_no_return
     }
 
-    /// Handles fallback method validation
-    fn handle_fallback_method(&mut self, method_sig: &Signature, span: Span) {
-        if !self.validate_fallback_signature(method_sig) {
+    /// Validates the fallback signature, recording an error when it is malformed
+    fn validate_fallback_method(&mut self, method_sig: &Signature, span: Span) -> bool {
+        let is_valid = self.validate_fallback_signature(method_sig);
+        if !is_valid {
             self.add_error(
                 span,
                 format!("{} method must have signature 'fn {}(&self)' with no parameters and no return value",
                         FALLBACK_METHOD, FALLBACK_METHOD),
             );
+        }
+        is_valid
+    }
+
+    /// Registers the fallback handler of a router implementation
+    ///
+    /// The handler is kept as a route so the router sees it (`has_fallback`) and dispatches every
+    /// unmatched selector to it. It never gets a selector arm or a codec of its own: the router
+    /// filters it out of `available_methods`.
+    fn handle_fallback_method(&mut self, method: &T)
+    where
+        T: Clone,
+    {
+        if self.validate_fallback_method(method.sig(), method.sig().span()) {
+            self.handle_regular_method(method);
         }
     }
 
@@ -570,7 +586,10 @@ impl Visit<'_> for MethodCollector<'_, TraitItemFn> {
             }
             // Special methods with custom handling
             CONSTRUCTOR_METHOD => self.handle_constructor_method(method),
-            FALLBACK_METHOD => self.handle_fallback_method(&method.sig, method.sig.span()),
+            // A client never dispatches, so the fallback is validated but not registered
+            FALLBACK_METHOD => {
+                self.validate_fallback_method(&method.sig, method.sig.span());
+            }
             // Regular user-defined methods
             _ => self.handle_regular_method(method),
         }
@@ -603,7 +622,7 @@ impl Visit<'_> for MethodCollector<'_, ImplItemFn> {
                     self.handle_constructor_method(method);
                 }
             }
-            FALLBACK_METHOD => self.handle_fallback_method(&method.sig, method.sig.span()),
+            FALLBACK_METHOD => self.handle_fallback_method(method),
             // Regular user-defined methods
             _ => {
                 let is_public = self.is_trait_impl || matches!(method.vis, Visibility::Public(_));
@@ -689,6 +708,71 @@ mod tests {
             fn fallback()
         };
         assert!(!collector.validate_fallback_signature(&invalid_without_self));
+    }
+
+    /// A router implementation keeps its fallback as a route, so the dispatcher can reach it
+    #[test]
+    fn test_fallback_is_registered_for_router_impls() {
+        let resolver = StructResolver::default();
+        let mut collector =
+            MethodCollector::<ImplItemFn>::new_for_impl(Span::call_site(), false, &resolver);
+
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                pub fn get_value(&self) -> u32 {
+                    42
+                }
+
+                fn fallback(&self) {}
+            }
+        };
+        visit::visit_item_impl(&mut collector, &impl_block);
+
+        assert!(collector.errors.is_empty());
+        assert_eq!(collector.methods.len(), 2);
+        assert!(collector
+            .methods
+            .iter()
+            .any(|method| method.parsed_signature().is_fallback()));
+    }
+
+    /// A malformed fallback is reported instead of being registered
+    #[test]
+    fn test_malformed_fallback_is_rejected_for_router_impls() {
+        let resolver = StructResolver::default();
+        let mut collector =
+            MethodCollector::<ImplItemFn>::new_for_impl(Span::call_site(), false, &resolver);
+
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                fn fallback(&self, data: u64) -> bool {
+                    data > 10
+                }
+            }
+        };
+        visit::visit_item_impl(&mut collector, &impl_block);
+
+        assert_eq!(collector.errors.len(), 1);
+        assert!(collector.methods.is_empty());
+    }
+
+    /// A client trait validates the fallback but never turns it into a callable method
+    #[test]
+    fn test_fallback_is_not_registered_for_client_traits() {
+        let resolver = StructResolver::default();
+        let mut collector = MethodCollector::<TraitItemFn>::new(Span::call_site(), &resolver);
+
+        let trait_def: syn::ItemTrait = parse_quote! {
+            trait ClientAPI {
+                fn get_value(&self) -> u32;
+                fn fallback(&self);
+            }
+        };
+        visit::visit_item_trait(&mut collector, &trait_def);
+
+        assert!(collector.errors.is_empty());
+        assert_eq!(collector.methods.len(), 1);
+        assert!(!collector.methods[0].parsed_signature().is_fallback());
     }
 
     #[test]

--- a/crates/sdk-derive/derive-core/src/method.rs
+++ b/crates/sdk-derive/derive-core/src/method.rs
@@ -158,15 +158,17 @@ impl<T: MethodLike> ParsedMethod<T> {
         if let Some((attr, _)) = &attr {
             if !attr.is_validation_enabled() {
                 let function_id = attr.function_id_bytes()?;
-                let abi = sig.function_abi_with(resolver).ok().and_then(|mut abi| {
+                let abi = sig.function_abi_with(resolver).ok().map(|mut abi| {
                     abi.state_mutability = state_mutability;
                     // The pinned signature is the interface the router dispatches on, so the
-                    // published entry has to hash to it. One that cannot be mapped onto the
-                    // derived parameters leaves nothing to publish.
+                    // published entry has to hash to it. Leaf parameters are mapped onto it
+                    // here; a signature that cannot be mapped leaves the derived entry as is,
+                    // and the artifact generator rejects the selector mismatch with the full
+                    // explanation instead of publishing it.
                     if let Some(pinned_signature) = attr.signature() {
-                        abi.retype_from_signature(&pinned_signature).ok()?;
+                        let _ = abi.retype_from_signature(&pinned_signature);
                     }
-                    Some(abi)
+                    abi
                 });
                 let signature = attr
                     .signature()

--- a/crates/sdk-derive/derive-core/src/method.rs
+++ b/crates/sdk-derive/derive-core/src/method.rs
@@ -391,6 +391,11 @@ pub struct MethodCollector<'a, T: MethodLike> {
     pub methods: Vec<ParsedMethod<T>>,
     /// Constructor method
     pub constructor: Option<ParsedMethod<T>>,
+    /// Fallback handler of a router implementation
+    ///
+    /// Kept apart from `methods`: it has no selector arm, so it must not occupy a selector in
+    /// the collision check either.
+    pub fallback: Option<ParsedMethod<T>>,
     /// Source span for error reporting
     pub span: Span,
     /// Collection of errors encountered during parsing
@@ -409,6 +414,7 @@ impl<'a, T: MethodLike> MethodCollector<'a, T> {
         Self {
             methods: Vec::new(),
             constructor: None,
+            fallback: None,
             span,
             errors: Vec::new(),
             selectors: HashSet::new(),
@@ -422,6 +428,7 @@ impl<'a, T: MethodLike> MethodCollector<'a, T> {
         Self {
             methods: Vec::new(),
             constructor: None,
+            fallback: None,
             span,
             errors: Vec::new(),
             selectors: HashSet::new(),
@@ -517,15 +524,27 @@ impl<'a, T: MethodLike> MethodCollector<'a, T> {
 
     /// Registers the fallback handler of a router implementation
     ///
-    /// The handler is kept as a route so the router sees it (`has_fallback`) and dispatches every
-    /// unmatched selector to it. It never gets a selector arm or a codec of its own: the router
-    /// filters it out of `available_methods`.
+    /// The handler is stored on its own so the router dispatches every unmatched selector to it.
+    /// It never gets a selector arm or a codec, and it takes no selector away from the regular
+    /// routes: a method pinned to `fallback()` can coexist with it.
     fn handle_fallback_method(&mut self, method: &T)
     where
         T: Clone,
     {
-        if self.validate_fallback_method(method.sig(), method.sig().span()) {
-            self.handle_regular_method(method);
+        let span = method.sig().span();
+        if !self.validate_fallback_method(method.sig(), span) {
+            return;
+        }
+        if self.fallback.is_some() {
+            self.add_error(
+                span,
+                format!("Multiple {FALLBACK_METHOD} methods defined. Only one is allowed"),
+            );
+            return;
+        }
+        match ParsedMethod::from_ref(method, self.resolver) {
+            Ok(parsed_method) => self.fallback = Some(parsed_method),
+            Err(err) => self.add_error(span, format!("Failed to parse fallback method: {err}")),
         }
     }
 
@@ -737,11 +756,35 @@ mod tests {
         visit::visit_item_impl(&mut collector, &impl_block);
 
         assert!(collector.errors.is_empty());
-        assert_eq!(collector.methods.len(), 2);
+        assert_eq!(collector.methods.len(), 1);
+        assert!(!collector.methods[0].parsed_signature().is_fallback());
         assert!(collector
-            .methods
-            .iter()
-            .any(|method| method.parsed_signature().is_fallback()));
+            .fallback
+            .as_ref()
+            .is_some_and(|method| method.parsed_signature().is_fallback()));
+        // The fallback has no selector arm, so it reserves no selector either.
+        assert_eq!(collector.selectors.len(), 1);
+        assert!(collector.validate_selectors().is_ok());
+    }
+
+    /// Only one fallback can be defined
+    #[test]
+    fn test_second_fallback_is_rejected_for_router_impls() {
+        let resolver = StructResolver::default();
+        let mut collector =
+            MethodCollector::<ImplItemFn>::new_for_impl(Span::call_site(), false, &resolver);
+
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                fn fallback(&self) {}
+
+                fn fallback(&mut self) {}
+            }
+        };
+        visit::visit_item_impl(&mut collector, &impl_block);
+
+        assert_eq!(collector.errors.len(), 1);
+        assert!(collector.fallback.is_some());
     }
 
     /// A malformed fallback is reported instead of being registered
@@ -762,6 +805,7 @@ mod tests {
 
         assert_eq!(collector.errors.len(), 1);
         assert!(collector.methods.is_empty());
+        assert!(collector.fallback.is_none());
     }
 
     /// A client trait validates the fallback but never turns it into a callable method
@@ -781,6 +825,7 @@ mod tests {
         assert!(collector.errors.is_empty());
         assert_eq!(collector.methods.len(), 1);
         assert!(!collector.methods[0].parsed_signature().is_fallback());
+        assert!(collector.fallback.is_none());
     }
 
     #[test]

--- a/crates/sdk-derive/derive-core/src/method.rs
+++ b/crates/sdk-derive/derive-core/src/method.rs
@@ -158,9 +158,15 @@ impl<T: MethodLike> ParsedMethod<T> {
         if let Some((attr, _)) = &attr {
             if !attr.is_validation_enabled() {
                 let function_id = attr.function_id_bytes()?;
-                let abi = sig.function_abi_with(resolver).ok().map(|mut abi| {
+                let abi = sig.function_abi_with(resolver).ok().and_then(|mut abi| {
                     abi.state_mutability = state_mutability;
-                    abi
+                    // The pinned signature is the interface the router dispatches on, so the
+                    // published entry has to hash to it. One that cannot be mapped onto the
+                    // derived parameters leaves nothing to publish.
+                    if let Some(pinned_signature) = attr.signature() {
+                        abi.retype_from_signature(&pinned_signature).ok()?;
+                    }
+                    Some(abi)
                 });
                 let signature = attr
                     .signature()

--- a/crates/sdk-derive/derive-core/src/router.rs
+++ b/crates/sdk-derive/derive-core/src/router.rs
@@ -619,6 +619,37 @@ mod b {
         assert_eq!(method.function_id(), [0xb6, 0xea, 0x7d, 0x04]);
     }
 
+    /// The published ABI of a method with a pinned selector hashes to that selector
+    #[test]
+    fn test_pinned_selector_is_what_the_abi_publishes() {
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                #[function_id("upgradeTo(address,uint256,string,bytes)")]
+                pub fn upgrade_to(
+                    &mut self,
+                    target_address: Address,
+                    genesis_hash: B256,
+                    genesis_version: String,
+                    wasm_bytecode: Bytes,
+                ) {
+                }
+            }
+        };
+
+        let router = process_router(quote! { mode = "solidity" }, impl_block.into_token_stream())
+            .expect("Failed to process router");
+
+        let method = router.available_methods()[0];
+        let abi = method
+            .function_abi()
+            .expect("a pinned leaf retype keeps the ABI");
+        assert_eq!(abi.signature().unwrap(), method.signature());
+        assert_eq!(abi.function_id().unwrap(), method.function_id());
+        assert_eq!(method.function_id(), [0x28, 0x8f, 0xb3, 0xb8]);
+        assert_eq!(abi.inputs[1].name, "genesis_hash");
+        assert_eq!(abi.inputs[1].ty, "uint256");
+    }
+
     /// A `fallback` handler is a route the dispatcher can reach, but it has no selector arm
     #[test]
     fn test_fallback_receives_unmatched_selectors() {

--- a/crates/sdk-derive/derive-core/src/router.rs
+++ b/crates/sdk-derive/derive-core/src/router.rs
@@ -332,11 +332,28 @@ impl Router {
         })
     }
 
+    /// The guard a handler's mutability calls for: anything but `payable` rejects a call that
+    /// carries value before the handler runs.
+    fn value_guard(handler: &ParsedMethod<ImplItemFn>, what: &str) -> TokenStream2 {
+        if handler.state_mutability().allows_value() {
+            return quote! {};
+        }
+        let message = format!("nonpayable {what} cannot receive value");
+        quote! {
+            use fluentbase_sdk::ContextReader as _;
+            if !self.sdk.context().contract_value().is_zero() {
+                panic!(#message);
+            }
+        }
+    }
+
     /// Generates input validation logic.
     fn generate_input_validation(&self) -> TokenStream2 {
-        if self.has_fallback() {
+        if let Some(fallback) = self.fallback() {
+            let value_guard = Self::value_guard(fallback, "fallback");
             quote! {
                 if input_length < 4 {
+                    #value_guard
                     self.fallback();
                     return;
                 }
@@ -380,16 +397,7 @@ impl Router {
         let param_count = params.len();
         let return_type_count = route.parsed_signature().return_type().len();
 
-        let value_guard = if route.state_mutability().allows_value() {
-            quote! {}
-        } else {
-            quote! {
-                use fluentbase_sdk::ContextReader as _;
-                if !self.sdk.context().contract_value().is_zero() {
-                    panic!("nonpayable method cannot receive value");
-                }
-            }
-        };
+        let value_guard = Self::value_guard(route, "method");
 
         // Generate parameter handling based on parameter count
         let param_handling = match param_count {
@@ -465,9 +473,11 @@ impl Router {
 
     /// Generates the fallback handler match arm.
     fn generate_fallback_arm(&self) -> TokenStream2 {
-        if self.has_fallback() {
+        if let Some(fallback) = self.fallback() {
+            let value_guard = Self::value_guard(fallback, "fallback");
             quote! {
                 _ => {
+                    #value_guard
                     self.fallback();
                 }
             }
@@ -684,9 +694,77 @@ mod b {
             .expect("Failed to generate router code")
             .to_string()
             .replace(' ', "");
-        assert!(generated.contains("_=>{self.fallback();}"));
-        assert!(generated.contains("ifinput_length<4{self.fallback();return;}"));
+        // Both dispatch paths end in the handler; the guard in front of it is covered separately.
+        assert!(generated.contains("self.fallback();}"));
+        assert!(generated.contains("self.fallback();return;}"));
         assert!(!generated.contains("unsupported method selector"));
+        assert!(!generated.contains("insufficient input length"));
+    }
+
+    /// A fallback that is not payable rejects value on both dispatch paths, like any route
+    #[test]
+    fn test_non_payable_fallback_rejects_value() {
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                pub fn get_value(&self) -> u32 {
+                    42
+                }
+
+                fn fallback(&self) {}
+            }
+        };
+
+        let router = process_router(quote! { mode = "solidity" }, impl_block.into_token_stream())
+            .expect("Failed to process router");
+        let generated = router
+            .generate()
+            .expect("Failed to generate router code")
+            .to_string()
+            .replace(' ', "");
+
+        assert_eq!(
+            generated
+                .matches("nonpayablefallbackcannotreceivevalue")
+                .count(),
+            2
+        );
+        // The guard runs before the handler on the short-input path and on the unknown-selector
+        // path alike.
+        assert_eq!(
+            generated
+                .matches("panic!(\"nonpayablefallbackcannotreceivevalue\");}self.fallback();")
+                .count(),
+            2
+        );
+    }
+
+    /// A payable fallback (`&mut self`, or annotated payable) accepts value-bearing calls
+    #[test]
+    fn test_payable_fallback_accepts_value() {
+        for impl_block in [
+            parse_quote! {
+                impl<SDK: SharedAPI> App<SDK> {
+                    fn fallback(&mut self) {}
+                }
+            },
+            parse_quote! {
+                impl<SDK: SharedAPI> App<SDK> {
+                    #[state_mutability("payable")]
+                    fn fallback(&self) {}
+                }
+            },
+        ] {
+            let impl_block: syn::ItemImpl = impl_block;
+            let router =
+                process_router(quote! { mode = "solidity" }, impl_block.into_token_stream())
+                    .expect("Failed to process router");
+            let generated = router
+                .generate()
+                .expect("Failed to generate router code")
+                .to_string();
+            assert!(!generated.contains("nonpayable fallback"));
+            assert!(!generated.contains("state_mutability"));
+        }
     }
 
     /// The fallback owns no selector, so a route pinned to `fallback()` can coexist with it

--- a/crates/sdk-derive/derive-core/src/router.rs
+++ b/crates/sdk-derive/derive-core/src/router.rs
@@ -28,6 +28,8 @@ pub struct Router {
     routes: Vec<ParsedMethod<ImplItemFn>>,
     /// Constructor method if defined
     constructor: Option<ParsedMethod<ImplItemFn>>,
+    /// Fallback handler if defined; never a route, it owns no selector
+    fallback: Option<ParsedMethod<ImplItemFn>>,
     /// Indicates whether this is a trait implementation
     is_trait_impl: bool,
 }
@@ -84,7 +86,10 @@ impl Router {
             return Err(error);
         }
 
-        if collector.methods.is_empty() && collector.constructor.is_none() {
+        if collector.methods.is_empty()
+            && collector.constructor.is_none()
+            && collector.fallback.is_none()
+        {
             let help = if is_trait_impl {
                 "For trait implementations, make sure the trait contains method declarations"
             } else {
@@ -119,6 +124,7 @@ impl Router {
             impl_block,
             routes: collector.methods,
             constructor: collector.constructor,
+            fallback: collector.fallback,
             is_trait_impl,
         })
     }
@@ -138,12 +144,14 @@ impl Router {
         &self.routes
     }
 
-    /// Returns all available method routes excluding fallback.
+    /// Returns all available method routes; the fallback is not one of them.
     pub fn available_methods(&self) -> Vec<&ParsedMethod<ImplItemFn>> {
-        self.routes
-            .iter()
-            .filter(|route| route.parsed_signature().rust_name() != "fallback")
-            .collect()
+        self.routes.iter().collect()
+    }
+
+    /// Returns the fallback handler if present.
+    pub fn fallback(&self) -> Option<&ParsedMethod<ImplItemFn>> {
+        self.fallback.as_ref()
     }
 
     /// Checks if the router is based on a trait implementation.
@@ -153,9 +161,7 @@ impl Router {
 
     /// Checks if the router has a fallback handler.
     pub fn has_fallback(&self) -> bool {
-        self.routes
-            .iter()
-            .any(|r| r.parsed_signature().is_fallback())
+        self.fallback.is_some()
     }
 
     /// Checks if the router has a constructor.
@@ -681,6 +687,45 @@ mod b {
         assert!(generated.contains("_=>{self.fallback();}"));
         assert!(generated.contains("ifinput_length<4{self.fallback();return;}"));
         assert!(!generated.contains("unsupported method selector"));
+    }
+
+    /// The fallback owns no selector, so a route pinned to `fallback()` can coexist with it
+    #[test]
+    fn test_fallback_does_not_reserve_a_selector() {
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                #[function_id("fallback()")]
+                pub fn catch_all(&self) {}
+
+                fn fallback(&self) {}
+            }
+        };
+
+        let router = process_router(quote! { mode = "solidity" }, impl_block.into_token_stream())
+            .expect("a route pinned to fallback() must not collide with the fallback");
+
+        assert!(router.has_fallback());
+        let routes = router.available_methods();
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].signature(), "fallback()");
+        assert_eq!(routes[0].parsed_signature().rust_name(), "catch_all");
+    }
+
+    /// A router may consist of a fallback alone
+    #[test]
+    fn test_fallback_only_router_is_accepted() {
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                fn fallback(&self) {}
+            }
+        };
+
+        let router = process_router(quote! { mode = "solidity" }, impl_block.into_token_stream())
+            .expect("a fallback-only router should be accepted");
+
+        assert!(router.has_fallback());
+        assert!(router.available_methods().is_empty());
+        router.generate().expect("Failed to generate router code");
     }
 
     /// Without a fallback, unknown selectors and short inputs still revert

--- a/crates/sdk-derive/derive-core/src/router.rs
+++ b/crates/sdk-derive/derive-core/src/router.rs
@@ -619,6 +619,62 @@ mod b {
         assert_eq!(method.function_id(), [0xb6, 0xea, 0x7d, 0x04]);
     }
 
+    /// A `fallback` handler is a route the dispatcher can reach, but it has no selector arm
+    #[test]
+    fn test_fallback_receives_unmatched_selectors() {
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                pub fn get_value(&self) -> u32 {
+                    42
+                }
+
+                fn fallback(&self) {}
+            }
+        };
+
+        let router = process_router(quote! { mode = "solidity" }, impl_block.into_token_stream())
+            .expect("Failed to process router");
+
+        assert!(router.has_fallback());
+        assert_eq!(router.available_methods().len(), 1);
+        assert_eq!(
+            router.available_methods()[0].parsed_signature().rust_name(),
+            "get_value"
+        );
+
+        let generated = router
+            .generate()
+            .expect("Failed to generate router code")
+            .to_string()
+            .replace(' ', "");
+        assert!(generated.contains("_=>{self.fallback();}"));
+        assert!(generated.contains("ifinput_length<4{self.fallback();return;}"));
+        assert!(!generated.contains("unsupported method selector"));
+    }
+
+    /// Without a fallback, unknown selectors and short inputs still revert
+    #[test]
+    fn test_unknown_selectors_revert_without_fallback() {
+        let impl_block: syn::ItemImpl = parse_quote! {
+            impl<SDK: SharedAPI> App<SDK> {
+                pub fn get_value(&self) -> u32 {
+                    42
+                }
+            }
+        };
+
+        let router = process_router(quote! { mode = "solidity" }, impl_block.into_token_stream())
+            .expect("Failed to process router");
+
+        assert!(!router.has_fallback());
+        let generated = router
+            .generate()
+            .expect("Failed to generate router code")
+            .to_string();
+        assert!(generated.contains("unsupported method selector"));
+        assert!(generated.contains("insufficient input length for method selector"));
+    }
+
     #[test]
     fn test_trait_router_generation() {
         let impl_block: syn::ItemImpl = parse_quote! {

--- a/crates/sdk-derive/docs/router.md
+++ b/crates/sdk-derive/docs/router.md
@@ -133,7 +133,9 @@ pub fn constructor(&mut self, owner: Address, initial_supply: U256) {
 
 The `fallback` method handles unmatched function selectors:
 
-- **Signature**: Must be `fn fallback(&self)` with no parameters or return
+- **Signature**: Must be `fn fallback(&self)` or `fn fallback(&mut self)`, with no parameters
+  and no return value
+- **Short inputs**: Calls shorter than a 4-byte selector are routed to the fallback as well
 - **Optional**: Contract reverts on unknown selectors if not defined
 
 ## Notes & Best Practices

--- a/crates/sdk-derive/docs/router.md
+++ b/crates/sdk-derive/docs/router.md
@@ -136,6 +136,9 @@ The `fallback` method handles unmatched function selectors:
 - **Signature**: Must be `fn fallback(&self)` or `fn fallback(&mut self)`, with no parameters
   and no return value
 - **Short inputs**: Calls shorter than a 4-byte selector are routed to the fallback as well
+- **Value**: A `&self` fallback is `view` and rejects calls that carry value, like any other
+  non-payable method; declare it `&mut self` (payable) or annotate it with
+  `#[state_mutability("payable")]` to accept them
 - **Optional**: Contract reverts on unknown selectors if not defined
 
 ## Notes & Best Practices

--- a/crates/sdk-derive/src/lib.rs
+++ b/crates/sdk-derive/src/lib.rs
@@ -87,12 +87,23 @@ pub fn function_id(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// # Special Methods
 ///
-/// - **deploy**: Always excluded from routing, used for initialization ```rust,ignore fn
-///   deploy(&self) { // Deployment logic, called only once } ```
+/// - **deploy**: Always excluded from routing, used for initialization.
+///
+/// ```rust,ignore
+/// fn deploy(&self) {
+///     // Deployment logic, called only once.
+/// }
+/// ```
 ///
 /// - **fallback**: Handles unmatched selectors and inputs shorter than a selector; takes `&self`
-///   or `&mut self`, no parameters, no return value ```rust,ignore fn fallback(&self) { // Called
-///   for unknown function selectors } ```
+///   or `&mut self`, no parameters, and no return value. A `&self` fallback is `view` and rejects
+///   calls that carry value; `&mut self` (or `#[state_mutability("payable")]`) accepts them.
+///
+/// ```rust,ignore
+/// fn fallback(&self) {
+///     // Called for unknown function selectors.
+/// }
+/// ```
 ///
 /// # Attributes
 ///

--- a/crates/sdk-derive/src/lib.rs
+++ b/crates/sdk-derive/src/lib.rs
@@ -90,8 +90,9 @@ pub fn function_id(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// - **deploy**: Always excluded from routing, used for initialization ```rust,ignore fn
 ///   deploy(&self) { // Deployment logic, called only once } ```
 ///
-/// - **fallback**: Handles unmatched selectors ```rust,ignore fn fallback(&self) { // Called for
-///   unknown function selectors } ```
+/// - **fallback**: Handles unmatched selectors and inputs shorter than a selector; takes `&self`
+///   or `&mut self`, no parameters, no return value ```rust,ignore fn fallback(&self) { // Called
+///   for unknown function selectors } ```
 ///
 /// # Attributes
 ///

--- a/crates/sdk-derive/tests/ui/router/pass/with_fallback.rs
+++ b/crates/sdk-derive/tests/ui/router/pass/with_fallback.rs
@@ -1,0 +1,36 @@
+#![allow(dead_code)]
+extern crate alloc;
+extern crate fluentbase_sdk;
+use fluentbase_sdk::{
+    basic_entrypoint,
+    derive::{router, Contract},
+    SharedAPI, U256,
+};
+
+#[derive(Contract)]
+struct App<SDK> {
+    sdk: SDK,
+}
+
+pub trait RouterAPI {
+    fn get_value(&self) -> U256;
+
+    // Handles every selector the router does not know, and inputs shorter than a selector
+    fn fallback(&self);
+}
+
+#[router(mode = "solidity")]
+impl<SDK: SharedAPI> RouterAPI for App<SDK> {
+    #[function_id("getValue()", validate(true))]
+    fn get_value(&self) -> U256 {
+        U256::from(42)
+    }
+
+    fn fallback(&self) {}
+}
+
+impl<SDK: SharedAPI> App<SDK> {
+    pub fn deploy(&self) {}
+}
+
+basic_entrypoint!(App);

--- a/docs/06-runtime-upgrade.md
+++ b/docs/06-runtime-upgrade.md
@@ -9,7 +9,7 @@ It exists so chain operators can replace system runtime bytecode, but it must st
 2. Input wasm is validated and compiled to rWasm.
 3. Contract invokes native upgrade syscall with target address + serialized rWasm module.
 4. Host side verifies caller path and installs new code at target.
-5. Upgrade emits target/genesis refs/code hash; recompile emits target/code hash.
+5. Upgrade emits target/genesis refs/code hash.
 
 ---
 
@@ -18,7 +18,6 @@ It exists so chain operators can replace system runtime bytecode, but it must st
 Upgrade contract exposes:
 
 - `upgradeTo(...)`
-- `recompile(...)`
 - `planUpgrade(...)`
 - `upgradeToPlanned(...)`
 - `changeOwner(...)`
@@ -27,10 +26,7 @@ Upgrade contract exposes:
 
 Key behavior:
 - only owner can upgrade,
-- `recompile(address)` loads the target account bytecode with `code_size`/`code_copy`, requires it to be
-  original WASM bytes, recompiles it to rWasm, and then uses the same upgrade syscall path as
-  `upgradeTo(...)`,
-- `upgradeTo(...)` emits `RuntimeUpgraded`, while `recompile(...)` emits `ContractRecompiled`,
+- `upgradeTo(...)` emits `RuntimeUpgraded`,
 - `planUpgrade(...)` lets the owner pre-authorize a release batch as exact `(target, raw WASM
   hash)` pairs plus release metadata and an authorized upgrador,
 - `upgradeToPlanned(...)` can be called only by that upgrador and only for a stored target/hash

--- a/docs/06-runtime-upgrade.md
+++ b/docs/06-runtime-upgrade.md
@@ -18,6 +18,7 @@ It exists so chain operators can replace system runtime bytecode, but it must st
 Upgrade contract exposes:
 
 - `upgradeTo(...)`
+- `upgradeEvmTo(...)`
 - `planUpgrade(...)`
 - `upgradeToPlanned(...)`
 - `changeOwner(...)`
@@ -27,6 +28,9 @@ Upgrade contract exposes:
 Key behavior:
 - only owner can upgrade,
 - `upgradeTo(...)` emits `RuntimeUpgraded`,
+- `upgradeEvmTo(...)` is the same owner-only path for Solidity system contracts: it installs EVM
+  bytecode through the native EVM runtime-upgrade syscall and emits `RuntimeUpgraded` with the
+  keccak256 of the installed bytes,
 - `planUpgrade(...)` lets the owner pre-authorize a release batch as exact `(target, raw WASM
   hash)` pairs plus release metadata and an authorized upgrador,
 - `upgradeToPlanned(...)` can be called only by that upgrador and only for a stored target/hash

--- a/e2e/runtime/src/bridge.rs
+++ b/e2e/runtime/src/bridge.rs
@@ -12,6 +12,10 @@ use revm::{
     context::result::{ExecutionResult, Output},
 };
 
+/// Balance the bridge starts with in the tests that assert it stays unchanged. Without it those
+/// assertions compare an empty account to itself and hold even if the hook stops accounting.
+const BRIDGE_PREFUND: U256 = U256::from_limbs([1_000_000_000, 0, 0, 0]);
+
 sol! {
     event ReceivedMessage(bytes32 messageHash, bool successfulCall, bytes returnData);
 
@@ -135,7 +139,9 @@ fn test_failed_send_message_does_not_burn_bridge_balance() {
         message: Bytes::new(),
     }
     .abi_encode();
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let result = ctx.call_evm_tx(
         Address::repeat_byte(0x01),
         PRECOMPILE_ROLLUP_BRIDGE,
@@ -167,7 +173,9 @@ fn test_bridge_transaction_fails_on_zero_topics_emitted() {
         message: Bytes::new(),
     }
     .abi_encode();
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let result = ctx.call_evm_tx(
         Address::repeat_byte(0x01),
         PRECOMPILE_ROLLUP_BRIDGE,
@@ -202,7 +210,9 @@ fn test_receive_message_revert_restores_bridge_balance() {
         message: Bytes::new(),
     }
     .abi_encode();
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let result = ctx.call_evm_tx(
         Address::repeat_byte(0x01),
         PRECOMPILE_ROLLUP_BRIDGE,
@@ -383,7 +393,9 @@ fn test_send_message_fails_on_value_mismatch() {
 
     ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
 
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let input = sendMessageCall {
         to: Address::repeat_byte(0x02),
         message: Bytes::new(),
@@ -409,7 +421,9 @@ fn test_send_message_fails_when_no_matching_log_emitted() {
 
     ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, vec![opcode::STOP]);
 
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let input = sendMessageCall {
         to: Address::repeat_byte(0x02),
         message: Bytes::new(),
@@ -435,7 +449,9 @@ fn test_receive_message_fails_when_success_log_missing() {
 
     ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, vec![opcode::STOP]);
 
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let input = receiveMessageCall {
         from: Address::repeat_byte(0x01),
         to: Address::repeat_byte(0x01),
@@ -491,7 +507,9 @@ fn test_receive_message_burns_balance_when_log_marks_unsuccessful_call() {
 
     ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
 
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let input = receiveMessageCall {
         from: Address::repeat_byte(0x01),
         to: Address::repeat_byte(0x01),
@@ -659,7 +677,9 @@ fn test_receive_failed_message_unsuccessful_log_restores_balance() {
 
     ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
 
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let input = receiveFailedMessageCall {
         from: Address::repeat_byte(0x01),
         to: Address::repeat_byte(0x01),
@@ -715,7 +735,9 @@ fn test_receive_failed_message_unsuccessful_retried_failed_log_restores_balance(
 
     ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
 
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let input = receiveFailedMessageCall {
         from: Address::repeat_byte(0x01),
         to: Address::repeat_byte(0x01),
@@ -750,7 +772,9 @@ fn test_receive_failed_message_revert_restores_bridge_balance() {
     bytecode.push(opcode::REVERT);
     ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
 
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let input = receiveFailedMessageCall {
         from: Address::repeat_byte(0x01),
         to: Address::repeat_byte(0x01),
@@ -781,7 +805,9 @@ fn test_receive_failed_message_fails_when_success_log_missing() {
 
     ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, vec![opcode::STOP]);
 
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
     let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
     let input = receiveFailedMessageCall {
         from: Address::repeat_byte(0x01),
         to: Address::repeat_byte(0x01),

--- a/e2e/runtime/src/fee_manager.rs
+++ b/e2e/runtime/src/fee_manager.rs
@@ -166,9 +166,10 @@ fn test_fee_manager_withdraw_authority_survives_rejected_zero_transfer() {
     assert!(!withdraw(&mut ctx, DEFAULT_FEE_MANAGER_AUTH, recipient));
     assert_eq!(ctx.get_balance(PRECOMPILE_FEE_MANAGER), amount);
 
-    // The real owner still can.
+    // The real owner still can, and the withdrawal drains the fee manager.
     assert!(withdraw(&mut ctx, governance, recipient));
     assert_eq!(ctx.get_balance(recipient), amount);
+    assert_eq!(ctx.get_balance(PRECOMPILE_FEE_MANAGER), U256::ZERO);
 }
 
 /// Renunciation stays the explicit fork-only exit and is not weakened by the zero-address guard.
@@ -221,10 +222,9 @@ fn test_fee_manager_withdraw() {
     );
     assert!(result.is_success());
 
-    let new_balance = ctx.get_balance(recipient);
-    assert_eq!(new_balance, amount);
-
-    // Note: The current implementation emits `FeeWithdrawn` and does not transfer; success indicates positive balance and correct auth.
+    // The whole balance moves: the recipient is credited and the fee manager is drained.
+    assert_eq!(ctx.get_balance(recipient), amount);
+    assert_eq!(ctx.get_balance(PRECOMPILE_FEE_MANAGER), U256::ZERO);
 }
 
 #[test]

--- a/e2e/runtime/src/router.rs
+++ b/e2e/runtime/src/router.rs
@@ -42,3 +42,29 @@ fn test_client_solidity() {
     let msg: String = SolidityABI::decode(msg_b, 0).unwrap();
     assert_eq!(msg, "Hello World");
 }
+
+/// A selector the example router does not know is dispatched to its `fallback`, which echoes the
+/// calldata; before the fallback was registered the call reverted on "unsupported method selector".
+#[test]
+fn test_router_fallback_receives_unknown_selector() {
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+    const DEPLOYER_ADDRESS: Address = address!("1231238908230948230948209348203984029834");
+    ctx.add_balance(DEPLOYER_ADDRESS, U256::from(10e18));
+
+    let contract_address = ctx.deploy_evm_tx(
+        DEPLOYER_ADDRESS,
+        FLUENTBASE_EXAMPLES_ROUTER_SOLIDITY.wasm_bytecode.into(),
+    );
+
+    for input in [&hex!("deadbeef0102030405")[..], &hex!("0102")[..]] {
+        let result = ctx.call_evm_tx(
+            DEPLOYER_ADDRESS,
+            contract_address,
+            input.to_vec().into(),
+            None,
+            None,
+        );
+        assert!(result.is_success(), "fallback call failed: {result:?}");
+        assert_eq!(result.output().unwrap().as_ref(), input);
+    }
+}

--- a/e2e/runtime/src/update_account.rs
+++ b/e2e/runtime/src/update_account.rs
@@ -314,12 +314,18 @@ fn test_cant_upgrade_from_incorrect_address() {
     let result = ctx.call_evm_tx(
         address!("0x1111111111111111111111111111111111111111"),
         PRECOMPILE_RUNTIME_UPGRADE,
-        upgrade_input.into(),
+        bytes_input.into(),
         None,
         None,
     );
     println!("{:?}", result);
     assert!(!result.is_success());
+    // The call must be rejected by the owner check, not by a malformed selector.
+    let output = result.output().cloned().unwrap_or_default();
+    assert!(
+        String::from_utf8_lossy(&output).contains("incorrect caller"),
+        "unexpected revert reason: {output:?}"
+    );
 }
 
 /// A canonical EVM precompile that Fluent implements as rWasm in state. EVM-facing code queries for

--- a/examples/router-solidity/lib.rs
+++ b/examples/router-solidity/lib.rs
@@ -21,6 +21,7 @@ pub trait RouterAPI {
     fn custom_greeting(&self, message: String) -> String;
     fn byte_array(&self, data: [u8; 32]) -> [u8; 32];
     fn fixed_bytes(&self, data: FixedBytes<32>) -> FixedBytes<32>;
+    fn fallback(&mut self);
 }
 
 #[router(mode = "solidity")]
@@ -45,6 +46,13 @@ impl<SDK: SharedAPI> RouterAPI for App<SDK> {
     #[function_id("fixedBytes(bytes32)", validate(true))]
     fn fixed_bytes(&self, data: FixedBytes<32>) -> FixedBytes<32> {
         data
+    }
+
+    // Unknown selectors, and inputs shorter than a selector, land here instead of reverting.
+    // This example echoes the raw calldata so callers can see the router forwarded it.
+    fn fallback(&mut self) {
+        let input = self.sdk.bytes_input();
+        self.sdk.write(input);
     }
 }
 
@@ -148,5 +156,27 @@ mod tests {
         let encoded_output = &sdk.take_output();
         let output = FixedBytesReturn::decode(&encoded_output.as_slice()).unwrap();
         assert_eq!(output.0 .0, data);
+    }
+
+    /// A selector the router does not know reaches `fallback`, which echoes the calldata
+    #[test]
+    fn test_fallback_receives_unknown_selector() {
+        let input = hex::decode("deadbeef0102030405").unwrap();
+        let sdk = TestingContextImpl::default().with_input(input.clone());
+        let mut router = App::new(sdk.clone());
+        router.deploy();
+        router.main();
+        assert_eq!(sdk.take_output(), input);
+    }
+
+    /// An input shorter than a selector takes the same path
+    #[test]
+    fn test_fallback_receives_short_input() {
+        let input = vec![0x01, 0x02];
+        let sdk = TestingContextImpl::default().with_input(input.clone());
+        let mut router = App::new(sdk.clone());
+        router.deploy();
+        router.main();
+        assert_eq!(sdk.take_output(), input);
     }
 }

--- a/scripts/generate-contract-abis.bash
+++ b/scripts/generate-contract-abis.bash
@@ -49,7 +49,7 @@ find "$REPO_ROOT/contracts" -mindepth 2 -maxdepth 2 -name Cargo.toml | sort | wh
     printf '[]\n' >"${tmp_dir}/abi.json"
   fi
 
-  ABI_INPUT="${tmp_dir}/abi.json" ABI_OUTPUT="$abi_path" python3 - <<'PY'
+  ABI_INPUT="${tmp_dir}/abi.json" ABI_OUTPUT="$abi_path" CONTRACT_NAME="$contract_name" python3 - <<'PY'
 import json
 import os
 
@@ -59,7 +59,17 @@ with open(os.environ["ABI_INPUT"], encoding="utf-8") as abi_file:
 if not isinstance(abi, list):
     raise SystemExit("generated ABI must be a JSON array")
 
-with open(os.environ["ABI_OUTPUT"], "w", encoding="utf-8") as abi_file:
+# A contract without a `#[router]` (a hand-rolled entrypoint such as webauthn) generates nothing;
+# its published ABI is maintained by hand and must not be replaced with an empty array.
+output_path = os.environ["ABI_OUTPUT"]
+if not abi and os.path.exists(output_path):
+    with open(output_path, encoding="utf-8") as existing_file:
+        existing = json.load(existing_file)
+    if existing:
+        print(f"contracts/{os.environ['CONTRACT_NAME']}: no router found, keeping the hand-maintained ABI")
+        raise SystemExit(0)
+
+with open(output_path, "w", encoding="utf-8") as abi_file:
     json.dump(abi, abi_file, indent=2)
     abi_file.write("\n")
 PY


### PR DESCRIPTION
Follow-ups from the 2026-09-11 full-repository audit (`audits/2026-09-11-fluentbase-audit.md`), limited to the findings that survived re-verification against the code. One commit per finding.

## Fixes

- **Router fallback was never dispatched** (`H-SDK-DERIVE-01`). `#[router]` validated `fn fallback` but never registered it, so `has_fallback()` was always false and unknown selectors hit `panic!("unsupported method selector")`. The fallback is now a route of the implementation (client traits still only validate it), stays out of selector arms and codecs, and is covered in derive-core, in the router example and by an end-to-end call against the compiled example.
- **Published ABIs did not match the routers** (`H-E-CC-12`, `H-E-CC-W1`). A pinned `#[function_id("name(types)")]` is the interface the router dispatches on, but the generator kept the Rust-derived types, so runtime-upgrade published `upgradeTo(address,bytes32,…)` for a router that routes `upgradeTo(address,uint256,…)` and the selector check made regeneration fail (which is why `upgradeEvmTo` was missing). Leaf parameters are now retyped from the pinned signature, the runtime-upgrade ABI is regenerated, and a test pins the artifact to the router's selectors. The WebAuthn ABI loses the phantom `origin_index` parameter on `verifyStrict`, gets the same selector test, and the ABI script no longer overwrites hand-maintained ABIs of router-less contracts with `[]`.
- **Unreachable `recompile` entrypoint** (`E-CC-18`). `code_copy` never yields WASM (rWasm accounts return the serialized module, EVM-runtime accounts EVM bytecode, canonical precompiles nothing), so the call always panicked. Removed with its event and docs. This changes the runtime-upgrade contract's selector table; it takes effect on chain only through the normal runtime-upgrade process.
- **Publish workflow** (`I-01`). A manual run with `dry_run` off on a tag ref published without the canonical stable-tag check. Manual runs now default to dry run, always enter the job so a misdirected publish fails visibly, and any run that publishes must be on the canonical stable tag ref.

## Test fixes

- `E2E-05`: the unauthorized `upgradeTo` test sent the unprefixed input and reverted on the selector before `only_owner`; it now reaches the owner check and asserts the revert reason.
- `E2E-04`: eleven bridge tests compared the balance of an account that only the hook under test funds, so `0 == 0` always held; the bridge is pre-funded in those tests.
- `E2E-10`: withdraw tests now assert the fee manager is drained, and the stale "does not transfer" comment is gone.

## Verification

- `cargo test -p fluentbase-sdk-derive-core`: 157 passed.
- `cargo test --manifest-path examples/Cargo.toml -p fluentbase-examples-router-solidity`: 6 passed (2 new).
- `cargo test --manifest-path contracts/Cargo.toml -p fluentbase-contracts-webauthn -p fluentbase-contracts-runtime-upgrade`: 26 + 21 passed (2 new ABI tests).
- `cargo test --release --no-default-features --features std -p fluentbase-e2e -- router:: bridge:: fee_manager:: update_account::`: 40 passed.
- `contracts/runtime-upgrade/abi.json` regenerated with `fluentbase-build --generate abi`; `cargo fmt --all -- --check` clean; clippy clean on the touched crates.

## Not changed on purpose

`H-REVM-01/03/04/05`, `H-EVM-01` and `H-TYPES-01` were found to be wrong or latent on re-verification; `B-02` (zero fixture hash) is by design of partial-prestate fixtures; the crypto curve glue and the rotted `nitro`/`svm` e2e modules are left for separate decisions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Routers can now handle unknown selectors and calldata shorter than four bytes through a fallback method.
  - ABI generation now preserves manually maintained ABI definitions when generation produces no entries.
  - Release publishing supports manual dry runs, with safeguards for stable-tag publishing.

- **Changes**
  - Runtime upgrades now use `upgradeEvmTo`; the `recompile` operation is no longer available.
  - WebAuthn’s strict verification call no longer accepts `origin_index`.
  - Custom function selectors now remain consistent with published ABI signatures.

- **Documentation**
  - Updated release, router fallback, and runtime-upgrade guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->