### PR TITLE
fix(revm): skip bridge credit on balance overflow instead of failing the block

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -174,6 +174,13 @@ EVM / consensus (`crates/evm`, `crates/revm`):
 - Gas arithmetic without checked/saturating ops; memory-expansion cost overflow.
 - Any divergence from canonical EVM semantics, or dependence on map-iteration order, is a consensus
   split.
+- **Per-transaction conditions escaping as fatal errors.** A hook or handler that returns
+  `ContextError::Custom` (or any `EVMError` other than `InvalidTransaction`) for a condition that
+  attacker-controlled calldata can trigger: the block executor reports it as an internal failure,
+  the payload builder falls back to an empty block, and the transaction stays in the pool — one
+  transaction stops the sequencer from including any. Such a condition must fail the frame or the
+  transaction deterministically (the bridge pre-hook skips an overflowing credit; the post-hook
+  replaces the frame result).
 
 Build / CI (`crates/build`, `.github/workflows`):
 
@@ -262,3 +269,4 @@ AI coding agents working in this repository must:
 | --- | --- |
 | 2026-05-28 | Initial repository-specific security policy. |
 | 2026-06-10 | Added Auditor's Checklist (known vulnerability classes); paired with AGENTS.md Security Audit Mode. |
+| 2026-09-11 | Checklist: per-transaction conditions escaping as fatal EVM errors (bridge pre-hook overflow). |

--- a/crates/revm/src/bridge.rs
+++ b/crates/revm/src/bridge.rs
@@ -84,16 +84,20 @@ pub(crate) fn apply_bridge_pre_invocation_hook<CTX: ContextTr>(
             .load_account_with_code_mut(PRECOMPILE_ROLLUP_BRIDGE)?
             .data;
 
+        // A credit that would overflow the bridge balance is a property of this one call, not of
+        // the node: the calldata is attacker-controlled and any account can send it. Returning an
+        // error here would surface as `EVMError::Custom`, which the block executor treats as a
+        // fatal (non-transaction) failure and the payload builder answers with an empty block.
+        // Skip the mint instead and let the frame run: the bridge contract cannot pay out a value
+        // it never received, so the call reverts (or the post-hook fails the burn), and the frame
+        // checkpoint discards the rest.
         if !bridge_account.incr_balance(message_value) {
             let bridge_balance = bridge_account.balance();
             warn!(
                 %bridge_balance,
                 value = %message_value,
-                "Failed to increase bridge balance on receive/receiveFailed message"
+                "Skipping bridge balance credit on receive/receiveFailed message: overflow"
             );
-            return Err(ContextError::Custom(
-                "bridge pre-hook: failed to increase bridge balance".to_string(),
-            ));
         }
     }
 
@@ -561,7 +565,7 @@ mod tests {
     }
 
     #[test]
