### PR TITLE
fix: follow-ups from the 2026-09-11 audit round 2 (FLU-1388)

### DIFF
--- a/.github/scripts/release-manifest.sh
+++ b/.github/scripts/release-manifest.sh
@@ -181,6 +181,7 @@ verify_manifest() {
 import hashlib
 import json
 import pathlib
+import re
 import sys
 
 manifest = pathlib.Path(sys.argv[1])
@@ -206,8 +207,15 @@ check_file(data["sbom"], "sbom")
 
 if not data.get("source", {}).get("commit"):
     errors.append("source commit is missing")
-if data.get("builder", {}).get("image") and not data.get("builder", {}).get("digest"):
+builder_digest = data.get("builder", {}).get("digest") or ""
+if data.get("builder", {}).get("image") and not builder_digest:
     errors.append("builder image is set but digest/id is missing")
+if data.get("builder", {}).get("image") and builder_digest and not re.fullmatch(
+    r"[^@\s]+@sha256:[0-9a-f]{64}|sha256:[0-9a-f]{64}", builder_digest
+):
+    errors.append(
+        "builder digest %r is not a registry manifest digest (name@sha256:<64 hex>)" % builder_digest
+    )
 if not data.get("toolchain", {}).get("rustc"):
     errors.append("rustc version is missing")
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   compare-on-pr:
-    if: github.event_name == 'pull_request'
+    # Persistent self-hosted runners must not execute code from a fork; see ci.yml.
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     permissions:
       contents: read

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -34,6 +34,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Sign the pushed image's provenance so release.yml can prove the builder image was
+      # produced by this workflow at the release commit before building inside it.
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout repository
@@ -140,6 +144,7 @@ jobs:
           echo "  TAGS=${TAGS}"
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./
@@ -161,6 +166,16 @@ jobs:
             SDK_VERSION_BRANCH=${{ steps.meta.outputs.sdk_version_branch }}
             SDK_VERSION_TAG=${{ steps.meta.outputs.sdk_version_tag }}
           no-cache: true
+
+      - name: Attest image provenance
+        # Binds the image digest to this workflow, this repository and the commit that built it.
+        # release.yml verifies the attestation with `gh attestation verify` before it builds
+        # inside the image, which is what turns the pulled digest into a checked value.
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Inspect image
         env:

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -27,6 +27,10 @@ jobs:
   build:
     runs-on: self-hosted
     timeout-minutes: 45
+    # The `release` environment gates the only job that can push the builder image the
+    # release pipeline compiles and signs genesis inside. Configure required reviewers on it
+    # in the repository settings; the environment itself carries no secrets.
+    environment: release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
 
   tests:
     name: Tests (${{ matrix.name }})
+    # Self-hosted runners are persistent and shared with the jobs that publish the builder
+    # image, so code from a fork must never execute on them. A fork pull request runs only the
+    # GitHub-hosted guard job above; a maintainer pushes the branch to this repository to run
+    # the full suite.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -16,6 +16,8 @@ env:
 jobs:
   clippy:
     name: Clippy (${{ matrix.name }})
+    # Persistent self-hosted runners must not execute code from a fork; see ci.yml.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: self-hosted
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,8 @@ jobs:
     permissions:
       contents: read
       packages: read
+      # `gh attestation verify` reads the builder image's provenance attestation.
+      attestations: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
@@ -148,6 +150,33 @@ jobs:
           done
           echo "Builder image is unavailable: $IMAGE"
           exit 1
+
+      - name: Verify builder image provenance
+        if: ${{ github.event.inputs.dry_run != 'true' }}
+        # The digest above is whatever the registry served for a mutable tag. Before anything is
+        # compiled inside the image, require a provenance attestation signed by this repository's
+        # build-docker workflow for exactly that digest, built from the commit being released.
+        # A substituted image, or one built from another commit, fails here.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_DIGEST: ${{ steps.build_image.outputs.digest }}
+          RELEASE_COMMIT: ${{ github.sha }}
+          SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/build-docker.yml
+        run: |
+          set -euo pipefail
+          gh attestation verify "oci://${IMAGE_DIGEST}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${SIGNER_WORKFLOW}" \
+            --format json > /tmp/builder-attestation.json
+          built_from="$(jq -r '
+            [.[] | .verificationResult.statement.predicate.buildDefinition.resolvedDependencies[]?
+                   | .digest.gitCommit // empty] | first // ""
+          ' /tmp/builder-attestation.json)"
+          if [[ "$built_from" != "$RELEASE_COMMIT" ]]; then
+            echo "Builder image ${IMAGE_DIGEST} was attested for commit '${built_from}', not the release commit ${RELEASE_COMMIT}" >&2
+            exit 1
+          fi
+          echo "Builder image ${IMAGE_DIGEST} attested by ${SIGNER_WORKFLOW} at ${RELEASE_COMMIT}"
 
       - name: Install wasm32 target
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,7 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io --username "${{ github.actor }}" --password-stdin
 
       - name: Wait for fluentbase-build image
+        id: wait_image
         if: ${{ github.event.inputs.dry_run != 'true' }}
         run: |
           IMAGE="${{ steps.build_image.outputs.image }}:${{ steps.build_image.outputs.tag }}"
@@ -159,7 +160,7 @@ jobs:
         # A substituted image, or one built from another commit, fails here.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          IMAGE_DIGEST: ${{ steps.build_image.outputs.digest }}
+          IMAGE_DIGEST: ${{ steps.wait_image.outputs.digest }}
           RELEASE_COMMIT: ${{ github.sha }}
           SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/build-docker.yml
         run: |
@@ -186,7 +187,7 @@ jobs:
           FLUENTBASE_CONTRACTS_DOCKER: "true"
           FLUENTBASE_BUILD_DOCKER_IMAGE: ${{ steps.build_image.outputs.image }}
           FLUENTBASE_BUILD_DOCKER_TAG: ${{ steps.build_image.outputs.tag }}
-          FLUENTBASE_BUILD_DOCKER_DIGEST: ${{ steps.build_image.outputs.digest }}
+          FLUENTBASE_BUILD_DOCKER_DIGEST: ${{ steps.wait_image.outputs.digest }}
           # A dry run builds the image locally, so it has no digest to verify.
           FLUENTBASE_BUILD_ALLOW_UNVERIFIED_IMAGE: ${{ github.event.inputs.dry_run == 'true' }}
         run: |
@@ -227,7 +228,7 @@ jobs:
         env:
           FLUENTBASE_BUILD_DOCKER_IMAGE: ${{ steps.build_image.outputs.image }}
           FLUENTBASE_BUILD_DOCKER_TAG: ${{ steps.build_image.outputs.tag }}
-          FLUENTBASE_BUILD_DOCKER_DIGEST: ${{ steps.build_image.outputs.digest }}
+          FLUENTBASE_BUILD_DOCKER_DIGEST: ${{ steps.wait_image.outputs.digest }}
           BUILD_TARGET: "genesis"
           BUILD_PROFILE: "release"
         run: |

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ fluentbase
 ├── docs/         how execution actually works, for contributors and auditors
 ├── flips/        Fluent Improvement Proposals
 ├── audits/       internal and external security audit reports
-├── docker/       node, build, cross and reproducible Dockerfiles
+├── docker/       node, build and cross Dockerfiles
 └── scripts/      genesis reproduction, ABI generation, contract verification
 ```
 
@@ -341,8 +341,10 @@ Versions follow `<stage>.<major>.<minor>`.
 - **minor** covers everything that leaves genesis untouched: SDK fixes, docs, tooling.
 
 Tagged stable releases publish the SDK crates to crates.io, ship signed genesis assets and node
-binaries on GitHub Releases, and build a multi-arch Docker image. The
-[`reproducible`](docker/Dockerfile.reproducible) build lets anyone rebuild the node bit-for-bit.
+binaries on GitHub Releases, and build a multi-arch Docker image. Genesis is compiled inside the
+[`fluentbase-build`](docker/Dockerfile.build) image, whose digest the release pipeline verifies
+against a provenance attestation from `build-docker.yml` before building, and the release
+workflow builds it twice and compares the hashes.
 
 ---
 

--- a/crates/genesis/build.rs
+++ b/crates/genesis/build.rs
@@ -77,8 +77,11 @@ fn default_chain_config(chain_id: u64) -> ChainConfig {
         merge_netsplit_block: Some(0u64),
         shanghai_time: Some(0u64),
         cancun_time: Some(0u64),
-        terminal_total_difficulty: None,
-        terminal_total_difficulty_passed: false,
+        // Every Fluent network starts post-merge. reth activates Paris from an external genesis
+        // file only when this field is set; without it `prevrandao` is absent and the first
+        // payload built from the file panics in the EIP-2935 pre-block system call.
+        terminal_total_difficulty: Some(U256::ZERO),
+        terminal_total_difficulty_passed: true,
         ethash: None,
         clique: None,
         extra_fields: Default::default(),

--- a/crates/node/src/chainspec.rs
+++ b/crates/node/src/chainspec.rs
@@ -225,17 +225,28 @@ pub(crate) fn chain_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::
         "fluent-testnet" => FLUENT_TESTNET.clone(),
         "fluent-mainnet" => FLUENT_MAINNET.clone(),
         _ => {
-            let spec: ChainSpec = parse_genesis(s)?.into();
+            let genesis = parse_genesis(s)?;
             // reth activates Paris from a genesis file only through `terminalTotalDifficulty`.
             // Without Paris the block environment carries no `prevrandao`, which the pre-block
             // system calls and every delegated runtime need, so a validator started from such
-            // a file would fail on its first payload. Refuse the file up front instead.
+            // a file would fail on its first payload. Every Fluent chain starts post-merge with
+            // zero difficulty, so the only meaningful value is 0: a nonzero TTD would still
+            // activate Paris at block 0 through `mergeNetsplitBlock`, but describes a merge
+            // that never happens. Refuse anything else up front.
+            match genesis.config.terminal_total_difficulty {
+                Some(ttd) if ttd.is_zero() => {}
+                Some(ttd) => eyre::bail!(
+                    "the genesis file sets `config.terminalTotalDifficulty` to {ttd}: every \
+                     Fluent chain starts post-merge with zero difficulty, so it must be 0"
+                ),
+                None => eyre::bail!(
+                    "the genesis file does not set `config.terminalTotalDifficulty`: every \
+                     Fluent chain starts post-merge, set it to 0"
+                ),
+            }
+            let spec: ChainSpec = genesis.into();
             if !spec.is_paris_active_at_block(0) {
-                eyre::bail!(
-                    "the genesis file does not activate Paris at block 0: every Fluent chain \
-                     starts post-merge, set `config.terminalTotalDifficulty` (0 for a chain \
-                     that has no pre-merge history)"
-                );
+                eyre::bail!("the genesis file does not activate Paris at block 0");
             }
             Arc::new(spec)
         }
@@ -273,6 +284,15 @@ mod tests {
         let err = chain_value_parser(&genesis_json(None)).unwrap_err();
         assert!(
             err.to_string().contains("terminalTotalDifficulty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn genesis_file_with_nonzero_terminal_total_difficulty_is_refused() {
+        let err = chain_value_parser(&genesis_json(Some(U256::from(1)))).unwrap_err();
+        assert!(
+            err.to_string().contains("terminalTotalDifficulty") && err.to_string().contains("1"),
             "unexpected error: {err}"
         );
     }

--- a/crates/node/src/chainspec.rs
+++ b/crates/node/src/chainspec.rs
@@ -4,7 +4,7 @@ use fluentbase_genesis::local_genesis_from_file;
 use fluentbase_release_verify::ReleaseAsset;
 use reth_chainspec::{
     make_genesis_header, BaseFeeParams, BaseFeeParamsKind, Chain, ChainHardforks, ChainSpec,
-    EthereumHardfork, ForkCondition, Hardfork, DEV_HARDFORKS,
+    EthereumHardfork, EthereumHardforks, ForkCondition, Hardfork, DEV_HARDFORKS,
 };
 use reth_cli::chainspec::{parse_genesis, ChainSpecParser};
 use reth_primitives_traits::SealedHeader;
@@ -224,6 +224,62 @@ pub(crate) fn chain_value_parser(s: &str) -> eyre::Result<Arc<ChainSpec>, eyre::
         "fluent-devnet" => FLUENT_DEVNET.clone(),
         "fluent-testnet" => FLUENT_TESTNET.clone(),
         "fluent-mainnet" => FLUENT_MAINNET.clone(),
-        _ => Arc::new(parse_genesis(s)?.into()),
+        _ => {
+            let spec: ChainSpec = parse_genesis(s)?.into();
+            // reth activates Paris from a genesis file only through `terminalTotalDifficulty`.
+            // Without Paris the block environment carries no `prevrandao`, which the pre-block
+            // system calls and every delegated runtime need, so a validator started from such
+            // a file would fail on its first payload. Refuse the file up front instead.
+            if !spec.is_paris_active_at_block(0) {
+                eyre::bail!(
+                    "the genesis file does not activate Paris at block 0: every Fluent chain \
+                     starts post-merge, set `config.terminalTotalDifficulty` (0 for a chain \
+                     that has no pre-merge history)"
+                );
+            }
+            Arc::new(spec)
+        }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::chain_value_parser;
+    use alloy_genesis::{ChainConfig, Genesis};
+    use reth_chainspec::EthereumHardforks;
+    use reth_revm::primitives::U256;
+
+    /// A genesis file in the shape `crates/genesis/build.rs` writes, with the merge field under test
+    fn genesis_json(terminal_total_difficulty: Option<U256>) -> String {
+        let genesis = Genesis {
+            config: ChainConfig {
+                chain_id: 1337,
+                merge_netsplit_block: Some(0),
+                shanghai_time: Some(0),
+                cancun_time: Some(0),
+                prague_time: Some(0),
+                osaka_time: Some(0),
+                terminal_total_difficulty,
+                terminal_total_difficulty_passed: terminal_total_difficulty.is_some(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        serde_json::to_string(&genesis).unwrap()
+    }
+
+    #[test]
+    fn genesis_file_without_terminal_total_difficulty_is_refused() {
+        let err = chain_value_parser(&genesis_json(None)).unwrap_err();
+        assert!(
+            err.to_string().contains("terminalTotalDifficulty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn genesis_file_with_terminal_total_difficulty_activates_paris() {
+        let spec = chain_value_parser(&genesis_json(Some(U256::ZERO))).unwrap();
+        assert!(spec.is_paris_active_at_block(0));
+    }
 }

--- a/crates/revm/Cargo.toml
+++ b/crates/revm/Cargo.toml
@@ -101,4 +101,3 @@ debug-print = [
     # "rwasm/debug-print",
 ]
 wasmtime = ["fluentbase-runtime/wasmtime", "rwasm/wasmtime"]
-eip1559-full-compatibility = []

--- a/crates/revm/src/api/exec.rs
+++ b/crates/revm/src/api/exec.rs
@@ -65,7 +65,7 @@ where
     fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         default_runtime_executor().reset_call_id_counter();
         self.0.ctx.set_tx(tx);
-        let mut h = RwasmHandler::<_, _>::default();
+        let mut h = RwasmHandler::<_, _>::new(self.1.burn_base_fee);
         h.run(self)
     }
 
@@ -77,7 +77,7 @@ where
         &mut self,
     ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
         default_runtime_executor().reset_call_id_counter();
-        let mut h = RwasmHandler::<_, _>::default();
+        let mut h = RwasmHandler::<_, _>::new(self.1.burn_base_fee);
         h.run(self).map(|result| {
             let state = self.finalize();
             ExecResultAndState::new(result, state)
@@ -112,7 +112,7 @@ where
     fn inspect_one_tx(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         default_runtime_executor().reset_call_id_counter();
         self.0.ctx.set_tx(tx);
-        let mut h = RwasmHandler::<_, _>::default();
+        let mut h = RwasmHandler::<_, _>::new(self.1.burn_base_fee);
         h.inspect_run(self)
     }
 }
@@ -144,7 +144,7 @@ where
             system_contract_address,
             data,
         ));
-        let mut h = RwasmHandler::<_, _>::default();
+        let mut h = RwasmHandler::<_, _>::new(self.1.burn_base_fee);
         h.run_system_call(self)
     }
 }

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -38,36 +38,65 @@ pub struct RwasmEvm<
 >(
     /// Inner EVM type.
     pub Evm<CTX, INSP, I, P, F>,
+    /// Fluent-specific execution options that have no place in the revm context.
+    pub RwasmEvmOptions,
 );
+
+/// Fluent-specific execution options.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RwasmEvmOptions {
+    /// Withhold the EIP-1559 base fee from the coinbase (Ethereum semantics).
+    ///
+    /// Off by default and on every node: Fluent credits the fee manager with the full effective
+    /// gas price. Only the Ethereum state-test comparison turns it on. See
+    /// `RwasmHandler::burn_base_fee`.
+    pub burn_base_fee: bool,
+}
 
 impl<CTX: ContextTr, INSP>
     RwasmEvm<CTX, INSP, EthInstructions<EthInterpreter, CTX>, RwasmPrecompiles>
 {
     /// Create a new Rwasm EVM.
     pub fn new(ctx: CTX, inspector: INSP) -> Self {
-        Self(Evm {
-            ctx,
-            inspector,
-            // Pinned to match the delegated EVM runtime, which always executes at Osaka because
-            // it is versioned by contract upgrade rather than by hardfork (see the
-            // `fluentbase_evm::evm` module docs). Deriving this from the chain spec instead
-            // would make the two interpreters disagree on which opcodes exist.
-            instruction: EthInstructions::new_mainnet_with_spec(SpecId::OSAKA),
-            precompiles: RwasmPrecompiles::default(),
-            frame_stack: FrameStack::new(),
-        })
+        Self(
+            Evm {
+                ctx,
+                inspector,
+                // Pinned to match the delegated EVM runtime, which always executes at Osaka
+                // because it is versioned by contract upgrade rather than by hardfork (see the
+                // `fluentbase_evm::evm` module docs). Deriving this from the chain spec instead
+                // would make the two interpreters disagree on which opcodes exist.
+                instruction: EthInstructions::new_mainnet_with_spec(SpecId::OSAKA),
+                precompiles: RwasmPrecompiles::default(),
+                frame_stack: FrameStack::new(),
+            },
+            RwasmEvmOptions::default(),
+        )
     }
 }
 
 impl<CTX, INSP, I, P> RwasmEvm<CTX, INSP, I, P> {
     /// Consumed self and returns a new Evm type with the given Inspector.
     pub fn with_inspector<OINSP>(self, inspector: OINSP) -> RwasmEvm<CTX, OINSP, I, P> {
-        RwasmEvm(self.0.with_inspector(inspector))
+        RwasmEvm(self.0.with_inspector(inspector), self.1)
     }
 
     /// Consumes self and returns a new Evm type with given Precompiles.
     pub fn with_precompiles<OP>(self, precompiles: OP) -> RwasmEvm<CTX, INSP, I, OP> {
-        RwasmEvm(self.0.with_precompiles(precompiles))
+        RwasmEvm(self.0.with_precompiles(precompiles), self.1)
+    }
+
+    /// Consumes self and returns the EVM with the EIP-1559 base-fee burn switched on or off.
+    ///
+    /// See [`RwasmEvmOptions::burn_base_fee`]; the chain's rule is `false`.
+    pub fn with_base_fee_burn(mut self, burn_base_fee: bool) -> Self {
+        self.1.burn_base_fee = burn_base_fee;
+        self
+    }
+
+    /// Fluent-specific execution options.
+    pub fn options(&self) -> &RwasmEvmOptions {
+        &self.1
     }
 
     /// Consumes self and returns the inner Inspector.

--- a/crates/revm/src/executor.rs
+++ b/crates/revm/src/executor.rs
@@ -251,7 +251,9 @@ fn execute_rwasm_frame<CTX: ContextTr, INSP: Inspector<CTX>>(
             timestamp: ctx.block().timestamp().as_limbs()[0],
             number: ctx.block().number().as_limbs()[0],
             difficulty: ctx.block().difficulty(),
-            prev_randao: ctx.block().prevrandao().unwrap(),
+            // Every supported chain spec is post-merge, so `prevrandao` is always present; a
+            // missing value (a chain spec without Paris) must not take the node down.
+            prev_randao: ctx.block().prevrandao().unwrap_or_default(),
             gas_limit: ctx.block().gas_limit(),
             base_fee: U256::from(ctx.block().basefee()),
         },

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -19,8 +19,25 @@ use revm::{
 /// Rwasm handler that implements the default [`Handler`] trait for the Evm.
 #[derive(Debug, Clone)]
 pub struct RwasmHandler<CTX, ERROR> {
+    /// Whether `reward_beneficiary` withholds the EIP-1559 base fee from the coinbase.
+    ///
+    /// Fluent credits the block beneficiary (the fee manager) with the full effective gas price:
+    /// no live network burns the base fee, and changing that is a fork. The Ethereum state-test
+    /// harness turns this on so its native-versus-rWASM comparison runs both sides with Ethereum
+    /// semantics; nothing that mirrors the chain should.
+    pub burn_base_fee: bool,
     /// Phantom data to hold the generic type parameters.
     pub _phantom: core::marker::PhantomData<(CTX, ERROR)>,
+}
+
+impl<CTX, ERROR> RwasmHandler<CTX, ERROR> {
+    /// Creates a handler; see [`RwasmHandler::burn_base_fee`] for the flag.
+    pub fn new(burn_base_fee: bool) -> Self {
+        Self {
+            burn_base_fee,
+            _phantom: core::marker::PhantomData,
+        }
+    }
 }
 
 impl<EVM, ERROR> Handler for RwasmHandler<EVM, ERROR>
@@ -75,22 +92,20 @@ where
         evm: &mut Self::Evm,
         exec_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
     ) -> Result<(), Self::Error> {
-        let (block, tx, _cfg, journal, _, _) = evm.ctx().all_mut();
+        let (block, tx, cfg, journal, _, _) = evm.ctx().all_mut();
         let basefee = block.basefee() as u128;
-        let coinbase_gas_price = tx.effective_gas_price(basefee);
+        let mut coinbase_gas_price = tx.effective_gas_price(basefee);
 
-        // Transfer fee to coinbase/beneficiary.
-        // EIP-1559 discard basefee for coinbase transfer. Basefee amount of gas is discarded.
-        #[cfg(feature = "eip1559-full-compatibility")]
-        let coinbase_gas_price = if _cfg
-            .spec()
-            .into()
-            .is_enabled_in(revm::primitives::hardfork::SpecId::LONDON)
+        // Ethereum semantics only (see `burn_base_fee`): EIP-1559 burns the base fee, so the
+        // coinbase receives the priority fee alone. Fluent's rule is the full effective price.
+        if self.burn_base_fee
+            && cfg
+                .spec()
+                .into()
+                .is_enabled_in(revm::primitives::hardfork::SpecId::LONDON)
         {
-            coinbase_gas_price.saturating_sub(basefee)
-        } else {
-            coinbase_gas_price
-        };
+            coinbase_gas_price = coinbase_gas_price.saturating_sub(basefee);
+        }
 
         journal
             .load_account_mut(block.beneficiary())?
@@ -103,9 +118,7 @@ where
 
 impl<CTX, ERROR> Default for RwasmHandler<CTX, ERROR> {
     fn default() -> Self {
-        Self {
-            _phantom: core::marker::PhantomData,
-        }
+        Self::new(false)
     }
 }
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -21,7 +21,7 @@ mod tests;
 mod types;
 
 pub use api::*;
-pub use evm::RwasmEvm;
+pub use evm::{RwasmEvm, RwasmEvmOptions};
 pub use handler::*;
 pub use precompiles::*;
 pub use result::*;

--- a/crates/revm/src/syscall.rs
+++ b/crates/revm/src/syscall.rs
@@ -40,7 +40,7 @@ use revm::{
     },
     Database, Inspector,
 };
-use rwasm::TrapCode;
+use rwasm::{TrapCode, N_BYTES_PER_MEMORY_PAGE, N_DEFAULT_MAX_MEMORY_PAGES};
 use std::{boxed::Box, vec, vec::Vec};
 use tracing::warn;
 
@@ -48,6 +48,15 @@ use tracing::warn;
 ///
 /// This allows tests to inject deterministic memory sources while production uses the
 /// default runtime executor.
+/// Largest input a CALL-family syscall accepts: the linear memory an ordinary contract can own.
+///
+/// A guest passes its input as an offset range into its own memory, so anything larger is out of
+/// bounds by construction, and the EVM runtime builds its calldata from EVM memory, whose
+/// expansion cost keeps it far below this. Checking the length first keeps a bogus range from
+/// reserving a large buffer before the memory read would reject it; `CREATE` has its own cap.
+pub(crate) const CALL_INPUT_HARD_CAP: usize =
+    (N_DEFAULT_MAX_MEMORY_PAGES * N_BYTES_PER_MEMORY_PAGE) as usize;
+
 pub(crate) trait MemoryReaderTr {
     fn memory_read(&self, call_id: u32, offset: usize, buffer: &mut [u8]) -> Result<(), TrapCode>;
 }
@@ -234,6 +243,13 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             let remaining_offset = inputs.input.start + $length;
             let remaining_length = inputs.input.end - inputs.input.start - $length;
             let lazy_contract_input = move || -> Result<Vec<u8>, TrapCode> {
+                // Probe the last byte first: guest memory is one contiguous region, so a
+                // readable last byte means the whole range is readable, and nothing is
+                // reserved for a range the read would reject anyway.
+                if remaining_length > 0 {
+                    let mut probe = [0u8; 1];
+                    mr.memory_read(call_id, remaining_offset + remaining_length - 1, &mut probe)?;
+                }
                 let mut variable_input = vec![0u8; remaining_length];
                 mr.memory_read(call_id, remaining_offset, &mut variable_input)?;
                 Ok(variable_input)
@@ -257,6 +273,13 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
             let remaining_offset = inputs.input.start + len;
             let remaining_length = inputs.input.end - inputs.input.start - len;
             let lazy_contract_input = move || -> Result<Vec<u8>, TrapCode> {
+                // Probe the last byte first: guest memory is one contiguous region, so a
+                // readable last byte means the whole range is readable, and nothing is
+                // reserved for a range the read would reject anyway.
+                if remaining_length > 0 {
+                    let mut probe = [0u8; 1];
+                    mr.memory_read(call_id, remaining_offset + remaining_length - 1, &mut probe)?;
+                }
                 let mut variable_input = vec![0u8; remaining_length];
                 mr.memory_read(call_id, remaining_offset, &mut variable_input)?;
                 Ok(variable_input)
@@ -355,6 +378,10 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
         }
 
         SYSCALL_ID_CALL => {
+            assert_halt!(
+                inputs.input.len() <= CALL_INPUT_HARD_CAP,
+                MalformedBuiltinParams
+            );
             let (input, lazy_contract_input) = get_input_validated!(>= 20 + 32);
             let target_address = Address::from_slice(&input[0..20]);
             let value = U256::from_le_slice(&input[20..52]);
@@ -419,6 +446,10 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
         }
 
         SYSCALL_ID_STATIC_CALL => {
+            assert_halt!(
+                inputs.input.len() <= CALL_INPUT_HARD_CAP,
+                MalformedBuiltinParams
+            );
             let (input, lazy_contract_input) = get_input_validated!(>= 20);
             let target_address = Address::from_slice(&input[0..20]);
             debug_syscall!("STATIC_CALL", "to={:?}", target_address);
@@ -471,6 +502,10 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
         }
 
         SYSCALL_ID_CALL_CODE => {
+            assert_halt!(
+                inputs.input.len() <= CALL_INPUT_HARD_CAP,
+                MalformedBuiltinParams
+            );
             let (input, lazy_contract_input) = get_input_validated!(>= 20 + 32);
             let target_address = Address::from_slice(&input[0..20]);
             let value = U256::from_le_slice(&input[20..52]);
@@ -533,6 +568,10 @@ pub(crate) fn execute_rwasm_interruption<CTX: ContextTr, INSP: Inspector<CTX>>(
         }
 
         SYSCALL_ID_DELEGATE_CALL => {
+            assert_halt!(
+                inputs.input.len() <= CALL_INPUT_HARD_CAP,
+                MalformedBuiltinParams
+            );
             let (input, lazy_contract_input) = get_input_validated!(>= 20);
             let target_address = Address::from_slice(&input[0..20]);
             debug_syscall!("DELEGATE_CALL", "to={:?}", target_address);

--- a/crates/revm/src/tests.rs
+++ b/crates/revm/src/tests.rs
@@ -1779,6 +1779,7 @@ mod eip8037_state_gas_tests {
 #[cfg(test)]
 mod static_call_frame_tests {
     use super::*;
+    use crate::syscall::CALL_INPUT_HARD_CAP;
     use fluentbase_sdk::{
         syscall::{SYSCALL_ID_CALL, SYSCALL_ID_CALL_CODE},
         FUEL_DENOM_RATE,
@@ -1795,6 +1796,17 @@ mod static_call_frame_tests {
     /// Raises a CALL-family syscall from a frame executing `CONTRACT` and returns what the host
     /// decided to do next.
     fn execute_call_syscall(code_hash: B256, is_static: bool, value: U256) -> NextAction {
+        execute_call_syscall_with_input_len(code_hash, is_static, value, None)
+    }
+
+    /// Like [`execute_call_syscall`], with the syscall's input range stretched to `input_len`
+    /// bytes while the guest memory behind it stays 52 bytes long.
+    fn execute_call_syscall_with_input_len(
+        code_hash: B256,
+        is_static: bool,
+        value: U256,
+        input_len: Option<usize>,
+    ) -> NextAction {
         let mut ctx: RwasmContext<InMemoryDB> =
             RwasmContext::new(InMemoryDB::default(), RwasmSpecId::PRAGUE);
         ctx.cfg = CfgEnv::new_with_spec(RwasmSpecId::PRAGUE);
@@ -1814,7 +1826,7 @@ mod static_call_frame_tests {
         let interruption_inputs = SystemInterruptionInputs {
             call_id: 0,
             code_hash,
-            input: 0..mr.0.len(),
+            input: 0..input_len.unwrap_or(mr.0.len()),
             fuel_limit: GAS_LIMIT * FUEL_DENOM_RATE,
             state: STATE_MAIN,
             fuel16_ptr: 0,
@@ -1849,6 +1861,33 @@ mod static_call_frame_tests {
         assert_eq!(inputs.target_address, CONTRACT);
         assert_eq!(inputs.caller, CONTRACT);
         assert_eq!(inputs.bytecode_address, CALLEE);
+    }
+
+    /// An input range above the hard cap halts before any of it is read; a range at the cap
+    /// passes the length check and reaches the memory read, which the 52-byte guest memory
+    /// behind the range cannot satisfy.
+    #[test]
+    fn call_input_above_hard_cap_halts_before_reading() {
+        for code_hash in [SYSCALL_ID_CALL, SYSCALL_ID_CALL_CODE] {
+            let NextAction::Return(result) = execute_call_syscall_with_input_len(
+                code_hash,
+                false,
+                U256::ZERO,
+                Some(CALL_INPUT_HARD_CAP + 1),
+            ) else {
+                panic!("an input above the hard cap must halt");
+            };
+            assert_eq!(result.result, InstructionResult::MalformedBuiltinParams);
+        }
+        let NextAction::Return(result) = execute_call_syscall_with_input_len(
+            SYSCALL_ID_CALL,
+            false,
+            U256::ZERO,
+            Some(CALL_INPUT_HARD_CAP),
+        ) else {
+            panic!("an input at the hard cap must reach the memory read and fail there");
+        };
+        assert_eq!(result.result, InstructionResult::MemoryOutOfBounds);
     }
 
     #[test]

--- a/crates/runtime/src/syscall_handler/tower/tower_fp2_add_sub_mul.rs
+++ b/crates/runtime/src/syscall_handler/tower/tower_fp2_add_sub_mul.rs
@@ -72,25 +72,30 @@ pub(crate) fn syscall_tower_fp2_add_sub_mul_handler<
     params: &[Value],
     _result: &mut [Value],
 ) -> Result<(), TrapCode> {
-    let (x_ptr, y_ptr) = (
+    // The guest ABI passes one pointer per limb (`_tower_fp2_*(a_c0, a_c1, b_c0, b_c1)`, see
+    // `fluentbase_types::import_linker`). The limbs are independent guest buffers, so nothing
+    // may be assumed about their layout; the result goes back through the two `a` pointers.
+    let (a_c0_ptr, a_c1_ptr, b_c0_ptr, b_c1_ptr) = (
         params[0].i32().unwrap() as u32,
         params[1].i32().unwrap() as u32,
+        params[2].i32().unwrap() as u32,
+        params[3].i32().unwrap() as u32,
     );
     let mut ac0 = [0u8; NUM_BYTES];
     let mut ac1 = [0u8; NUM_BYTES];
-    ctx.memory_read(x_ptr as usize, &mut ac0)?;
-    ctx.memory_read(x_ptr as usize + NUM_BYTES, &mut ac1)?;
+    ctx.memory_read(a_c0_ptr as usize, &mut ac0)?;
+    ctx.memory_read(a_c1_ptr as usize, &mut ac1)?;
     let mut bc0 = [0u8; NUM_BYTES];
     let mut bc1 = [0u8; NUM_BYTES];
-    ctx.memory_read(y_ptr as usize, &mut bc0)?;
-    ctx.memory_read(y_ptr as usize + NUM_BYTES, &mut bc1)?;
+    ctx.memory_read(b_c0_ptr as usize, &mut bc0)?;
+    ctx.memory_read(b_c1_ptr as usize, &mut bc1)?;
 
     let (res0, res1) =
         syscall_tower_fp2_add_sub_mul_impl::<NUM_BYTES, P, FIELD_OP>(ac0, ac1, bc0, bc1)
             .map_err(|exit_code| syscall_process_exit_code(ctx, exit_code))?;
 
-    ctx.memory_write(x_ptr as usize, &res0)?;
-    ctx.memory_write(x_ptr as usize + NUM_BYTES, &res1)?;
+    ctx.memory_write(a_c0_ptr as usize, &res0)?;
+    ctx.memory_write(a_c1_ptr as usize, &res1)?;
     Ok(())
 }
 
@@ -205,8 +210,60 @@ pub(crate) fn syscall_tower_fp2_add_sub_mul_impl<
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::executor::{RuntimeExecutor, RuntimeFactoryExecutor};
+    use fluentbase_types::{import_linker_v1_preview, Address, BytecodeOrHash, B256};
     use rand::Rng;
+    use rwasm::{CompilationConfig, RwasmModule};
     use std::str::FromStr;
+
+    /// Drives the real `_tower_fp2_bn254_add` import from a guest whose four limbs live in
+    /// separate, non-adjacent buffers, the way the SDK wrapper passes them.
+    ///
+    /// `a = 1 + 2i` at offsets 0 and 96, `b = 3 + 4i` at offsets 160 and 256, a canary right
+    /// after `a_c0`. The host must read `b` through its own pointers and write `a_c1` through
+    /// its pointer, not at `a_c0 + 32`.
+    #[test]
+    fn guest_fp2_add_reads_and_writes_each_limb_through_its_own_pointer() {
+        let wasm = wat::parse_str(
+            r#"(module
+                (import "fluentbase_v1preview" "_tower_fp2_bn254_add"
+                    (func $add (param i32 i32 i32 i32)))
+                (import "fluentbase_v1preview" "_write" (func $write (param i32 i32)))
+                (memory (export "memory") 1)
+                (func (export "main")
+                    (i32.store (i32.const 0) (i32.const 1))
+                    (i32.store (i32.const 32) (i32.const 0xdeadbeef))
+                    (i32.store (i32.const 96) (i32.const 2))
+                    (i32.store (i32.const 160) (i32.const 3))
+                    (i32.store (i32.const 256) (i32.const 4))
+                    i32.const 0 i32.const 96 i32.const 160 i32.const 256
+                    call $add
+                    i32.const 0 i32.const 32 call $write
+                    i32.const 96 i32.const 32 call $write
+                    i32.const 32 i32.const 4 call $write))"#,
+        )
+        .unwrap();
+        let mut executor = RuntimeFactoryExecutor::new(import_linker_v1_preview());
+        let config = CompilationConfig::default()
+            .with_entrypoint_name("main".into())
+            .with_import_linker(executor.import_linker.clone());
+        let (module, _) = RwasmModule::compile(config, &wasm).unwrap();
+        let result = executor.execute(
+            BytecodeOrHash::Bytecode {
+                bytecode: module,
+                hash: B256::with_last_byte(0x42),
+                address: Address::ZERO,
+            },
+            RuntimeContext::default().with_fuel_limit(1_000_000),
+        );
+        assert_eq!(result.exit_code, 0, "{result:?}");
+
+        let mut expected = Vec::new();
+        expected.extend_from_slice(&big_uint_into_bytes::<BN254_FP_SIZE>(&BigUint::from(4u32)));
+        expected.extend_from_slice(&big_uint_into_bytes::<BN254_FP_SIZE>(&BigUint::from(6u32)));
+        expected.extend_from_slice(&0xdeadbeef_u32.to_le_bytes());
+        assert_eq!(result.output, expected);
+    }
 
     fn random_bigint<const NUM_BYTES: usize>(modulus: &BigUint) -> BigUint {
         let mut rng = rand::rng();

--- a/crates/sdk-derive/derive-core/src/abi/function.rs
+++ b/crates/sdk-derive/derive-core/src/abi/function.rs
@@ -1,6 +1,8 @@
 use super::types::{rust_to_sol, ConversionError};
-use crate::abi::{error::ABIError, parameter::Parameter, structs::StructResolver};
-use convert_case::{Case, Casing};
+use crate::{
+    abi::{error::ABIError, parameter::Parameter, structs::StructResolver},
+    utils::naming::solidity_function_name,
+};
 use crypto_hashes::{digest::Digest, sha3::Keccak256};
 use serde::{Deserialize, Serialize};
 use syn::{FnArg, Pat, ReturnType, Signature, Type};
@@ -50,7 +52,7 @@ impl From<ConversionError> for ABIError {
 impl FunctionABI {
     pub fn from_signature(sig: &Signature) -> Result<Self, ABIError> {
         Ok(Self {
-            name: sig.ident.to_string().to_case(Case::Camel),
+            name: solidity_function_name(&sig.ident.to_string()),
             inputs: Self::convert_inputs(&sig.inputs.iter().collect::<Vec<_>>())?,
             outputs: Self::convert_outputs(&sig.output)?,
             state_mutability: StateMutability::NonPayable,

--- a/crates/sdk-derive/derive-core/src/signature.rs
+++ b/crates/sdk-derive/derive-core/src/signature.rs
@@ -1,3 +1,4 @@
+use crate::utils::naming::solidity_function_name;
 use crate::{
     abi::{
         constructor::ConstructorABI, error::ABIError, function::FunctionABI,
@@ -5,7 +6,6 @@ use crate::{
     },
     method::CONSTRUCTOR_METHOD,
 };
-use convert_case::{Case, Casing};
 use quote::ToTokens;
 use std::ops::Deref;
 use syn::{spanned::Spanned, FnArg, ReturnType, Signature};
@@ -33,9 +33,10 @@ impl ParsedSignature {
         self.0.ident.to_string()
     }
 
-    /// Returns the function name in Solidity style (camelCase)
+    /// Returns the function name in Solidity style (camelCase, or verbatim for a name that
+    /// already carries uppercase letters; see [`solidity_function_name`])
     pub fn sol_name(&self) -> String {
-        self.rust_name().to_case(Case::Camel)
+        solidity_function_name(&self.rust_name())
     }
 
     /// Returns the function's input arguments as a vector of (name, type) pairs

--- a/crates/sdk-derive/derive-core/src/sol_input.rs
+++ b/crates/sdk-derive/derive-core/src/sol_input.rs
@@ -4,6 +4,7 @@ use crate::{
         types::{convert_solidity_type, sol_to_rust},
     },
     attr::{StateMutabilityExt, STATE_MUTABILITY_ATTR},
+    utils::naming::solidity_function_name,
 };
 use alloy_sol_macro_input::{SolInput, SolInputKind};
 use convert_case::{Case, Casing};
@@ -328,8 +329,20 @@ fn sol_fn_to_trait_method(func: &ItemFunction, emit_mutability: bool) -> syn::Re
         return Ok(quote! {});
     }
 
-    // Convert function name to snake_case
-    let fn_name = format_ident!("{}", name.to_string().to_case(Case::Snake));
+    // The Rust method is named in snake_case when that spelling converts back to the Solidity
+    // one, which is what the router and client derive the selector from. A name it cannot
+    // reproduce (`mintNFT`, `tokenURI`, `DOMAIN_SEPARATOR`) is kept verbatim: snake-casing it
+    // would bake a selector no Solidity caller uses into the router and the generated client.
+    let sol_name = name.to_string();
+    let snake_name = sol_name.to_case(Case::Snake);
+    let (fn_name, name_attr) = if solidity_function_name(&snake_name) == sol_name {
+        (format_ident!("{}", snake_name), quote! {})
+    } else {
+        (
+            format_ident!("{}", sol_name),
+            quote! { #[allow(non_snake_case)] },
+        )
+    };
     let receiver = determine_method_receiver(func);
 
     // Generate function parameters. A dropped parameter would change the selector,
@@ -367,6 +380,7 @@ fn sol_fn_to_trait_method(func: &ItemFunction, emit_mutability: bool) -> syn::Re
     // Generate the function signature
     Ok(quote! {
         #mutability_attr
+        #name_attr
         fn #fn_name(#receiver #(, #args)*) #ret;
     })
 }
@@ -471,6 +485,59 @@ mod tests {
         let formatted = prettyplease::unparse(&file);
 
         assert_snapshot!("sol_struct_to_rust_tokens", formatted);
+    }
+
+    /// `mintNFT`, `tokenURI` and `DOMAIN_SEPARATOR` have no snake_case spelling that converts
+    /// back to them, so the trait keeps the Solidity name; `balanceOf` round-trips and stays
+    /// idiomatic. The generated client and a router over the trait derive the real selectors.
+    #[test]
+    fn test_mixed_case_names_keep_their_solidity_spelling() {
+        let solidity_code = r#"
+            interface INft {
+                function mintNFT(address to) external;
+                function tokenURI(uint256 id) external view returns (string memory);
+                function DOMAIN_SEPARATOR() external view returns (bytes32);
+                function balanceOf(address owner) external view returns (uint256);
+            }
+        "#;
+        let input: alloy_sol_macro_input::SolInput = parse_str(solidity_code).unwrap();
+
+        let generated = to_rust_trait(input).unwrap().to_string();
+        let file = syn::parse_file(&generated).unwrap();
+        let formatted = prettyplease::unparse(&file);
+
+        assert!(
+            formatted.contains("fn mintNFT(&mut self, to: Address);"),
+            "{formatted}"
+        );
+        assert!(
+            formatted.contains("fn tokenURI(&self, id: U256) -> String;"),
+            "{formatted}"
+        );
+        assert!(
+            formatted.contains("fn DOMAIN_SEPARATOR(&self) -> FixedBytes<32usize>;"),
+            "{formatted}"
+        );
+        assert!(
+            formatted.contains("fn balance_of(&self, owner: Address) -> U256;"),
+            "{formatted}"
+        );
+        assert_eq!(
+            formatted.matches("#[allow(non_snake_case)]").count(),
+            3,
+            "{formatted}"
+        );
+
+        // Each kept name derives the selector Solidity callers use.
+        for (rust_name, selector) in [
+            ("tokenURI(id: U256)", [0xc8, 0x7b, 0x56, 0xdd]),
+            ("DOMAIN_SEPARATOR()", [0x36, 0x44, 0xe5, 0x15]),
+            ("mintNFT(to: Address)", [0x54, 0xba, 0x0f, 0x27]),
+        ] {
+            let sig: syn::Signature = syn::parse_str(&format!("fn {rust_name}")).unwrap();
+            let abi = crate::abi::function::FunctionABI::from_signature(&sig).unwrap();
+            assert_eq!(abi.function_id().unwrap(), selector, "{rust_name}");
+        }
     }
 
     #[test]

--- a/crates/sdk-derive/derive-core/src/sol_input.rs
+++ b/crates/sdk-derive/derive-core/src/sol_input.rs
@@ -337,11 +337,25 @@ fn sol_fn_to_trait_method(func: &ItemFunction, emit_mutability: bool) -> syn::Re
     let snake_name = sol_name.to_case(Case::Snake);
     let (fn_name, name_attr) = if solidity_function_name(&snake_name) == sol_name {
         (format_ident!("{}", snake_name), quote! {})
-    } else {
+    } else if solidity_function_name(&sol_name) == sol_name {
         (
             format_ident!("{}", sol_name),
             quote! { #[allow(non_snake_case)] },
         )
+    } else {
+        // A name without uppercase letters that is not camelCase (`foo_bar`, `_foo`) is one no
+        // Rust identifier derives: the router and client would camel-case it to `fooBar`.
+        // Refusing it here beats compiling a trait whose selectors do not exist on chain.
+        return Err(syn::Error::new(
+            name.span(),
+            format!(
+                "Solidity function `{sol_name}` has no Rust spelling that derives its selector \
+                 (the router and client would use `{}`); rename it in the interface, or write \
+                 the trait by hand and pin `#[function_id(\"{sol_name}(...)\")]` on the \
+                 implementation",
+                solidity_function_name(&sol_name)
+            ),
+        ));
     };
     let receiver = determine_method_receiver(func);
 