-    fn pre_hook_fails_on_balance_overflow() {
+    fn pre_hook_skips_mint_on_balance_overflow() {
         let mut ctx = new_ctx();
         set_bridge_balance(&mut ctx, U256::MAX);
 
@@ -571,10 +575,36 @@ mod tests {
             U256::ZERO,
         );
 
-        let err = apply_bridge_pre_invocation_hook(&inputs, &mut ctx).unwrap_err();
+        // An overflowing credit must never escape as a context error: that is a fatal EVM error
+        // for the block executor, not a failed transaction.
+        apply_bridge_pre_invocation_hook(&inputs, &mut ctx).unwrap();
 
-        assert!(matches!(err, ContextError::Custom(_)));
         assert_eq!(bridge_balance(&mut ctx), U256::MAX);
+    }
+
+    #[test]
+    fn pre_hook_skips_mint_on_max_value_with_funded_bridge() {
+        // The reachable shape: any caller, `value = U256::MAX`, bridge holding at least 1 wei.
+        let mut ctx = new_ctx();
+        set_bridge_balance(&mut ctx, U256::from(1));
+
+        let inputs = make_call_inputs(
+            PRECOMPILE_ROLLUP_BRIDGE,
+            receive_message_input(U256::MAX),
+            U256::ZERO,
+        );
+        apply_bridge_pre_invocation_hook(&inputs, &mut ctx).unwrap();
+
+        assert_eq!(bridge_balance(&mut ctx), U256::from(1));
+
+        let inputs = make_call_inputs(
+            PRECOMPILE_ROLLUP_BRIDGE,
+            receive_failed_message_input(U256::MAX),
+            U256::ZERO,
+        );
+        apply_bridge_pre_invocation_hook(&inputs, &mut ctx).unwrap();
+
+        assert_eq!(bridge_balance(&mut ctx), U256::from(1));
     }
 
     #[test]

--- a/docs/05-security-invariants.md
+++ b/docs/05-security-invariants.md
@@ -110,7 +110,13 @@ sandboxed guest trap from becoming a node crash.
 Bridge hooks rely on expected event/data shape and ordering.
 Any ABI or flow change must update hook logic in sync.
 
-Why it matters: mismatch can mint/burn/settle wrong amounts.
+Hooks fail the frame or the transaction, never the block. A condition that any caller can trigger
+from calldata (an overflowing balance credit, a missing or malformed event) is a per-transaction
+failure: the pre-hook skips the credit and lets the frame run, the post-hook replaces the frame
+result. A `ContextError` returned from a hook is a fatal executor error: the payload builder falls
+back to an empty block and the transaction stays in the pool, so one transaction halts inclusion.
+
+Why it matters: mismatch can mint/burn/settle wrong amounts; a fatal error stops the sequencer.
 
 ---
 

--- a/e2e/runtime/src/bridge.rs
+++ b/e2e/runtime/src/bridge.rs
@@ -227,6 +227,133 @@ fn test_receive_message_revert_restores_bridge_balance() {
 }
 
 #[test]
+fn test_receive_message_overflowing_value_is_a_failed_transaction() {
+    // A `receiveMessage` whose `value` cannot be credited to the bridge without overflowing its
+    // balance used to surface as `EVMError::Custom`, which the block executor treats as fatal:
+    // the payload builder produced empty blocks while the transaction sat in the pool. It must be
+    // an ordinary failed transaction instead, and the bridge balance must not move.
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+
+    let mut bytecode = Vec::new();
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::REVERT);
+    ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
+
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
+    let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
+
+    let receive_message_input = receiveMessageCall {
+        from: Address::repeat_byte(0x01),
+        to: Address::repeat_byte(0x01),
+        value: U256::MAX,
+        chainId: U256::ONE,
+        blockNumber: U256::ZERO,
+        messageNonce: U256::ZERO,
+        message: Bytes::new(),
+    }
+    .abi_encode();
+    let result = ctx.call_evm_tx(
+        Address::repeat_byte(0x01),
+        PRECOMPILE_ROLLUP_BRIDGE,
+        receive_message_input.into(),
+        None,
+        None,
+    );
+    assert!(!result.is_success(), "unexpected result: {result:?}");
+    assert_eq!(ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE), old_balance);
+
+    let receive_failed_message_input = receiveFailedMessageCall {
+        from: Address::repeat_byte(0x01),
+        to: Address::repeat_byte(0x01),
+        value: U256::MAX,
+        chainId: U256::ONE,
+        blockNumber: U256::ZERO,
+        messageNonce: U256::ZERO,
+        message: Bytes::new(),
+    }
+    .abi_encode();
+    let result = ctx.call_evm_tx(
+        Address::repeat_byte(0x01),
+        PRECOMPILE_ROLLUP_BRIDGE,
+        receive_failed_message_input.into(),
+        None,
+        None,
+    );
+    assert!(!result.is_success(), "unexpected result: {result:?}");
+    assert_eq!(ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE), old_balance);
+}
+
+#[test]
+fn test_receive_message_overflowing_value_halts_when_log_marks_unsuccessful_call() {
+    // The shape the real bridge produces for an uncreditable value: the relayer path runs, the
+    // payout call fails, and the contract emits `ReceivedMessage(successfulCall = false)`. The
+    // post-hook then has to burn a value that was never minted, and fails the frame instead of
+    // the block.
+    let mut ctx = EvmTestingContext::default().with_full_genesis();
+
+    let log_data = ReceivedMessage {
+        messageHash: B256::ZERO,
+        successfulCall: false,
+        returnData: Bytes::new(),
+    }
+    .encode_data();
+
+    let mut bytecode = Vec::new();
+    const LOG_DATA_OFFSET: usize = 6 + 2 + 32 + 3 + 1;
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(log_data.len()).unwrap());
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(LOG_DATA_OFFSET).unwrap());
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::CODECOPY);
+    bytecode.push(opcode::PUSH32);
+    bytecode.extend_from_slice(ReceivedMessage::SIGNATURE_HASH.as_slice());
+    bytecode.push(opcode::PUSH1);
+    bytecode.push(u8::try_from(log_data.len()).unwrap());
+    bytecode.push(opcode::PUSH0);
+    bytecode.push(opcode::LOG1);
+    bytecode.push(opcode::STOP);
+    assert_eq!(bytecode.len(), LOG_DATA_OFFSET);
+    bytecode.extend(log_data);
+    ctx.add_evm_contract(PRECOMPILE_ROLLUP_BRIDGE, bytecode);
+
+    ctx.add_balance(PRECOMPILE_ROLLUP_BRIDGE, BRIDGE_PREFUND);
+    let old_balance = ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE);
+    assert_eq!(old_balance, BRIDGE_PREFUND);
+
+    let input = receiveMessageCall {
+        from: Address::repeat_byte(0x01),
+        to: Address::repeat_byte(0x01),
+        value: U256::MAX,
+        chainId: U256::ONE,
+        blockNumber: U256::ZERO,
+        messageNonce: U256::ZERO,
+        message: Bytes::new(),
+    }
+    .abi_encode();
+    let result = ctx.call_evm_tx(
+        Address::repeat_byte(0x01),
+        PRECOMPILE_ROLLUP_BRIDGE,
+        input.into(),
+        None,
+        None,
+    );
+    assert!(
+        matches!(
+            result,
+            ExecutionResult::Halt {
+                reason: RwasmHaltReason::MalformedBuiltinParams,
+                ..
+            }
+        ),
+        "unexpected result: {result:?}"
+    );
+    assert_eq!(ctx.get_balance(PRECOMPILE_ROLLUP_BRIDGE), old_balance);
+}
+
+#[test]
 fn test_send_message_burns_balance_on_successful_valid_log() {
     let mut ctx = EvmTestingContext::default().with_full_genesis();
 


### PR DESCRIPTION
Fixes FLU-1389 (C2-01 / P2-01 in the 2026-09-11 audit).

## Problem

`apply_bridge_pre_invocation_hook` credits the bridge account with the `value` argument of any `receiveMessage` / `receiveFailedMessage` calldata before the frame runs. When that credit overflows the bridge balance (`incr_balance` is a `checked_add`), the hook returned `ContextError::Custom`, and `frame_init` propagated it with `?`.

That is not a transaction failure. revm turns it into `EVMError::Custom`; alloy-evm maps only `InvalidTransaction` to a skippable error, so it becomes `Internal`; reth's payload builder treats it as fatal for the attempt and falls back to an empty payload; the validator loop keeps going. The transaction is never marked invalid, so it is re-selected for every subsequent block: one transaction from any funded account (`value = U256::MAX`, bridge holding at least 1 wei, which holds on both networks) stops the sequencer from including anything until the pool is cleaned by hand.

## Fix

- **`crates/revm/src/bridge.rs`**: an overflowing credit is skipped instead of returned as an error. The frame runs without the mint: the bridge contract cannot pay out a value it never received, so the call reverts, or the post-hook fails to burn the unminted value and replaces the frame result with `MalformedBuiltinParams`. Either way it is an ordinary failed transaction, the sender pays gas, and the frame checkpoint discards any partial state. The `warn!` stays.
- **Unit tests**: `pre_hook_fails_on_balance_overflow` (which pinned the fatal error) becomes `pre_hook_skips_mint_on_balance_overflow`; `pre_hook_skips_mint_on_max_value_with_funded_bridge` covers the reachable shape (`value = U256::MAX` against a funded bridge, both selectors).
- **e2e (`e2e/runtime/src/bridge.rs`)**: two full-transaction tests through `EvmTestingContext`, which unwraps `transact_commit` and therefore panicked on the old code: a reverting bridge yields a failed transaction with the balance untouched; a bridge that emits `ReceivedMessage(successfulCall = false)` (what the real contract does when the payout call fails) halts with `MalformedBuiltinParams`, balance untouched.
- **Docs**: `SECURITY.md` auditor's checklist gets the class "per-transaction conditions escaping as fatal errors"; `docs/05-security-invariants.md` §8 states that bridge hooks fail the frame or the transaction, never the block.

No historical block can contain such a transaction (it would have failed block building), so re-execution of network history is unaffected; the change only matters for transactions submitted from now on.

## Not in this PR

The hook still mints from calldata for any caller (round-1 REVM-07). That is neutralised by the frame checkpoint (an unauthorised call reverts in the contract and the mint is discarded) and is tracked separately.

## Verification

- `cargo test -p fluentbase-revm --lib bridge::tests`: 24 passed (1 rewritten, 1 new).
- `cargo test -p fluentbase-e2e --release --no-default-features --features std -- bridge::`: 22 passed (2 new).
- `cargo fmt --all -- --check` clean; `cargo clippy -p fluentbase-revm -p fluentbase-e2e --all-targets -- -D warnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of bridge message credit overflows. Transactions now fail normally without triggering a fatal executor error or producing an empty block.
  - Prevented bridge balances from changing when message values cannot be credited safely.
  - Added correct failure handling for unsuccessful bridge calls, including appropriate halt reporting.

- **Documentation**
  - Updated security guidance and invariants to document transaction-level failure behavior and sequencer safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->