@@ -538,6 +552,22 @@ mod tests {
             let abi = crate::abi::function::FunctionABI::from_signature(&sig).unwrap();
             assert_eq!(abi.function_id().unwrap(), selector, "{rust_name}");
         }
+    }
+
+    /// `foo_bar` cannot be spelled by any Rust identifier the naming rule maps back to it, so
+    /// the macro refuses it instead of deriving `fooBar`.
+    #[test]
+    fn test_lowercase_underscore_names_are_refused() {
+        let solidity_code = r#"
+            interface IOdd {
+                function foo_bar(address to) external;
+            }
+        "#;
+        let input: alloy_sol_macro_input::SolInput = parse_str(solidity_code).unwrap();
+
+        let err = to_rust_trait(input).unwrap_err().to_string();
+        assert!(err.contains("`foo_bar`"), "{err}");
+        assert!(err.contains("`fooBar`"), "{err}");
     }
 
     #[test]

--- a/crates/sdk-derive/derive-core/src/utils/mod.rs
+++ b/crates/sdk-derive/derive-core/src/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod naming;
 pub mod selector;

--- a/crates/sdk-derive/derive-core/src/utils/naming.rs
+++ b/crates/sdk-derive/derive-core/src/utils/naming.rs
@@ -1,0 +1,43 @@
+use convert_case::{Case, Casing};
+
+/// Solidity spelling of a Rust method name.
+///
+/// An idiomatic snake_case name is converted to camelCase (`balance_of` → `balanceOf`). A name
+/// that already contains an uppercase letter is taken verbatim: `mintNFT`, `tokenURI` and
+/// `DOMAIN_SEPARATOR` have no snake_case spelling that converts back to them, and re-casing such
+/// a name (`mintNFT` → `mintNft`) silently changes the selector the router dispatches on and the
+/// client encodes.
+#[must_use]
+pub fn solidity_function_name(rust_name: &str) -> String {
+    if rust_name.chars().any(|c| c.is_ascii_uppercase()) {
+        rust_name.to_string()
+    } else {
+        rust_name.to_case(Case::Camel)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::solidity_function_name;
+
+    #[test]
+    fn snake_case_names_become_camel_case() {
+        assert_eq!(solidity_function_name("balance_of"), "balanceOf");
+        assert_eq!(solidity_function_name("transfer"), "transfer");
+        assert_eq!(
+            solidity_function_name("safe_transfer_from"),
+            "safeTransferFrom"
+        );
+    }
+
+    #[test]
+    fn names_with_uppercase_letters_are_kept_verbatim() {
+        assert_eq!(solidity_function_name("mintNFT"), "mintNFT");
+        assert_eq!(solidity_function_name("tokenURI"), "tokenURI");
+        assert_eq!(
+            solidity_function_name("DOMAIN_SEPARATOR"),
+            "DOMAIN_SEPARATOR"
+        );
+        assert_eq!(solidity_function_name("balanceOf"), "balanceOf");
+    }
+}

--- a/crates/sdk-derive/src/lib.rs
+++ b/crates/sdk-derive/src/lib.rs
@@ -293,7 +293,9 @@ pub fn solidity_storage(input: TokenStream) -> TokenStream {
 /// # Features
 ///
 /// - **Automatic type conversion**: Solidity → Rust types
-/// - **Name conversion**: camelCase → snake_case for methods
+/// - **Name conversion**: camelCase → snake_case for methods when the snake_case name
+///   converts back to the Solidity one; a name it cannot reproduce (`mintNFT`, `tokenURI`,
+///   `DOMAIN_SEPARATOR`) is kept verbatim so the router and client derive the real selector
 /// - **Method receivers**: `&self` for view/pure, `&mut self` for others
 /// - **Struct support**: Generates Rust structs for Solidity structs
 /// - **Works with router**: Use traits in `#[router]` implementations

--- a/crates/sdk-derive/src/lib.rs
+++ b/crates/sdk-derive/src/lib.rs
@@ -295,7 +295,9 @@ pub fn solidity_storage(input: TokenStream) -> TokenStream {
 /// - **Automatic type conversion**: Solidity → Rust types
 /// - **Name conversion**: camelCase → snake_case for methods when the snake_case name
 ///   converts back to the Solidity one; a name it cannot reproduce (`mintNFT`, `tokenURI`,
-///   `DOMAIN_SEPARATOR`) is kept verbatim so the router and client derive the real selector
+///   `DOMAIN_SEPARATOR`) is kept verbatim so the router and client derive the real selector.
+///   A lowercase name with underscores (`foo_bar`) has no Rust spelling that derives its
+///   selector and is rejected with a compile error
 /// - **Method receivers**: `&self` for view/pure, `&mut self` for others
 /// - **Struct support**: Generates Rust structs for Solidity structs
 /// - **Works with router**: Use traits in `#[router]` implementations

--- a/docs/04-gas-and-fuel.md
+++ b/docs/04-gas-and-fuel.md
@@ -163,6 +163,29 @@ seed the same empty warm set, which is what the `e2e/evm` fixture runner does.
 
 ---
 
+## Ethereum compatibility: the base fee is not burned
+
+[EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) burns the base fee and credits the block
+beneficiary with the priority fee alone. Fluent credits the beneficiary with the full effective gas
+price, `gas_used × effective_gas_price` (`RwasmHandler::reward_beneficiary` in
+`crates/revm/src/handler.rs`), and the beneficiary is always the fee manager
+(`PRECOMPILE_FEE_MANAGER`, enforced by `FluentConsensus`), where the fees accumulate for withdrawal.
+This has been the rule on mainnet since genesis; canonical state roots reflect it, so changing it
+is a fork.
+
+Two things are deliberately different from the chain rule and must stay contained:
+
+- The Ethereum state-test comparison in `e2e/evm` runs the rWASM side with the burn switched on
+  per EVM instance (`RwasmEvm::with_base_fee_burn(true)`) so the corpus' expected roots hold. It is
+  an instance option, not a build feature, so the fixture replays in the same binary use the chain
+  rule and assert the fee manager's credit for every replayed transaction.
+- The unmerged branch `fix/testnet-block-validation` encodes a testnet-only burn window below
+  block 21,845,842 for history produced before the current rule. Testnet history below the
+  21,300,000 fork is served from a snapshot; whether `devel` re-executes blocks 21,300,000 to
+  21,845,842 cleanly under the current rule is tracked in FLU-1395.
+
+---
+
 ## Operational invariants
 
 - never allocate large host buffers before validating/bounding lengths,

--- a/e2e/evm/Cargo.toml
+++ b/e2e/evm/Cargo.toml
@@ -11,7 +11,7 @@ fluentbase-runtime = { path = "../../crates/runtime" }
 fluentbase-evm = { path = "../../crates/evm" }
 fluentbase-sdk = { path = "../../crates/sdk" }
 fluentbase-genesis = { path = "../../crates/genesis", default-features = false }
-fluentbase-revm = { path = "../../crates/revm", features = ["eip1559-full-compatibility"] }
+fluentbase-revm = { path = "../../crates/revm" }
 
 revm = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched", default-features = false, features = ["std", "serde-json", "serde"] }
 revm-statetest-types = { git = "https://github.com/fluentlabs-xyz/revm-rwasm.git", branch = "v107-patched", default-features = false }

--- a/e2e/evm/src/runner.rs
+++ b/e2e/evm/src/runner.rs
@@ -16,7 +16,7 @@ use revm::{
     bytecode::Bytecode,
     context::{
         result::{EVMError, ExecutionResult, HaltReason, InvalidTransaction, Output},
-        ContextTr,
+        BlockEnv, ContextTr, Transaction, TxEnv,
     },
     database::{bal::EvmDatabaseError, EmptyDB, InMemoryDB, State, StateBuilder},
     handler::{EthPrecompiles, MainnetContext},
@@ -76,6 +76,40 @@ pub enum TestErrorKind {
     Panic,
     #[error("missing account {address}")]
     MissingAccount { address: Address },
+    #[error("coinbase credit mismatch for {coinbase}: got {got}, expected {expected}")]
+    CoinbaseCreditMismatch {
+        coinbase: Address,
+        got: U256,
+        expected: U256,
+    },
+}
+
+/// What the block beneficiary must hold after a fixture transaction.
+///
+/// Fixtures drop the fee manager (the coinbase on every Fluent network) from their partial
+/// state, so its credit was never asserted. It is computed here instead: the beneficiary
+/// receives `gas_used * effective_gas_price` in full, the chain's rule (no EIP-1559 burn).
+#[derive(Clone, Copy, Debug)]
+struct CoinbaseExpectation {
+    coinbase: Address,
+    pre_balance: U256,
+    effective_gas_price: u128,
+}
+
+impl CoinbaseExpectation {
+    /// `None` when the beneficiary also sends or receives the transaction, because then its
+    /// balance moves for reasons other than the fee credit.
+    fn for_transaction(pre_balance: U256, block_env: &BlockEnv, tx_env: &TxEnv) -> Option<Self> {
+        let coinbase = block_env.beneficiary;
+        if tx_env.caller == coinbase || tx_env.kind.to() == Some(&coinbase) {
+            return None;
+        }
+        Some(Self {
+            coinbase,
+            pre_balance,
+            effective_gas_price: tx_env.effective_gas_price(block_env.basefee as u128),
+        })
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -716,6 +750,7 @@ fn check_fluent_execution(
     >,
     db: &mut State<EmptyDB>,
     spec: SpecId,
+    coinbase: Option<CoinbaseExpectation>,
     print_json_outcome: bool,
 ) -> Result<(), TestErrorKind> {
     let validation = compute_test_roots(exec_result, db);
@@ -793,6 +828,29 @@ fn check_fluent_execution(
         for (sk, sv) in &account_should_be.storage {
             let actual_value = db.storage(*k, *sk).unwrap();
             assert_eq!(actual_value, *sv);
+        }
+    }
+
+    // Validate the fee credit of the block beneficiary. A fixture that lists the coinbase in its
+    // expected state already pins the exact balance above.
+    if let (Ok(result), Some(expectation)) = (exec_result, coinbase) {
+        if !test.state.contains_key(&expectation.coinbase) {
+            let expected = expectation.pre_balance
+                + U256::from(result.gas_used()) * U256::from(expectation.effective_gas_price);
+            let got = db
+                .load_cache_account(expectation.coinbase)
+                .ok()
+                .and_then(|account| account.account.as_ref().map(|plain| plain.info.balance))
+                .unwrap_or_default();
+            if got != expected {
+                let error = TestErrorKind::CoinbaseCreditMismatch {
+                    coinbase: expectation.coinbase,
+                    got,
+                    expected,
+                };
+                print_json(Some(&error));
+                return Err(error);
+            }
         }
     }
 
@@ -1016,7 +1074,8 @@ pub fn execute_evm_test_suite(
                     let mut evm2 = RwasmContext::new(fluent_state, spec_id)
                         .with_cfg(cfg_env.clone())
                         .with_block(block_env.clone())
-                        .build_rwasm_with_inspector(TraceInspector::new());
+                        .build_rwasm_with_inspector(TraceInspector::new())
+                        .with_base_fee_burn(true);
                     evm2.0.cfg.legacy_bytecode_enabled = false;
                     let result_fluent = evm2.inspect_tx_commit(tx_env.clone());
                     if cfg!(feature = "debug-print") {
@@ -1062,7 +1121,8 @@ pub fn execute_evm_test_suite(
                     let mut evm2 = RwasmContext::new(fluent_state, spec_id)
                         .with_cfg(cfg_env.clone())
                         .with_block(block_env.clone())
-                        .build_rwasm();
+                        .build_rwasm()
+                        .with_base_fee_burn(true);
                     evm2.0.cfg.legacy_bytecode_enabled = false;
                     let start = Instant::now();
                     let result_fluent = evm2.transact_commit(tx_env.clone());
@@ -1221,6 +1281,13 @@ pub fn execute_fluent_test_suite(
                 }
                 fill_tx_env(&mut tx_env, &unit.transaction, &test);
                 tx_env.chain_id = Some(cfg_env.chain_id);
+                let coinbase_pre_balance = unit
+                    .pre
+                    .get(&block_env.beneficiary)
+                    .map(|account| account.balance)
+                    .unwrap_or_default();
+                let coinbase =
+                    CoinbaseExpectation::for_transaction(coinbase_pre_balance, &block_env, &tx_env);
 
                 let cache = cache_state.clone();
                 // cache.set_state_clear_flag(spec_id.is_enabled_in(SpecId::SPURIOUS_DRAGON));
@@ -1246,6 +1313,7 @@ pub fn execute_fluent_test_suite(
                         &result_fluent,
                         evm.0.db_mut(),
                         spec_id,
+                        coinbase,
                         print_json_outcome,
                     );
                     output
@@ -1267,6 +1335,7 @@ pub fn execute_fluent_test_suite(
                         &result,
                         evm.0.db_mut(),
                         spec_id,
+                        coinbase,
                         print_json_outcome,
                     );
                     if cfg!(feature = "debug-print") {


### PR DESCRIPTION
Follow-ups for the high and medium findings of the 2026-09-11 audit round 2 (FLU-1388). The critical bridge pre-hook finding (FLU-1389) is handled separately; the low-severity items stay in Backlog for their own PRs. One commit per sub-issue; the tree was verified at every step against `devel` (`e1c60fb14`).

## Changes

| Commit | Issue | Change |
| --- | --- | --- |
| `fix(runtime)` | FLU-1390 | `_tower_fp2_*` host handlers read and write every limb through its own guest pointer; guest-side test with non-adjacent buffers. |
| `fix(revm)` | FLU-1397 | CALL-family `_exec` input capped at an ordinary contract's memory; the lazy calldata reader probes bounds before allocating. |
| `ci` | FLU-1392 | `pull_request` jobs run on self-hosted runners only for branches of this repository; `build-docker.yml` sits behind a `release` environment. |
| `ci(release)` | FLU-1393 | `build-docker.yml` attests the builder image; `release.yml` verifies the attestation (this repo's workflow, the release commit) before building inside it. Empty `Dockerfile.reproducible` removed with its README claim. |
| `fix(genesis)` | FLU-1394 | Generated genesis files carry `terminalTotalDifficulty: 0`; `--chain <file>` refuses a genesis that does not activate Paris; `prevrandao` encoding is total. |
| `fix(sdk-derive)` | FLU-1391 | Solidity names that do not round-trip through snake_case (`mintNFT`, `tokenURI`, `DOMAIN_SEPARATOR`) are kept verbatim, so routers and clients derive the real selector. |
| `fix(e2e)` | FLU-1396 | Fixture replays assert the fee-manager credit. The EIP-1559 burn is a per-instance option (`RwasmEvm::with_base_fee_burn`) instead of a cargo feature. |
| `docs` | FLU-1395 | Fee-manager credit rule and the testnet burn window documented. |

## Verification

- `cargo test -p fluentbase-revm --release`: 63 passed; `-p fluentbase-runtime --release tower_fp2`: 4 passed; `-p fluentbase-sdk-derive-core`: 166 passed; `-p fluentbase-node chainspec`: 2 passed.
- `cargo test -p fluentbase-e2e --release --no-default-features --features std`: 131 passed, 9 ignored, 0 failed.
- `e2e/evm` fixture suite (`--features std`): 12 passed, with the new coinbase-credit assertion on all 11 replayed transactions.
- `rustfmt` clean on every touched crate; workflow YAML parsed.

## Left for follow-up

- FLU-1395: the re-execution of testnet blocks 21,300,000 to 21,845,842 under the current fee rule still has to be run; only the documentation part is in this PR.
- FLU-1392: required reviewers on the `release` environment are a repository-settings step.
- FLU-1393: the attestation round trip runs for real only on the next tagged release; a dry run does not attest.
- FLU-1390 changes the output of the `_tower_fp2_*` syscalls for any existing caller; no in-repo contract uses them, but a re-execute over network history before release is the usual check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provenance attestation and verification for container images used in releases.
  * Added safer handling for oversized contract-call inputs.
  * Improved Solidity function naming support, preserving names such as `mintNFT` and `DOMAIN_SEPARATOR`.

* **Bug Fixes**
  * Genesis configurations now explicitly activate post-merge behavior.
  * Prevented execution failures when pre-merge randomness is unavailable.
  * Corrected elliptic-curve syscall handling for non-contiguous input buffers.
  * Improved fee-credit validation in EVM compatibility tests.

* **Documentation**
  * Clarified genesis build verification and base-fee handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->